### PR TITLE
ADDED: HMAC-based key derivation (HKDF) via crypto_data_hkdf/4

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,8 @@ The modules that ship with Scryer&nbsp;Prolog are also called
 * [`sockets`](src/prolog/lib/sockets.pl)
   Predicates for opening and accepting TCP connections as streams.
 * [`crypto`](src/prolog/lib/crypto.pl)
-  Cryptographically secure random numbers and hashes, and
-  reasoning about elliptic curves.
+  Cryptographically secure random numbers and hashes, HMAC-based
+  key derivation (HKDF), and reasoning about elliptic curves.
 
 To read contents of external files, use `phrase_from_file/2` from
 [`library(pio)`](src/prolog/lib/pio.pl) to apply a&nbsp;DCG to

--- a/src/prolog/clause_types.rs
+++ b/src/prolog/clause_types.rs
@@ -287,7 +287,8 @@ pub enum SystemClauseType {
     WriteTermToChars,
     ScryerPrologVersion,
     CryptoRandomByte,
-    CryptoDataHash
+    CryptoDataHash,
+    CryptoDataHKDF
 }
 
 impl SystemClauseType {
@@ -472,6 +473,7 @@ impl SystemClauseType {
             &SystemClauseType::ScryerPrologVersion => clause_name!("$scryer_prolog_version"),
             &SystemClauseType::CryptoRandomByte => clause_name!("$crypto_random_byte"),
             &SystemClauseType::CryptoDataHash => clause_name!("$crypto_data_hash"),
+            &SystemClauseType::CryptoDataHKDF => clause_name!("$crypto_data_hkdf"),
         }
     }
 
@@ -636,6 +638,7 @@ impl SystemClauseType {
             ("$scryer_prolog_version", 1) => Some(SystemClauseType::ScryerPrologVersion),
             ("$crypto_random_byte", 1) => Some(SystemClauseType::CryptoRandomByte),
             ("$crypto_data_hash", 3) => Some(SystemClauseType::CryptoDataHash),
+            ("$crypto_data_hkdf", 6) => Some(SystemClauseType::CryptoDataHKDF),
             _ => None,
         }
     }

--- a/src/prolog/machine/machine_state_impl.rs
+++ b/src/prolog/machine/machine_state_impl.rs
@@ -2746,6 +2746,51 @@ impl MachineState {
         *list = result;
     }
 
