### PR TITLE
Update downcast dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default = ["readline_rs_compat"]
 
 [dependencies]
 cfg-if = "0.1.7"
-downcast = "0.9.1"
+downcast = "0.10.0"
 num = "0.2"
 ordered-float = "0.5.0"
 prolog_parser = "0.8.3"


### PR DESCRIPTION
It wasn't able to compile with latest Rust 1.33:
```
error[E0034]: multiple applicable items in scope
   --> /home/akochkov/.cargo/registry/src/github.com-1ecc6299db9ec823/downcast-0.9.2/src/lib.rs:120:38
    |
120 |     fn is_type(&self) -> bool { self.type_id() == TypeId::of::<T>() }
    |                                      ^^^^^^^ multiple `type_id` found
    |
note: candidate #1 is defined in the trait `Any`
   --> /home/akochkov/.cargo/registry/src/github.com-1ecc6299db9ec823/downcast-0.9.2/src/lib.rs:29:5
    |
29  |     fn type_id(&self) -> TypeId { TypeId::of::<Self>() }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to disambiguate the method call, write `Any::type_id(&self)` instead
note: candidate #2 is defined in the trait `std::any::Any`
    = help: to disambiguate the method call, write `std::any::Any::type_id(&self)` instead

error: aborting due to previous error

For more information about this error, try `rustc --explain E0034`.
error: Could not compile `downcast`.
warning: build failed, waiting for other jobs to finish...
error: failed to compile `scryer-prolog v0.8.22`, intermediate artifacts can be found at `/tmp/cargo-installoOr7fH`

Caused by:
  build failed
```

See these commits:
-  https://github.com/fkoep/downcast-rs/commit/76d52cb3a293b922c483a303d918077e4fa10bbc
- https://github.com/fkoep/downcast-rs/commit/c65a1aaa42e39cfe84faf1902fdaa7dd3aa65f78