### PR TITLE
correct verify_attributes/3 for variables that have no CLP(ℤ) attribute attached (#373)

### DIFF
--- a/src/prolog/lib/clpz.pl
+++ b/src/prolog/lib/clpz.pl
@@ -7371,7 +7371,8 @@ goals_entail(Goals, E) :-
 
 verify_attributes(Var, Other, Gs) :-
         % portray_clause(Var = Other),
-        (   get_attr(Var, clpz, clpz_attr(_,_,_,Dom,Ps,Q)) ->
+        (   get_atts(Var, clpz(CLPZ)) ->
+            CLPZ = clpz_attr(_,_,_,Dom,Ps,Q),
             (   nonvar(Other) ->
                 (   integer(Other) -> true
                 ;   type_error(integer, Other)
@@ -7379,14 +7380,17 @@ verify_attributes(Var, Other, Gs) :-
                 domain_contains(Dom, Other),
                 phrase(trigger_props(Ps), [Q], [_]),
                 Gs = [phrase(do_queue, [Q], _)]
-            ;   fd_get(Other, OD, OPs),
-                domains_intersection(OD, Dom, Dom1),
-                append_propagators(Ps, OPs, Ps1),
-                new_queue(Q0),
-                variables_same_queue([Var,Other]),
-                phrase((fd_put(Other,Dom1,Ps1),
-                        trigger_props(Ps1)), [Q0], _),
-                Gs = [phrase(do_queue, [Q0], _)]
+            ;   (   get_atts(Other, clpz(clpz_attr(_,_,_,OD,OPs,_))) ->
+                    domains_intersection(OD, Dom, Dom1),
+                    append_propagators(Ps, OPs, Ps1),
+                    new_queue(Q0),
+                    variables_same_queue([Var,Other]),
+                    phrase((fd_put(Other,Dom1,Ps1),
+                            trigger_props(Ps1)), [Q0], _),
+                    Gs = [phrase(do_queue, [Q0], _)]
+                ;   put_atts(Other, clpz(CLPZ)),
+                    Gs = []
+                )
             )
         ;   Gs = []
         ).


### PR DESCRIPTION
Example:

    ?- freeze(B, queen_value_truth(C,N,B)), Q #= N #<==> B.
       clpz:(Q#=N#<==>B), clpz:(B in 0..1), freeze:freeze(B,queen_value_truth(C,N,B))
    ;  false.