### PR TITLE
Fix some old Rust codes

### DIFF
--- a/src/prolog/heap_print.rs
+++ b/src/prolog/heap_print.rs
@@ -147,7 +147,7 @@ fn char_to_string(c: char) -> String {
         '\u{0c}' => "\\f".to_string(), // UTF-8 form feed
         '\u{08}' => "\\b".to_string(), // UTF-8 backspace
         '\u{07}' => "\\a".to_string(), // UTF-8 alert
-        '\x20'...'\x7e' => c.to_string(),
+        '\x20'..='\x7e' => c.to_string(),
         _ => format!("\\x{:x}\\", c as u32),
     }
 }

--- a/src/prolog/iterators.rs
+++ b/src/prolog/iterators.rs
@@ -342,7 +342,7 @@ fn contains_cut_var<'a, Iter: Iterator<Item = &'a Term>>(terms: Iter) -> bool {
 
 pub struct ChunkedIterator<'a> {
     pub chunk_num: usize,
-    iter: Box<Iterator<Item = ChunkedTerm<'a>> + 'a>,
+    iter: Box<dyn Iterator<Item = ChunkedTerm<'a>> + 'a>,
     deep_cut_encountered: bool,
     cut_var_in_head: bool,
 }
@@ -351,7 +351,7 @@ type ChunkedIteratorItem<'a> = (usize, usize, Vec<ChunkedTerm<'a>>);
 type RuleBodyIteratorItem<'a> = (usize, usize, Vec<&'a QueryTerm>);
 
 impl<'a> ChunkedIterator<'a> {
-    pub fn rule_body_iter(self) -> Box<Iterator<Item = RuleBodyIteratorItem<'a>> + 'a> {
+    pub fn rule_body_iter(self) -> Box<dyn Iterator<Item = RuleBodyIteratorItem<'a>> + 'a> {
         Box::new(self.filter_map(|(cn, lt_arity, terms)| {
             let filtered_terms: Vec<_> = terms
                 .into_iter()

--- a/src/prolog/machine/machine_errors.rs
+++ b/src/prolog/machine/machine_errors.rs
@@ -250,7 +250,7 @@ impl MachineError {
         }
     }
 
-    fn into_iter(self, offset: usize) -> Box<Iterator<Item = HeapCellValue>> {
+    fn into_iter(self, offset: usize) -> Box<dyn Iterator<Item = HeapCellValue>> {
         match self.from {
             ErrorProvenance::Constructed => {
                 Box::new(self.stub.into_iter().map(move |hcv| match hcv {

--- a/src/prolog/machine/machine_state.rs
+++ b/src/prolog/machine/machine_state.rs
@@ -943,22 +943,22 @@ impl CallPolicy for CWILCallPolicy {
     }
 }
 
-downcast!(CallPolicy);
+downcast!(dyn CallPolicy);
 
 pub(crate) struct DefaultCallPolicy {}
 
 impl CallPolicy for DefaultCallPolicy {}
 
 pub(crate) struct CWILCallPolicy {
-    pub(crate) prev_policy: Box<CallPolicy>,
+    pub(crate) prev_policy: Box<dyn CallPolicy>,
     count: Integer,
     limits: Vec<(Integer, usize)>,
     inference_limit_exceeded: bool,
 }
 
 impl CWILCallPolicy {
-    pub(crate) fn new_in_place(policy: &mut Box<CallPolicy>) {
-        let mut prev_policy: Box<CallPolicy> = Box::new(DefaultCallPolicy {});
+    pub(crate) fn new_in_place(policy: &mut Box<dyn CallPolicy>) {
+        let mut prev_policy: Box<dyn CallPolicy> = Box::new(DefaultCallPolicy {});
         mem::swap(&mut prev_policy, policy);
 
         let new_policy = CWILCallPolicy {
@@ -1016,8 +1016,8 @@ impl CWILCallPolicy {
         self.limits.is_empty()
     }
 
-    pub(crate) fn into_inner(&mut self) -> Box<CallPolicy> {
-        let mut new_inner: Box<CallPolicy> = Box::new(DefaultCallPolicy {});
+    pub(crate) fn into_inner(&mut self) -> Box<dyn CallPolicy> {
+        let mut new_inner: Box<dyn CallPolicy> = Box::new(DefaultCallPolicy {});
         mem::swap(&mut self.prev_policy, &mut new_inner);
         new_inner
     }
@@ -1028,7 +1028,7 @@ pub(crate) trait CutPolicy: Any {
     fn cut(&mut self, &mut MachineState, RegType) -> bool;
 }
 
-downcast!(CutPolicy);
+downcast!(dyn CutPolicy);
 
 fn cut_body(machine_st: &mut MachineState, addr: Addr) -> bool {
     let b = machine_st.b;

--- a/src/prolog/machine/machine_state_impl.rs
+++ b/src/prolog/machine/machine_state_impl.rs
@@ -3151,8 +3151,8 @@ impl MachineState {
         &mut self,
         indices: &mut IndexStore,
         code_repo: &CodeRepo,
-        call_policy: &mut Box<CallPolicy>,
-        cut_policy: &mut Box<CutPolicy>,
+        call_policy: &mut Box<dyn CallPolicy>,
+        cut_policy: &mut Box<dyn CutPolicy>,
         parsing_stream: &mut PrologStream,
         ct: &ClauseType,
         arity: usize,
@@ -3167,7 +3167,7 @@ impl MachineState {
 	    return;
 	}
 	
-        let mut default_call_policy: Box<CallPolicy> = Box::new(DefaultCallPolicy {});
+        let mut default_call_policy: Box<dyn CallPolicy> = Box::new(DefaultCallPolicy {});
         let call_policy = if use_default_cp {
             &mut default_call_policy
         } else {
@@ -3217,8 +3217,8 @@ impl MachineState {
         &mut self,
         indices: &mut IndexStore,
         code_repo: &CodeRepo,
-        call_policy: &mut Box<CallPolicy>,
-        cut_policy: &mut Box<CutPolicy>,
+        call_policy: &mut Box<dyn CallPolicy>,
+        cut_policy: &mut Box<dyn CutPolicy>,
         parsing_stream: &mut PrologStream,
         instr: &ControlInstruction,
     ) {
@@ -3253,7 +3253,7 @@ impl MachineState {
     pub(super) fn execute_indexed_choice_instr(
         &mut self,
         instr: &IndexedChoiceInstruction,
-        call_policy: &mut Box<CallPolicy>,
+        call_policy: &mut Box<dyn CallPolicy>,
     ) {
         match instr {
             &IndexedChoiceInstruction::Try(l) => {
@@ -3292,7 +3292,7 @@ impl MachineState {
     pub(super) fn execute_choice_instr(
         &mut self,
         instr: &ChoiceInstruction,
-        call_policy: &mut Box<CallPolicy>,
+        call_policy: &mut Box<dyn CallPolicy>,
     ) {
         match instr {
             &ChoiceInstruction::TryMeElse(offset) => {
@@ -3341,7 +3341,7 @@ impl MachineState {
     pub(super) fn execute_cut_instr(
         &mut self,
         instr: &CutInstruction,
-        cut_policy: &mut Box<CutPolicy>,
+        cut_policy: &mut Box<dyn CutPolicy>,
     ) {
         match instr {
             &CutInstruction::NeckCut => {

--- a/src/prolog/machine/mod.rs
+++ b/src/prolog/machine/mod.rs
@@ -51,8 +51,8 @@ use std::sync::atomic::AtomicBool;
 use termion::raw::IntoRawMode;
 
 pub struct MachinePolicies {
-    call_policy: Box<CallPolicy>,
-    cut_policy: Box<CutPolicy>,
+    call_policy: Box<dyn CallPolicy>,
+    cut_policy: Box<dyn CutPolicy>,
 }
 
 lazy_static! {
@@ -75,7 +75,7 @@ pub struct Machine {
     pub(super) indices: IndexStore,
     pub(super) code_repo: CodeRepo,
     pub(super) toplevel_idx: usize,
-    pub(super) prolog_stream: ParsingStream<Box<Read>>,
+    pub(super) prolog_stream: ParsingStream<Box<dyn Read>>,
 }
 
 impl Index<LocalCodePtr> for CodeRepo {

--- a/src/prolog/machine/system_calls.rs
+++ b/src/prolog/machine/system_calls.rs
@@ -550,8 +550,8 @@ impl MachineState {
         ct: &SystemClauseType,
         code_repo: &CodeRepo,
         indices: &mut IndexStore,
-        call_policy: &mut Box<CallPolicy>,
-        cut_policy: &mut Box<CutPolicy>,
+        call_policy: &mut Box<dyn CallPolicy>,
+        cut_policy: &mut Box<dyn CutPolicy>,
         current_input_stream: &mut PrologStream,
     ) -> CallResult {
         match ct {

--- a/src/prolog/read.rs
+++ b/src/prolog/read.rs
@@ -23,7 +23,7 @@ impl<'a> TermRef<'a> {
     }
 }
 
-pub type PrologStream = ParsingStream<Box<Read>>;
+pub type PrologStream = ParsingStream<Box<dyn Read>>;
 
 pub mod readline {
     use prolog_parser::ast::*;
@@ -116,7 +116,7 @@ pub mod readline {
 
     #[inline]
     pub fn input_stream() -> ::PrologStream {
-        let reader: Box<Read> = Box::new(ReadlineStream::input_stream(String::from("")));
+        let reader: Box<dyn Read> = Box::new(ReadlineStream::input_stream(String::from("")));
         parsing_stream(reader)
     }
 }


### PR DESCRIPTION
Hi there,

Thanks for the solid project! I'm enjoying using it! 

Just want to provide some little fixes which triggers warning on latest toolchains :-) We use `cargo fix` on nightly-2019-10-04 toolchain to generate the patch automatically:
- Fixed `...` to `..=`
- Fixed trait object to `dyn` trait object

Hope you like it!

Best,
Yu