### PR TITLE
also include a newline in portray_clause/1

### DIFF
--- a/src/prolog/lib/format.pl
+++ b/src/prolog/lib/format.pl
@@ -393,7 +393,7 @@ portray_clause(Term) :-
         maplist(write, Ls).
 
 portray_clause_(Term) -->
-        portray_(Term), ".".
+        portray_(Term), ".\n".
 
 literal(Lit) --> format_("~q", [Lit]).
 
@@ -461,18 +461,18 @@ a :-
 ?- nl, portray_clause([a,b,c,d]), nl.
 "abcd".
 
-?- nl, portray_clause(X), nl.
-?- nl, portray_clause((f(X) :- X)), nl.
+?- nl, portray_clause(X).
+?- nl, portray_clause((f(X) :- X)).
 
-?- nl, portray_clause((h :- ( a -> b; c))), nl.
+?- nl, portray_clause((h :- ( a -> b; c))).
 
-?- nl, portray_clause((h :- ( (a -> x ; y) -> b; c))), nl.
+?- nl, portray_clause((h :- ( (a -> x ; y) -> b; c))).
 
-?- nl, portray_clause((h(X) :- ( (a(X) ; y(A,B)) -> b; c))), nl.
+?- nl, portray_clause((h(X) :- ( (a(X) ; y(A,B)) -> b; c))).
 
-?- nl, portray_clause((h :- (a,d;b,c) ; (b,e;d))), nl.
+?- nl, portray_clause((h :- (a,d;b,c) ; (b,e;d))).
 
-?- nl, portray_clause((a :- b ; c ; d)), nl.
+?- nl, portray_clause((a :- b ; c ; d)).
 
 ?- nl, portray_clause((h :- L = '.')).
 


### PR DESCRIPTION
As a brief followup, I think including a newline makes `portrtay_clause/1` even more useful.

Sample program where I am now using this feature:

https://www.metalevel.at/logic/plres.pl

This implements the resolution calculus for propositional logic, and emits the result for easy verification with Prolog.