### PR TITLE
ADDED: library(si) for safe type tests.

### DIFF
--- a/src/prolog/lib/si.pl
+++ b/src/prolog/lib/si.pl
@@ -1,0 +1,47 @@
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+   Safe type tests
+   ===============
+
+   "si" stands for "sufficiently instantiated".
+
+   These predicates:
+
+    - throw instantiation errors if the argument is
+      not sufficiently instantiated to make a sound decision
+    - succeed if the argument is of the specified type
+    - fail otherwise.
+
+   For instance, atom_si(A) yields an *instantiation error* if A is a
+   variable. This is logically sound, since in that case the argument
+   is not sufficiently instantiated to make any decision.
+
+   The definitions are taken from:
+
+       https://stackoverflow.com/questions/27306453/safer-type-tests-in-prolog
+
+   "si" can also be read as "safe inference", so possibly also other
+   predicates are candidates for this library.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+:- module(si, [atom_si/1,
+               integer_si/1,
+               atomic_si/1,
+               list_si/1]).
+
+:- use_module(library(lists)).
+
+atom_si(A) :-
+   functor(A, _, 0),    % for the instantiation error
+   atom(A).
+
+integer_si(I) :-
+   functor(I, _, 0),
+   integer(I).
+
+atomic_si(AC) :-
+   functor(AC,_,0).
+
+list_si(L) :-
+   \+ \+ length(L, _),
+   sort(L, _).


### PR DESCRIPTION
These are safe type tests, please consider including this library in Scryer Prolog. It would make Scryer the first system to support these new predicates.

This is how type tests should have been defined in the first place. Notably, exceptions are thrown if no decision can be made at this point.

Possibly other sound predicates are also good candidates for inclusion in this new library in the future. Hence the name "si", which can also be read as "safe inference" or "sound inference".