### PR TITLE
ADDED: crypto_n_random_bytes/2, creating cryptographically secure random bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ ref_thread_local = "0.0.0"
 rug = { version = "1.4.0", optional = true }
 rustyline = "6.0.0"
 unicode_reader = "1.0.0"
+ring = "0.16.13"

--- a/src/prolog/clause_types.rs
+++ b/src/prolog/clause_types.rs
@@ -286,6 +286,7 @@ pub enum SystemClauseType {
     WriteTerm,
     WriteTermToChars,
     ScryerPrologVersion,
+    CryptoRandomByte
 }
 
 impl SystemClauseType {
@@ -468,6 +469,7 @@ impl SystemClauseType {
             &SystemClauseType::WriteTerm => clause_name!("$write_term"),
             &SystemClauseType::WriteTermToChars => clause_name!("$write_term_to_chars"),
             &SystemClauseType::ScryerPrologVersion => clause_name!("$scryer_prolog_version"),
+            &SystemClauseType::CryptoRandomByte => clause_name!("$crypto_random_byte"),
         }
     }
 
@@ -630,6 +632,7 @@ impl SystemClauseType {
             ("$write_term", 7) => Some(SystemClauseType::WriteTerm),
             ("$write_term_to_chars", 7) => Some(SystemClauseType::WriteTermToChars),
             ("$scryer_prolog_version", 1) => Some(SystemClauseType::ScryerPrologVersion),
+            ("$crypto_random_byte", 1) => Some(SystemClauseType::CryptoRandomByte),
             _ => None,
         }
     }

--- a/src/prolog/lib/crypto.pl
+++ b/src/prolog/lib/crypto.pl
@@ -12,7 +12,8 @@
    using strings leaves little trace of what was processed in the system,
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-:- module(crypto, [hex_bytes/2]).
+:- module(crypto, [hex_bytes/2,
+                   crypto_n_random_bytes/2]).
 
 :- use_module(library(error)).
 :- use_module(library(lists)).
@@ -70,3 +71,10 @@ bytes_hex([B|Bs]) --> [C0,C1],
 char_hexval(C, H) :- nth0(H, "0123456789abcdef", C), !.
 char_hexval(C, H) :- nth0(H, "0123456789ABCDEF", C), !.
 
+
+crypto_n_random_bytes(N, Bs) :-
+        must_be(integer, N),
+        length(Bs, N),
+        maplist(crypto_random_byte, Bs).
+
+crypto_random_byte(B) :- '$crypto_random_byte'(B).


### PR DESCRIPTION
The ring crate is used since it will be needed also for future predicates in library(crypto).

This is the first step to porting [Bitcoinolog](https://www.metalevel.at/bitcoinolog/) to Scryer Prolog.

Please review, and merge if applicable. Thank you!