### PR TITLE
clpz_monotonic/0 --> monotonic/0

### DIFF
--- a/src/prolog/lib/clpz.pl
+++ b/src/prolog/lib/clpz.pl
@@ -4295,11 +4295,13 @@ tuples_in(Tuples, Relation) :-
 relation_tuple(Relation, Tuple) :-
         relation_unifiable(Relation, Tuple, Us, _, _),
         (   ground(Tuple) -> memberchk(Tuple, Relation)
-        ;   tuple_domain(Tuple, Us),
+        ;   phrase(tuple_domain(Tuple, Us), _),
             (   Tuple = [_,_|_] -> tuple_freeze(Tuple, Us)
             ;   true
             )
         ).
+
+list_first_rest([L|Ls], L, Ls).
 
 tuple_domain([], _) --> [].
 tuple_domain([T|Ts], Relation0) -->

--- a/src/prolog/lib/clpz.pl
+++ b/src/prolog/lib/clpz.pl
@@ -141,7 +141,7 @@
         queue/2,
         enabled/1.
 
-:- dynamic(clpz_monotonic/0).
+:- dynamic(monotonic/0).
 :- dynamic(clpz_equal_/2).
 :- dynamic(clpz_geq_/2).
 :- dynamic(clpz_neq/2).
@@ -906,13 +906,13 @@ X = 1+1.
 This behaviour is highly problematic from a logical point of view, and
 it may render declarative debugging techniques inapplicable.
 
-Assert `clpz:clpz_monotonic` to make CLP(Z) **monotonic**: This means
+Assert `clpz:monotonic` to make CLP(Z) **monotonic**: This means
 that _adding_ new constraints _cannot_ yield new solutions. When this
 flag is `true`, we must wrap variables that occur in arithmetic
 expressions with the functor `(?)/1` or `(#)/1`. For example:
 
 ==
-?- assertz(clpz:clpz_monotonic).
+?- assertz(clpz:monotonic).
 true.
 
 ?- #(X) #= #(Y) + #(Z).
@@ -2585,7 +2585,7 @@ parse_clpz(E, R,
             ]).
 
 non_monotonic(X) :-
-        (   \+ fd_var(X), clpz_monotonic ->
+        (   \+ fd_var(X), monotonic ->
             instantiation_error(X)
         ;   true
         ).
@@ -2932,7 +2932,7 @@ clpz_equal(X, Y) :- clpz_equal_(X, Y), reinforce(X).
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 expr_conds(E, E)                 --> [integer(E)],
-        { var(E), !, \+ clpz_monotonic }.
+        { var(E), !, \+ monotonic }.
 expr_conds(E, E)                 --> { integer(E) }.
 expr_conds(?(E), E)              --> [integer(E)].
 expr_conds(#(E), E)              --> [integer(E)].
@@ -7072,7 +7072,7 @@ initial_expr(_, []-1).
 automaton(Seqs, Template, Sigs, Ns, As0, Cs, Is, Fs) :-
         must_be(list(list), [Sigs,Ns,As0,Cs,Is]),
         (   var(Seqs) ->
-            (   clpz_monotonic ->
+            (   monotonic ->
                 instantiation_error(Seqs)
             ;   Seqs = Sigs
             )
@@ -7461,7 +7461,7 @@ attributes_goals([propagator(P, State)|As]) -->
         (   { ground(State) } -> []
         ;   { phrase(attribute_goal_(P), Gs) } ->
             { % del_attr(State, clpz_aux), State = processed,
-              (   clpz_monotonic ->
+              (   monotonic ->
                   maplist(unwrap_with(bare_integer), Gs, Gs1)
               ;   maplist(unwrap_with(=), Gs, Gs1)
               ),


### PR DESCRIPTION
These two commits implement a small name change to enable the monotonic execution mode (providing `clpz:monotonic` in analogy to `clpb:monotonic/0`), and also make the extensional relation constraint `tuples_in/2` work.