### PR TITLE
Authenticated encryption in library(crypto), new encoding/1 option for hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ The modules that ship with Scryer&nbsp;Prolog are also called
 * [`crypto`](src/prolog/lib/crypto.pl)
   Cryptographically secure random numbers and hashes, HMAC-based
   key derivation (HKDF), password-based key derivation (PBKDF2),
-  and reasoning about elliptic curves.
+  authenticated encryption, and reasoning about elliptic curves.
 
 To read contents of external files, use `phrase_from_file/2` from
 [`library(pio)`](src/prolog/lib/pio.pl) to apply a&nbsp;DCG to

--- a/src/prolog/clause_types.rs
+++ b/src/prolog/clause_types.rs
@@ -289,7 +289,9 @@ pub enum SystemClauseType {
     CryptoRandomByte,
     CryptoDataHash,
     CryptoDataHKDF,
-    CryptoPasswordHash
+    CryptoPasswordHash,
+    CryptoDataEncrypt,
+    CryptoDataDecrypt
 }
 
 impl SystemClauseType {
@@ -476,6 +478,8 @@ impl SystemClauseType {
             &SystemClauseType::CryptoDataHash => clause_name!("$crypto_data_hash"),
             &SystemClauseType::CryptoDataHKDF => clause_name!("$crypto_data_hkdf"),
             &SystemClauseType::CryptoPasswordHash => clause_name!("$crypto_password_hash"),
+            &SystemClauseType::CryptoDataEncrypt => clause_name!("$crypto_data_encrypt"),
+            &SystemClauseType::CryptoDataDecrypt => clause_name!("$crypto_data_decrypt"),
         }
     }
 
@@ -642,6 +646,8 @@ impl SystemClauseType {
             ("$crypto_data_hash", 3) => Some(SystemClauseType::CryptoDataHash),
             ("$crypto_data_hkdf", 6) => Some(SystemClauseType::CryptoDataHKDF),
             ("$crypto_password_hash", 4) => Some(SystemClauseType::CryptoPasswordHash),
+            ("$crypto_data_encrypt", 5) => Some(SystemClauseType::CryptoDataEncrypt),
+            ("$crypto_data_decrypt", 5) => Some(SystemClauseType::CryptoDataDecrypt),
             _ => None,
         }
     }

--- a/src/prolog/lib/crypto.pl
+++ b/src/prolog/lib/crypto.pl
@@ -155,16 +155,17 @@ crypto_random_byte(B) :- '$crypto_random_byte'(B).
    characters, and Hash is the computed hash as a list of hexadecimal
    characters.
 
-   The single supported option is:
+   Options is a list of:
 
-      algorithm(A)
-
-   where A is one of ripemd160, sha256, sha384, sha512, sha512_256,
-   or a variable.
-
-   If A is a variable, then it is unified with the default algorithm,
-   which is an algorithm that is considered cryptographically secure
-   at the time of this writing.
+     - algorithm(+A)
+       where A is one of ripemd160, sha256, sha384, sha512,
+       sha512_256, or a variable. If A is a variable, then it is
+       unified with the default algorithm, which is an algorithm that
+       is considered cryptographically secure at the time of this
+       writing.
+     - encoding(+Encoding)
+       The default encoding is utf8. The alternative is octet,
+       to treat the input as a list of raw bytes.
 
    Example:
 
@@ -182,8 +183,9 @@ crypto_random_byte(B) :- '$crypto_random_byte'(B).
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 crypto_data_hash(Data0, Hash, Options0) :-
-        chars_bytes_(Data0, Data, crypto_data_hash/3),
         must_be(list, Options0),
