### PR TITLE
Several smaller improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,6 @@ REPL:
 
 ```
 ?- [user].
-(type Enter + Ctrl-D to terminate the stream when finished)
 :- module(test, [local_member/2]).
 :- use_module(library(lists)).
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,12 @@ The modules that ship with Scryer&nbsp;Prolog are also called
   `time/1` reports the CPU&nbsp;time of a goal. It is useful
   for measuring the performance of your code.
 
+To read contents of external files, use `phrase_from_file/2` from
+[`library(pio)`](src/prolog/lib/pio.pl) to apply a&nbsp;DCG to
+file&nbsp;contents. The predicates in
+[`library(charsio)`](src/prolog/lib/charsio.pl) are also useful for
+parsing.
+
 To use predicates provided by the `lists` library, write:
 
 ```

--- a/src/prolog/lib/charsio.pl
+++ b/src/prolog/lib/charsio.pl
@@ -60,34 +60,42 @@ extend_var_list_([V|Vs], N, VarList, NewVarList, VarType) :-
 char_type(Char, Type) :-
     (   var(Char) -> throw(error(instantiation_error, char_type/2))
     ;   atom_length(Char, 1) ->
-        (   ground(Type) -> '$char_type'(Char, Type)
-        ;   Type = symbolic_control, '$char_type'(Char, Type)
-        ;   Type = layout, '$char_type'(Char, Type)
-        ;   Type = symbolic_hexadecimal, Char = x
-        ;   Type = octal_digit, '$char_type'(Char, Type)
-        ;   Type = binary_digit, '$char_type'(Char, Type)
-        ;   Type = hexadecimal_digit, '$char_type'(Char, Type)
-        ;   Type = exponent, '$char_type'(Char, Type)
-        ;   Type = sign, '$char_type'(Char, Type)
-        ;   Type = upper, '$char_type'(Char, Type)
-        ;   Type = lower, '$char_type'(Char, Type)
-        ;   Type = graphic, '$char_type'(Char, Type)
-        ;   Type = alpha, '$char_type'(Char, Type)
-        ;   Type = decimal_digit, '$char_type'(Char, Type)
-        ;   Type = alnum, '$char_type'(Char, Type)
-        ;   Type = meta, '$char_type'(Char, Type)
-        ;   Type = solo, '$char_type'(Char, Type)
-        ;   Type = prolog, '$char_type'(Char, Type)
-        ;   Type = alphabetic, '$char_type'(Char, Type)
-        ;   Type = whitespace, '$char_type'(Char, Type)
-        ;   Type = control, '$char_type'(Char, Type)
-        ;   Type = numeric, '$char_type'(Char, Type)
-        ;   Type = ascii, '$char_type'(Char, Type)
-        ;   Type = ascii_punctuation, '$char_type'(Char, Type)
-        ;   Type = ascii_graphic, '$char_type'(Char, Type)
+        (   ground(Type) ->
+            (   ctype(Type) ->
+                '$char_type'(Char, Type)
+            ;   throw(error(domain_error(char_type, Type), char_type/2))
+            )
+        ;   ctype(Type),
+            '$char_type'(Char, Type)
         )
     ;   throw(error(type_error(in_character, Char), char_type/2))
     ).
+
+
+ctype(alnum).
+ctype(alpha).
+ctype(alphabetic).
+ctype(ascii).
+ctype(ascii_graphic).
+ctype(ascii_punctuation).
+ctype(binary_digit).
+ctype(control).
+ctype(decimal_digit).
+ctype(exponent).
+ctype(graphic).
+ctype(hexadecimal_digit).
+ctype(layout).
+ctype(lower).
+ctype(meta).
+ctype(numeric).
+ctype(octal_digit).
+ctype(prolog).
+ctype(sign).
+ctype(solo).
+ctype(symbolic_control).
+ctype(symbolic_hexadecimal).
+ctype(upper).
+ctype(whitespace).
 
 
 get_single_char(C) :-

--- a/src/prolog/lib/charsio.pl
+++ b/src/prolog/lib/charsio.pl
@@ -47,7 +47,7 @@ extend_var_list(Value, VarList, NewVarList, VarType) :-
     term_variables(Value, Vars),
     extend_var_list_(Vars, 0, VarList, NewVarList, VarType).
 
-extend_var_list_([], N, VarList, VarList, _).
+extend_var_list_([], _, VarList, VarList, _).
 extend_var_list_([V|Vs], N, VarList, NewVarList, VarType) :-
     (  var_list_contains_variable(VarList, V) ->
        extend_var_list_(Vs, N, VarList, NewVarList, VarType)


### PR DESCRIPTION
For example, `char_type/2` now throws domain errors if an unknown type is specified. This helps when porting programs to Scryer Prolog, and is also a good guard against typos, because an exception lets programmers quickly pinpoint the root cause of issues.