### PR TITLE
enable goal expansion for CLP(ℤ) goals

### DIFF
--- a/src/prolog/lib/clpz.pl
+++ b/src/prolog/lib/clpz.pl
@@ -3064,7 +3064,7 @@ is_false(var(X)) :- nonvar(X).
 
 :- dynamic(goal_expansion/1).
 
-goal_expansion(Goal0, _Layout1, _Module, Goal, []) :-
+user:goal_expansion(Goal0, Goal) :-
         \+ goal_expansion(false),
         clpz_expandable(Goal0),
         clpz_expansion(Goal0, Goal).


### PR DESCRIPTION
Example:

    integer_successor(I0, I) :- I #= I0 + 1.

Yielding:

    ?- listing(integer_successor/2).
    integer_successor(A,B) :-
       (  integer(B) ->
          (  integer(A) ->
             B=:=A+1
          ;  C is B,
             clpz:clpz_equal(C,A+1)
          )
       ;  (  integer(A) ->
             (  var(B) ->
                B is A+1
             ;  C is A+1,
                clpz:clpz_equal(B,C)
             )
          ;  clpz:clpz_equal(B,A+1)
          )
       ).

Thus, fast low-level arithmetic is used whenever possible.