### PR TITLE
Two small documentation additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,40 @@ only the standard predicate&nbsp;`(=)/2` is used.
 Definite clause grammars as provided by `library(dcgs)` are ideally
 suited for reasoning about strings.
 
+### Tabling (SLG resolution)
+
+One of the foremost attractions of Prolog is that logical consequences
+of pure&nbsp;programs can be derived by various execution strategies
+that differ regarding essential properties such as termination,
+completeness and efficiency.
+
+The default execution strategy of Prolog is depth-first search with
+chronological backtracking. This strategy is very efficient. Its main
+drawback is that it is *incomplete*: It may fail to find any solution
+even if one exists.
+
+Scryer Prolog supports an alternative execution strategy which is
+called *tabling* and also known as tabled&nbsp;execution and
+SLG&nbsp;resolution. To enable tabled execution for a predicate, use
+[`library(tabling)`](src/prolog/lib/tabling.pl) and add a `(table)/1`
+directive for the desired predicate indicator. For example, if we
+write:
+
+```
+:- use_module(library(tabling)).
+:- table a/0.
+
+a :- a.
+```
+
+Then the query `?- a.` *terminates* (and fails), whereas it
+does&nbsp;not terminate with the default execution strategy.
+
+Scryer Prolog implements tabling via *delimited continuations* as
+described in [*Tabling as a Library with Delimited
+Control*](https://biblio.ugent.be/publication/6880648/file/6885145.pdf)
+by Desouter&nbsp;et.&nbsp;al.
+
 ### Modules
 
 Scryer has a simple predicate-based module system. It provides a

--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ The modules that ship with Scryer&nbsp;Prolog are also called
 * [`time`](src/prolog/lib/time.pl)
   `time/1` reports the CPU&nbsp;time of a goal. It is useful
   for measuring the performance of your code.
+* [`cont`](src/prolog/lib/cont.pl)
+  Provides *delimited continuations* via `reset/3` and `shift/1`.
 
 To read contents of external files, use `phrase_from_file/2` from
 [`library(pio)`](src/prolog/lib/pio.pl) to apply a&nbsp;DCG to


### PR DESCRIPTION
These two commits document tabling and `library(cont)` in the README.

Please review, and merge if applicable.