### PR TITLE
Small corrections, additions and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,12 +281,15 @@ Logic&nbsp;Programming&nbsp;(LP) and Constraints.
 
 In addition to built-in support for [`dif/2`](src/prolog/lib/dif.pl),
 [`freeze/2`](src/prolog/lib/freeze.pl),
-[CLP(ℤ)](src/prolog/lib/clpz.pl) and [CLP(B)](src/prolog/lib/clpb.pl),
+[CLP(B)](src/prolog/lib/clpb.pl) and [CLP(ℤ)](src/prolog/lib/clpz.pl),
 Scryer provides a convenient way to implement new user-defined
 constraints: *Attributed variables* are available via
 [`library(atts)`](src/prolog/lib/atts.pl) as in SICStus&nbsp;Prolog,
 which is one of the most sophisticated and fastest constraint systems
-in existence.
+in existence. In [`library(iso_ext)`](src/prolog/lib/iso_ext.pl),
+Scryer provides predicates for backtrackable (`bb_b_put/2`) and
+non-backtrackable (`bb_put/2`) global variables, which are needed to
+implement certain types of constraint&nbsp;solvers.
 
 These features make Scryer Prolog an ideal platform for teaching,
 learning and developing portable CLP&nbsp;applications.

--- a/README.md
+++ b/README.md
@@ -350,7 +350,8 @@ The modules that ship with Scryer&nbsp;Prolog are also called
 * [`format`](src/prolog/lib/format.pl)
   The nonterminal `format_//2` is used to describe formatted output,
   arranging arguments according to a given format&nbsp;string.
-  The predicate `format/2` is provided for impure output.
+  The predicates `format/2`, `portray_clause/1` and `listing/1`
+  provide formatted *impure* output.
 * [`assoc`](src/prolog/lib/assoc.pl)
   providing `empty_assoc/1`, `get_assoc/3`, `put_assoc/4` etc.
   to manage elements in AVL&nbsp;trees which ensure

--- a/src/prolog/lib/charsio.pl
+++ b/src/prolog/lib/charsio.pl
@@ -3,7 +3,7 @@
                     write_term_to_chars/3]).
 
 :- use_module(library(iso_ext)).
-
+:- use_module(library(error)).
 
 fabricate_var_name(VarType, VarName, N) :-
     char_code('A', AC),
@@ -58,17 +58,17 @@ extend_var_list_([V|Vs], N, VarList, NewVarList, VarType) :-
 
 
 char_type(Char, Type) :-
-    (   var(Char) -> throw(error(instantiation_error, char_type/2))
+    (   var(Char) -> instantiation_error(char_type/2)
     ;   atom_length(Char, 1) ->
         (   ground(Type) ->
             (   ctype(Type) ->
                 '$char_type'(Char, Type)
-            ;   throw(error(domain_error(char_type, Type), char_type/2))
+            ;   domain_error(char_type, Type, char_type/2)
             )
         ;   ctype(Type),
             '$char_type'(Char, Type)
         )
-    ;   throw(error(type_error(in_character, Char), char_type/2))
+    ;   type_error(in_character, Char, char_type/2)
     ).
 
 
@@ -101,13 +101,13 @@ ctype(whitespace).
 get_single_char(C) :-
     (  var(C) -> '$get_single_char'(C)
     ;  atom_length(C, 1) -> '$get_single_char'(C)
-    ;  throw(error(type_error(in_character, C), get_single_char/1))
+    ;  type_error(in_character, C, get_single_char/1)
     ).
 
 
 read_term_from_chars(Chars, Term) :-
     (  var(Chars) ->
-       throw(error(instantiation_error, read_term_from_chars/2))
+       instantiation_error(read_term_from_chars/2)
     ;  nonvar(Term) ->
        throw(error(uninstantiation_error(Term), read_term_from_chars/2))
     ;  '$skip_max_list'(_, -1, Chars, Chars0),
@@ -115,23 +115,23 @@ read_term_from_chars(Chars, Term) :-
        partial_string(Chars) ->
        true
     ;
-       throw(error(type_error(complete_string, Chars), read_term_from_chars/2))
+       type_error(complete_string, Chars, read_term_from_chars/2)
     ),
     '$read_term_from_chars'(Chars, Term).
 
 
 write_term_to_chars(_, Options, _) :-
-    var(Options), throw(error(instantiation_error, write_term_to_chars/3)).
+    var(Options), instantiation_error(write_term_to_chars/3).
 write_term_to_chars(Term, Options, Chars) :-
     '$skip_max_list'(_, -1, Options, Options0),
     (  var(Options0)  ->
-       throw(error(instantiation_error, write_term_to_chars/3))
+       instantiation_error(write_term_to_chars/3)
     ;  nonvar(Chars)  ->
        throw(error(uninstantiation_error(Chars), write_term_to_chars/3))
     ;  Options0 == [] ->
        true
     ;
-       throw(error(type_error(list, Options), write_term_to_chars/3))
+       type_error(list, Options, write_term_to_chars/3)
     ),
     builtins:inst_member_or(Options, ignore_ops(IgnoreOps), ignore_ops(false)),
     builtins:inst_member_or(Options, numbervars(NumberVars), numbervars(false)),

--- a/src/prolog/lib/clpz.pl
+++ b/src/prolog/lib/clpz.pl
@@ -6917,12 +6917,6 @@ contribution_at(T, Task, Offset-Bs, Contribution) :-
             ?(Contribution) #= B*C
         ).
 
