### PR TITLE
ADDED: group_pairs_by_key/2

### DIFF
--- a/src/prolog/lib/pairs.pl
+++ b/src/prolog/lib/pairs.pl
@@ -1,6 +1,7 @@
 :- module(pairs, [pairs_keys_values/3,
 		  pairs_keys/2,
 		  pairs_values/2,
+		  group_pairs_by_key/2,
 		  map_list_to_pairs/3]).
 
 
@@ -19,3 +20,14 @@ map_list_to_pairs2([], _, []).
 map_list_to_pairs2([H|T0], Pred, [K-H|T]) :-
         call(Pred, H, K),
         map_list_to_pairs2(T0, Pred, T).
+
+
+group_pairs_by_key([], []).
+group_pairs_by_key([K-V|KVs0], [K-[V|Vs]|KVs]) :-
+        same_key(K, KVs0, Vs, KVs1),
+        group_pairs_by_key(KVs1, KVs).
+
+same_key(K0, [K1-V|KVs0], [V|Vs], KVs) :-
+        K0 == K1, !,
+        same_key(K0, KVs0, Vs, KVs).
+same_key(_, KVs, [], KVs).


### PR DESCRIPTION
Pairs must be keysorted and may also contain variables as keys.

Examples:

    ?-  group_pairs_by_key([1-a,1-b,2-c], Ps).
       Ps = [1-[a,b],2-[c]].

    ?-  group_pairs_by_key([X-a,X-b,2-c], Ps).
       Ps = [X-[a,b],2-[c]].