+
+    pub(super)
+    fn integers_to_bytevec(
+        &self,
+        r: RegType,
+        caller: MachineStub,
+    ) -> Vec<u8> {
+
+        let mut bytes: Vec<u8> = Vec::new();
+
+        match self.try_from_list(r, caller) {
+            Err(_) => { unreachable!() }
+            Ok(addrs) => {
+
+                for addr in addrs {
+                    let addr = self.store(self.deref(addr));
+
+                    match Number::try_from((addr, &self.heap)) {
+                        Ok(Number::Fixnum(n)) => {
+                            match u8::try_from(n) {
+                                Ok(b) => {
+                                    bytes.push(b);
+                                }
+                                Err(_) => { }
+                            }
+
+                            continue;
+                        }
+                        Ok(Number::Integer(n)) => {
+                            if let Some(b) = n.to_u8() {
+                               bytes.push(b);
+                            }
+
+                            continue;
+                        }
+                        _ => {
+                        }
+                    }
+                }
+            }
+        }
+        bytes
+    }
+
+
     pub(super)
     fn try_from_list(
         &self,

--- a/src/prolog/machine/system_calls.rs
+++ b/src/prolog/machine/system_calls.rs
@@ -39,7 +39,7 @@ use crate::crossterm::event::{read, Event, KeyCode, KeyEvent, KeyModifiers};
 use crate::crossterm::terminal::{enable_raw_mode, disable_raw_mode};
 
 use ring::rand::{SecureRandom, SystemRandom};
-use ring::digest;
+use ring::{digest,hkdf};
 use ripemd160::{Ripemd160, Digest};
 
 pub fn get_key() -> KeyEvent {
@@ -5206,41 +5206,8 @@ impl MachineState {
                 self.unify(arg, byte);
             }
             &SystemClauseType::CryptoDataHash => {
-                let mut bytes: Vec<u8> = Vec::new();
-
                 let stub = MachineError::functor_stub(clause_name!("crypto_data_hash"), 3);
-
-                match self.try_from_list(temp_v!(1), stub) {
-                    Err(e) => return Err(e),
-                    Ok(addrs) => {
-
-                        for addr in addrs {
-                            let addr = self.store(self.deref(addr));
-
-                            match Number::try_from((addr, &self.heap)) {
-                                Ok(Number::Fixnum(n)) => {
-                                    match u8::try_from(n) {
-                                        Ok(b) => {
-                                            bytes.push(b);
-                                        }
-                                        Err(_) => { }
-                                    }
-
-                                    continue;
-                                }
-                                Ok(Number::Integer(n)) => {
-                                    if let Some(b) = n.to_u8() {
-                                       bytes.push(b);
-                                    }
-
-                                    continue;
-                                }
-                                _ => {
-                                }
-                            }
-                        }
-                    }
-                }
+                let bytes = self.integers_to_bytevec(temp_v!(1), stub);
 
                 let algorithm = self[temp_v!(3)];
                 let algorithm_str = match self.store(self.deref(algorithm)) {
@@ -5276,6 +5243,58 @@ impl MachineState {
 
                 self.unify(self[temp_v!(2)], ints_list);
             }
+            &SystemClauseType::CryptoDataHKDF => {
+                let stub1 = MachineError::functor_stub(clause_name!("crypto_data_hkdf"), 6);
+                let data = self.integers_to_bytevec(temp_v!(1), stub1);
+                let stub2 = MachineError::functor_stub(clause_name!("crypto_data_hkdf"), 6);
+                let salt = self.integers_to_bytevec(temp_v!(2), stub2);
+                let stub3 = MachineError::functor_stub(clause_name!("crypto_data_hkdf"), 6);
+                let info = self.integers_to_bytevec(temp_v!(3), stub3);
+
+                let algorithm = match self.store(self.deref(self[temp_v!(4)])) {
+                    Addr::Con(h) if self.heap.atom_at(h) => {
+                        if let HeapCellValue::Atom(ref atom, _) = &self.heap[h] {
+                            atom.as_str()
+                        } else {
+                            unreachable!()
+                        }
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                };
+
+                let length =
+                    match Number::try_from((self[temp_v!(5)], &self.heap)) {
+                        Ok(Number::Fixnum(n)) => {
+                            usize::try_from(n).unwrap()
+                        }
+                        Ok(Number::Integer(n)) => {
+                            n.to_usize().unwrap()
+                        }
+                        _ => {
+                            unreachable!()
+                        }
+                    };
+
+                let ints_list =
+                        {   let digest_alg  =
+                               match algorithm {
+                                  "sha256" =>     { hkdf::HKDF_SHA256 }
+                                  "sha384" =>     { hkdf::HKDF_SHA384 }
+                                  "sha512" =>     { hkdf::HKDF_SHA512 }
+                                  _ =>            { unreachable!() }
+                               };
+                             let salt = hkdf::Salt::new(digest_alg, &salt);
+                             let mut bytes : Vec<u8> = Vec::new();
+                             bytes.resize(length, 0);
+                             salt.extract(&data).expand(&[&info[..]], MyKey(length)).unwrap().fill(&mut bytes).unwrap();
+
+                             Addr::HeapCell(self.heap.to_list(bytes.iter().map(|b| HeapCellValue::Integer(Rc::new(Integer::from(*b))))))
+                        };
+
+                self.unify(self[temp_v!(6)], ints_list);
+            }
         };
 
         return_from_clause!(self.last_call, self)
@@ -5291,4 +5310,12 @@ fn rng() -> &'static dyn SecureRandom {
     }
 
     RANDOM.deref()
+}
+
+struct MyKey<T: core::fmt::Debug + PartialEq>(T);
+
+impl hkdf::KeyType for MyKey<usize> {
+    fn len(&self) -> usize {
+        self.0
+    }
 }


### PR DESCRIPTION
This is useful to generate keys and initialization vectors from suitable input keying material, so that future predicates for symmetric encryption can be used with appropriate parameters.

Please review, and merge if applicable. Thank you!