### PR TITLE
use partial strings for passing argv to toplevel.pl

### DIFF
--- a/src/prolog/machine/mod.rs
+++ b/src/prolog/machine/mod.rs
@@ -336,23 +336,16 @@ impl Machine {
     }
 
     pub fn run_top_level(&mut self) {
-	    use std::env;
+        use std::env;
 
-	    let mut filename_atoms = vec![];
+        let mut arg_pstrs = vec![];
+        for arg in env::args() {
+            arg_pstrs.push(self.machine_st.heap.put_complete_string(&arg));
+        }
+        let list_addr = Addr::HeapCell(self.machine_st.heap.to_list(arg_pstrs.into_iter()));
 
-	    // the first of these is the path to the scryer-prolog executable, so skip
-	    // it.
-	    for filename in env::args().skip(1) {
-	        let atom = clause_name!(filename, self.indices.atom_tbl);
-	        filename_atoms.push(HeapCellValue::Atom(atom, None));
-	    }
-
-	    let list_addr =
-	        Addr::HeapCell(self.machine_st.heap.to_list(filename_atoms.into_iter()));
-
-	    self.machine_st[temp_v!(1)] = list_addr;
+        self.machine_st[temp_v!(1)] = list_addr;
         self.machine_st.p = CodePtr::Local(LocalCodePtr::DirEntry(self.toplevel_idx));
-
         self.run_query();
     }
 

--- a/src/prolog/toplevel.pl
+++ b/src/prolog/toplevel.pl
@@ -3,13 +3,14 @@
 
 :- module('$toplevel', ['$repl'/1, consult/1, use_module/1, use_module/2]).
 
-'$repl'(ListOfModules) :-
-    maplist('$use_list_of_modules', ListOfModules),
+'$repl'([_|Args]) :-
+    maplist('$use_list_of_modules', Args),
     false.
 '$repl'(_) :- '$repl'.
 
-'$use_list_of_modules'(Module) :-
-    catch(use_module(Module), E, '$print_exception'(E)).
+'$use_list_of_modules'(Mod0) :-
+    atom_chars(Mod, Mod0),
+    catch(use_module(Mod), E, '$print_exception'(E)).
 
 '$repl' :-
     catch('$read_and_match', E, '$print_exception'(E)),


### PR DESCRIPTION
In run_top_level: rename variables, make them partial strings

The rename is mostly cosmetic: all of argv is passed, and if argv
contains flags, goals, etc, it's more than filenames.

Using partial strings instead of atom came from discussions about how to
pass goals in the CLI, and can thus be considered preliminary work for
that.

In toplevel.pl: convert partial string to atom before passing it to
`use_module`.

-----
ℹ️New PR for clarity. This is a baby step towards #187, as came up in the discussion of my previous attempt in #313. Here, we only change the format of argv passed into toplevel. Further steps, like processing `-v/--version`, and ultimately taking in goals, can happen in follow-up work.

~⚠️ The change doesn't *work*, it seems that `atom_chars(Mod, Mod0)` fails to convert the partial string Mod0 into an atom (expected by `use_module('file.pl')`). Any help is appreciated 😄~