### PR TITLE
Take goals from CLI arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,10 +35,10 @@ fn main() {
     let handler = signal::SigHandler::Handler(handle_sigint);
     unsafe { signal::signal(signal::Signal::SIGINT, handler) }.unwrap();
 
-    if env::args().skip(1).any(|a| a == "-v" || a == "--version") {
-        println!("{:}", git_version!());
-        return;
-    }
+    // if env::args().skip(1).any(|a| a == "-v" || a == "--version") {
+    //     println!("{:}", git_version!());
+    //     return;
+    // }
 
     let mut wam = Machine::new(readline::input_stream(), Stream::stdout());
     wam.run_top_level();

--- a/src/prolog/machine/mod.rs
+++ b/src/prolog/machine/mod.rs
@@ -336,24 +336,16 @@ impl Machine {
     }
 
     pub fn run_top_level(&mut self) {
-	    use std::env;
+	use std::env;
 
-	    let mut filename_atoms = vec![];
+	let atoms_tbl = &self.indices.atom_tbl;
+	let arg_atoms = env::args().map(|arg| HeapCellValue::Atom(clause_name!(arg, atoms_tbl), None));
+	let list_addr = Addr::HeapCell(self.machine_st.heap.to_list(arg_atoms.into_iter()));
 
-	    // the first of these is the path to the scryer-prolog executable, so skip
-	    // it.
-	    for filename in env::args().skip(1) {
-	        let atom = clause_name!(filename, self.indices.atom_tbl);
-	        filename_atoms.push(HeapCellValue::Atom(atom, None));
-	    }
+	self.machine_st[temp_v!(1)] = list_addr;
+	self.machine_st.p = CodePtr::Local(LocalCodePtr::DirEntry(self.toplevel_idx));
 
-	    let list_addr =
-	        Addr::HeapCell(self.machine_st.heap.to_list(filename_atoms.into_iter()));
-
-	    self.machine_st[temp_v!(1)] = list_addr;
-        self.machine_st.p = CodePtr::Local(LocalCodePtr::DirEntry(self.toplevel_idx));
-
-        self.run_query();
+	self.run_query();
     }
 
     pub fn new(current_input_stream: Stream, current_output_stream: Stream) -> Self

--- a/src/prolog/toplevel.pl
+++ b/src/prolog/toplevel.pl
@@ -1,12 +1,36 @@
 :- use_module(library(lists)).
 :- use_module(library(si)).
 
-:- module('$toplevel', ['$repl'/1, consult/1, use_module/1, use_module/2]).
+:- module('$toplevel', ['$entrypoint'/1, consult/1, use_module/1, use_module/2]).
 
-'$repl'(ListOfModules) :-
-    maplist('$use_list_of_modules', ListOfModules),
-    false.
-'$repl'(_) :- '$repl'.
+%% Note: due to the way we run this, the entrypoint rule cannot have multiple
+%%       rule heads (we're setting up the heap, and it's consumed once?).
+%% TODO - Is this true?
+%%      - Handing over to the REPL doesn't work.
+'$entrypoint'(Args) :-
+  '$run'(Args).
+
+%% first arg is executable name
+'$run'([_ | Args]) :-
+    member(V, ['-v', '--version']),
+    member(V, Args),
+    write('version: todo\n'). %% todo: print actual version
+'$run'([_ | Args]) :-
+    '$run'(Args, [], []).
+
+'$run'([G, Goal | Args], Mods, Goals) :-
+    member(G, ['-g', '--goal']),
+    '$run'(Args, Mods, [Goal | Goals]).
+'$run'([Mod | Args], Mods, Goals) :-
+    '$run'(Args, [Mod | Mods], Goals).
+'$run'([], Mods0, []) :- %% no goals, run repl
+    reverse(Mods0, Mods),
+    maplist('$use_list_of_modules', Mods),
+    '$repl'.
+'$run'([], Mods0, Goals0) :-
+    reverse(Mods0, Mods),
+    reverse(Goals0, Goals),
+    write('run with goals: todo\n').
 
 '$use_list_of_modules'(Module) :-
     catch(use_module(Module), E, '$print_exception'(E)).


### PR DESCRIPTION
The idea is that toplevel.pl is processing argv, and acts accordingly.

It's all broken right now, i.e.

- the version isn't printed when -v/--version is passed
- there's nothing happening to passed goals
- the hand-over to the repl doesn't work

---
I'm not sure where this goes wrong. Could someone please glance at the `toplevel.pl` changes and tell me if I'm missing something obvious? Running `'$run'/3` in swipl makes me think that it's basically OK.

This is for #187. (🏓@triska)