### PR TITLE
weighted_maximum/3 now works

### DIFF
--- a/src/prolog/lib/clpb.pl
+++ b/src/prolog/lib/clpb.pl
@@ -34,7 +34,7 @@
 :- use_module(library(lists)).
 :- use_module(library(non_iso)).
 :- use_module(library(dcgs)).
-%:- use_module(library(types)).
+:- use_module(library(error), []).
 
 :- attribute
         clpb/1,
@@ -77,8 +77,8 @@ must_be(list(What), Where, Term) :- !,
 must_be(ground, _, Term) :- !,
         functor(Term, _, _).
 
-must_be(Type, Goal-Arg, Term) :-
-        must_be(Term, Type, Goal, Arg).
+must_be(Type, _, Term) :-
+        error:must_be(Type, Term).
 
 clpz_list(Nil, _) :- Nil == [].
 clpz_list(Ls, Where) :-
@@ -87,7 +87,6 @@ clpz_list(Ls, Where) :-
     ;   Ls = [_|Rest],
         clpz_list(Rest, Where)
     ).
-    
 
 
 instantiation_error(Term) :- instantiation_error(Term, unknown(Term)-1).
@@ -139,7 +138,10 @@ partition(Pred, Ls0, As, Bs) :-
         include(Pred, Ls0, As),
         exclude(Pred, Ls0, Bs).
 
-sum_list(Ls, S) :- sumlist(Ls, S).
+sum_list(Ls, S) :-
+        foldl(sum_, Ls, 0, S).
+
+sum_(L, S0, S) :- S is S0 + L.
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   Pairs.

--- a/src/prolog/lib/error.pl
+++ b/src/prolog/lib/error.pl
@@ -33,6 +33,10 @@ must_be(Type, Term) :-
 must_be_(Type, _) :-
         var(Type),
         instantiation_error(Type).
+must_be_(var, Term) :-
+        (   var(Term) -> true
+        ;   throw(error(uninstantiation_error, _))
+        ).
 must_be_(integer, Term) :- check_(integer, integer, Term).
 must_be_(atom, Term)    :- check_(atom, atom, Term).
 must_be_(list, Term)    :- check_(ilist, list, Term).
@@ -52,6 +56,7 @@ type(type).
 type(integer).
 type(atom).
 type(list).
+type(var).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    can_be(Type, Term)


### PR DESCRIPTION
This adds support for weighted_maximum/3. 

random_labeling/2 is the only remaining CLP(B) predicate that needs further support from built-ins. Notably, set_random/1 and maybe/0 must be provided by the engine to set a random seed and succeed with probability 0.5, respectively.