+        option(encoding(Encoding), Options0, utf8),
+        encoding_bytes(Encoding, Data0, Data),
         functor_hash_options(algorithm, A, Options0, _),
         (   hash_algorithm(A) -> true
         ;   domain_error(hash_algorithm, A, crypto_data_hash/3)
@@ -235,6 +237,9 @@ hash_algorithm(sha512_256).
      - salt(+List)
        Optionally, a list of bytes that are used as salt. The
        default is all zeroes.
+     - encoding(+Encoding)
+       The default encoding is utf8. The alternative is octet,
+       to treat the input as a list of raw bytes.
 
    The `info/1`  option can be  used to  generate multiple keys  from a
    single  master key,  using for  example values  such as  "key" and
@@ -245,7 +250,8 @@ hash_algorithm(sha512_256).
 
 crypto_data_hkdf(Data0, L, Bytes, Options0) :-
         functor_hash_options(algorithm, Algorithm, Options0, Options),
-        chars_bytes_(Data0, Data, crypto_data_hkdf/4),
+        option(encoding(Encoding), Options, utf8),
+        encoding_bytes(Encoding, Data0, Data),
         option(salt(SaltBytes), Options, []),
         must_be_bytes(SaltBytes, crypto_data_hkdf/4),
         option(info(Info0), Options, []),
@@ -339,7 +345,7 @@ dollar_segments(Ls, Segments) :-
 
      - algorithm(+Algorithm)
        The algorithm to use. Currently, the only available algorithm
-       is =|pbkdf2-sha512|=, which is therefore also the default.
+       is 'pbkdf2-sha512', which is therefore also the default.
      - cost(+C)
        C is an integer, denoting the binary logarithm of the number
        of _iterations_ used for the derivation of the hash. This

--- a/src/prolog/lib/format.pl
+++ b/src/prolog/lib/format.pl
@@ -544,7 +544,7 @@ listing(PI) :-
         ;   type_error(predicate_indicator, PI, listing/1)
         ),
         functor(Head, Name, Arity),
-        \+ \+ clause(Head, Body), % only true if there is at least one clause
+        \+ \+ clause(Head, _), % only true if there is at least one clause
         (   clause(Head, Body),
             (   Body == true ->
                 portray_clause(Head)

--- a/src/prolog/lib/format.pl
+++ b/src/prolog/lib/format.pl
@@ -275,8 +275,7 @@ cells(Fs0, Args, Tab, Es) -->
         cells(Fs, Args, Tab, [chars(Fs1)|Es]).
 
 n_newlines(0) --> !.
-n_newlines(1) --> !, [newline].
-n_newlines(N0) --> { N0 > 1, N is N0 - 1 }, [newline], n_newlines(N).
+n_newlines(N0) --> { N0 > 0, N is N0 - 1 }, [newline], n_newlines(N).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ?- phrase(upto_what(Cs, ~), "abc~test", Rest).


### PR DESCRIPTION
This PR implements **authenticated symmetric encryption** via `crypto_data_encrypt/6` and `crypto_data_decrypt/4` for encryption and decryption using the fast and secure ChaCha20 stream cipher in tandem with the Poly1305 authenticator.

Here is an example query to try:

<pre>
    ?- Algorithm = 'chacha20-poly1305',
       crypto_n_random_bytes(32, Key),
       crypto_n_random_bytes(12, IV),
       crypto_data_encrypt("this text is to be encrypted", Algorithm,
                   Key, IV, CipherText, [tag(Tag)]),
       crypto_data_decrypt(CipherText, Algorithm,
                   Key, IV, RecoveredText, [tag(Tag)]).
</pre>

It also adds the new `encoding/1` option to `crypto_data_hash/3` and `crypto_data_hkdf/4`. By specifying `encoding(octet)` as option, a list of characters can be treated as raw bytes. The default encoding is `utf8`.

Scryer Prolog's efficient representation for lists of characters is especially useful in the context of cryptographic applications: In addition to its efficiency and convenience, it also makes applications **more&nbsp;secure**, since the plain text is not made visible in the atom table by reasoning about lists of characters.

Please review, and merge if applicable. Many thanks!
