### PR TITLE
ADDED: Password-based key derivation (PBKDF2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,8 @@ The modules that ship with Scryer&nbsp;Prolog are also called
   Predicates for opening and accepting TCP connections as streams.
 * [`crypto`](src/prolog/lib/crypto.pl)
   Cryptographically secure random numbers and hashes, HMAC-based
-  key derivation (HKDF), and reasoning about elliptic curves.
+  key derivation (HKDF), password-based key derivation (PBKDF2),
+  and reasoning about elliptic curves.
 
 To read contents of external files, use `phrase_from_file/2` from
 [`library(pio)`](src/prolog/lib/pio.pl) to apply a&nbsp;DCG to

--- a/src/prolog/clause_types.rs
+++ b/src/prolog/clause_types.rs
@@ -288,7 +288,8 @@ pub enum SystemClauseType {
     ScryerPrologVersion,
     CryptoRandomByte,
     CryptoDataHash,
-    CryptoDataHKDF
+    CryptoDataHKDF,
+    CryptoPasswordHash
 }
 
 impl SystemClauseType {
@@ -474,6 +475,7 @@ impl SystemClauseType {
             &SystemClauseType::CryptoRandomByte => clause_name!("$crypto_random_byte"),
             &SystemClauseType::CryptoDataHash => clause_name!("$crypto_data_hash"),
             &SystemClauseType::CryptoDataHKDF => clause_name!("$crypto_data_hkdf"),
+            &SystemClauseType::CryptoPasswordHash => clause_name!("$crypto_password_hash"),
         }
     }
 
@@ -639,6 +641,7 @@ impl SystemClauseType {
             ("$crypto_random_byte", 1) => Some(SystemClauseType::CryptoRandomByte),
             ("$crypto_data_hash", 3) => Some(SystemClauseType::CryptoDataHash),
             ("$crypto_data_hkdf", 6) => Some(SystemClauseType::CryptoDataHKDF),
+            ("$crypto_password_hash", 4) => Some(SystemClauseType::CryptoPasswordHash),
             _ => None,
         }
     }


### PR DESCRIPTION
The new predicates crypto_password_hash/[2,3] let you store passwords safely, and easily verify passwords later.

Please review, and merge if applicable.

Also, many thanks to @matt2xu: I am now already using the new predicate `chars_utf8bytes/2` to use the UTF-8 representation of characters for hashing.