-nth0(0, [E|_], E) :- !.
-nth0(N, [_|Ls], E) :-
-        N > 0,
-        N1 is N - 1,
-        nth0(N1, Ls, E).
-
 nth1(I, Es, E) :-
         I0 is I-1,
         nth0(I0, Es, E).

--- a/src/prolog/lib/lists.pl
+++ b/src/prolog/lib/lists.pl
@@ -21,9 +21,9 @@ length(Xs, N) :-
     ;  var(Xs0)  -> R is N-M, length_rundown(Xs0, R)).
 length(_, N) :-
     integer(N), !,
-    throw(error(domain_error(not_less_than_zero, N), length/2)).
+    domain_error(not_less_than_zero, N, length/2).
 length(_, N) :-
-    throw(error(type_error(integer, N), length/2)).
+    type_error(integer, N, length/2).
 
 length_addendum([], N, N).
 length_addendum([_|Xs], N, M) :-

--- a/src/prolog/lib/lists.pl
+++ b/src/prolog/lib/lists.pl
@@ -63,7 +63,7 @@ reverse(Xs, Ys) :-
     ).
 
 reverse([], [], YsRev, YsRev).
-reverse([X1|Xs], [Y1|Ys], YsPreludeRev, Xss) :-
+reverse([_|Xs], [Y1|Ys], YsPreludeRev, Xss) :-
     reverse(Xs, Ys, [Y1|YsPreludeRev], Xss).
 
 
@@ -104,7 +104,7 @@ maplist(Cont, [E1|E1s], [E2|E2s], [E3|E3s], [E4|E4s], [E5|E5s], [E6|E6s], [E7|E7
 
 maplist(_, [], [], [], [], [], [], [], []).
 maplist(Cont, [E1|E1s], [E2|E2s], [E3|E3s], [E4|E4s], [E5|E5s], [E6|E6s], [E7|E7s], [E8|E8s]) :-
-    call(Cont, E1, E2, E3, E4, E5, E6, E7),
+    call(Cont, E1, E2, E3, E4, E5, E6, E7, E8),
     maplist(Cont, E1s, E2s, E3s, E4s, E5s, E6s, E7s, E8s).
 
 

--- a/src/prolog/lib/lists.pl
+++ b/src/prolog/lib/lists.pl
@@ -1,7 +1,7 @@
 :- module(lists, [member/2, select/3, append/2, append/3, foldl/4, foldl/5,
 		  memberchk/2, reverse/2, length/2, maplist/2,
 		  maplist/3, maplist/4, maplist/5, maplist/6,
-		  maplist/7, maplist/8, maplist/9, same_length/2,
+		  maplist/7, maplist/8, maplist/9, same_length/2, nth0/3,
 		  sum_list/2, transpose/2, list_to_set/2]).
 
 
@@ -177,3 +177,26 @@ unify_same(E-V, Prev-Var, E-V) :-
             Var = V
         ;   true
         ).
+
+
+nth0(N, Es, E) :-
+        can_be(integer, N),
+        can_be(list, Es),
+        (   integer(N) ->
+            nth0_index(N, Es, E)
+        ;   nth0_search(N, Es, E)
+        ).
+
+nth0_index(0, [E|_], E) :- !.
+nth0_index(N, [_|Es], E) :-
+        N > 0,
+        N1 is N - 1,
+        nth0_index(N1, Es, E).
+
+nth0_search(N, Es, E) :-
+        nth0_search(0, N, Es, E).
+
+nth0_search(N, N, [E|_], E).
+nth0_search(N0, N, [_|Es], E) :-
+        N1 is N0 + 1,
+        nth0_search(N1, N, Es, E).

--- a/src/prolog/lib/random.pl
+++ b/src/prolog/lib/random.pl
@@ -22,7 +22,7 @@ random(R) :-
 random_integer(Lower, Upper, R) :-
     var(R),
     (   (var(Lower) ; var(Upper)) ->
-            throw(error(instantiation_error, random_integer/3))
+            instantiation_error(random_integer/3)
     ;   \+ integer(Lower) ->
             domain_error(integer, Lower, random_integer/3)
     ;   \+ integer(Upper) ->

--- a/src/prolog/lib/time.pl
+++ b/src/prolog/lib/time.pl
@@ -6,7 +6,7 @@
    Reasoning about time stamps would be a useful addition, for example
    by obtaining the current time, comparing and formatting it.
 
-   '$cpu_new' can be replaced by statistics/2 once that is implemented.
+   '$cpu_now' can be replaced by statistics/2 once that is implemented.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 :- module(time, [max_sleep_time/1, sleep/1, time/1]).
@@ -22,7 +22,7 @@ sleep(T) :-
     (   T < 0 ->
         domain_error(not_less_than_zero, T, sleep/1)
     ;   max_sleep_time(N), T > N ->
-        throw(error(reprensentation_error(max_sleep_time), sleep/1))
+        throw(error(representation_error(max_sleep_time), sleep/1))
     ;   '$sleep'(T)
     ).
 


### PR DESCRIPTION
In addition to a few small corrections and improvements, these commits also provide `nth0/3` in `library(lists)`.

Using `nth0/3` is often a sign that better data structures could be appropriate. On the other hand, it is sometimes useful to have it.