### PR TITLE
ADDED: library(time), providing time/1 for benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "scryer-prolog"
 version = "0.8.120"
 dependencies = [
+ "cpu-time 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossterm 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "divrem 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -815,6 +825,7 @@ dependencies = [
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+"checksum cpu-time 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossterm 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8a3223215bc00c666d6be730e88aef245ad4a4f837e87a16c347e8acf701643"
 "checksum crossterm_winapi 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ prolog_parser = { version = "0.8.52", default-features = false }
 ref_thread_local = "0.0.0"
 rug = { version = "1.4.0", optional = true }
 rustyline = "6.0.0"
+cpu-time = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ arithmetic operators with the usual precedences,
 
 ```
 ?- write_canonical(-5 + 3 - (2 * 4) // 8), nl.
-   -(+(-5,3),//(*(2,4),8))
-true.
+-(+(-5,3),//(*(2,4),8))
+   true.
 ```
 
 New operators can be defined using the `op` declaration.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ The modules that ship with Scryer&nbsp;Prolog are also called
   CLP(B): Constraint Logic Programming over Boolean variables,
   a BDD-based SAT&nbsp;solver provided via the predicates
   `sat/1`, `taut/2`, `labeling/1` etc.
+* [`time`](src/prolog/lib/time.pl)
+  `time/1` reports the CPU&nbsp;time of a goal. It is useful
+  for measuring the performance of your code.
 
 To use predicates provided by the `lists` library, write:
 

--- a/src/prolog/clause_types.rs
+++ b/src/prolog/clause_types.rs
@@ -241,6 +241,7 @@ pub enum SystemClauseType {
     GetDoubleQuotes,
     InstallNewBlock,
     Maybe,
+    CPU_now,
     QuotedToken,
     ReadTermFromChars,
     ResetBlock,
@@ -347,6 +348,7 @@ impl SystemClauseType {
             &SystemClauseType::PartialStringTail => clause_name!("$partial_string_tail"),
             &SystemClauseType::LiftedHeapLength => clause_name!("$lh_length"),
             &SystemClauseType::Maybe => clause_name!("maybe"),
+            &SystemClauseType::CPU_now => clause_name!("$cpu_now"),
             &SystemClauseType::ModuleAssertDynamicPredicateToFront => {
                 clause_name!("$module_asserta")
             }
@@ -480,6 +482,7 @@ impl SystemClauseType {
             ("$install_inference_counter", 3) => Some(SystemClauseType::InstallInferenceCounter),
             ("$lh_length", 1) => Some(SystemClauseType::LiftedHeapLength),
             ("$maybe", 0) => Some(SystemClauseType::Maybe),
+            ("$cpu_now", 1) => Some(SystemClauseType::CPU_now),
             ("$module_exists", 1) => Some(SystemClauseType::ModuleExists),
             ("$module_of", 2) => Some(SystemClauseType::ModuleOf),
             ("$module_retract_clause", 5) => Some(SystemClauseType::ModuleRetractClause),

--- a/src/prolog/lib/time.pl
+++ b/src/prolog/lib/time.pl
@@ -1,0 +1,51 @@
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   Written April 2020 by Markus Triska (triska@metalevel.at)
+   Part of Scryer Prolog.
+
+   This library provides predicates for reasoning about time.
+   sleep/1 should be implemented here, sleeping for a number of seconds.
+   In addition, this library should provide reasoning about time stamps.
+
+   '$cpu_new' can be replaced by statistics/2 once that is implemented.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+:- module(time, [time/1]).
+
+:- use_module(library(format)).
+:- use_module(library(iso_ext)).
+
+time(Goal) :-
+        '$cpu_now'(T0),
+        Goal,
+        '$cpu_now'(T),
+        Time is T - T0,
+        (   bb_get('$first_answer', true) ->
+            format("   % CPU time: ~3f seconds~n", [Time])
+        ;   format("% CPU time: ~3f seconds~n   ", [Time])
+        ).
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+?- time((true;false)).
+   % CPU time: 0.000 seconds
+   true
+;  false.
+
+:- time(use_module(library(clpz))).
+   % CPU time: 2.762 seconds
+   true
+;  false.
+
+:- time(use_module(library(lists))).
+   % CPU time: 0.000 seconds
+   true
+;  false.
+
+?- time(member(X, [a,b,c])).
+   % CPU time: 0.000 seconds
+   X = a
+;  % CPU time: 0.002 seconds
+   X = b
+;  % CPU time: 0.004 seconds
+   X = c
+;  false.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */

--- a/src/prolog/machine/system_calls.rs
+++ b/src/prolog/machine/system_calls.rs
@@ -28,6 +28,9 @@ use std::io::{stdout, Write};
 use std::iter::once;
 use std::rc::Rc;
 
+use std::time::Duration;
+use cpu_time::ProcessTime;
+
 use crate::crossterm::event::{read, Event, KeyCode, KeyEvent};
 use crate::crossterm::terminal::{enable_raw_mode, disable_raw_mode};
 
@@ -1951,6 +1954,13 @@ impl MachineState {
                 };
 
                 self.fail = result;
+            }
+            &SystemClauseType::CPU_now => {
+                let a1 = self[temp_v!(1)];
+                let a2 = ProcessTime::now().as_duration().as_secs_f64();
+                let addr = self.heap.put_constant(Constant::Float(OrderedFloat(a2)));
+
+                self.unify(a1, addr);
             }
             &SystemClauseType::OpDeclaration => {
                 let priority = self[temp_v!(1)];


### PR DESCRIPTION
`sleep/1` and predicates for reasoning about time stamps should also be added to this library.

Please review, and merge if applicable. Thank you!