### PR TITLE
add n as an option to get the next solution

### DIFF
--- a/src/prolog/machine/system_calls.rs
+++ b/src/prolog/machine/system_calls.rs
@@ -41,7 +41,7 @@ pub fn next_keypress() -> ContinueResult {
 
     for c in stdin.keys() {
         match c.unwrap() {
-            Key::Char(' ') | Key::Char(';') => return ContinueResult::ContinueQuery,
+            Key::Char(' ') | Key::Char(';') | Key::Char('n') => return ContinueResult::ContinueQuery,
             Key::Char('.') => return ContinueResult::Conclude,
             _ => {}
         }


### PR DESCRIPTION
I don't know if it's in ISO Prolog or not, but in SWI Prolog, pressing 'n' does the same as ';'. I was very used to that behavior, so I added it but I don't know if it's standard or worth adding it. 