### PR TITLE
Created and Tested Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target
+Dockerfile
+README.md
+.git
+.gitignore
+.gitmodules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,33 @@
-FROM rust:slim
+# Based on https://blog.sedrik.se/posts/my-docker-setup-for-rust/
+FROM ekidd/rust-musl-builder as builder
 
-WORKDIR ~/scryer-prolog
+WORKDIR /home/rust/
+
+# Install external dependencies
+RUN sudo apt-get update
+RUN sudo apt-get -y install m4
+
+# Avoid having to install/build all dependencies by copying
+# the Cargo files and making a dummy src/main.rs and build.rs
+COPY Cargo.toml .
+COPY Cargo.lock .
+RUN echo "fn main() {}" > src/main.rs
+RUN echo "fn main() {}" > build.rs
+RUN cargo build --release
+
+# We need to touch our real main.rs and build.rs files or else
+# docker will use the cached one.
 COPY . .
+RUN sudo touch src/main.rs
+RUN sudo touch build.rs
 
-RUN cargo --version
-RUN cargo install --path .
+RUN cargo build --release
 
-CMD ["scryer-prolog"]
+# Size optimization
+# RUN strip target/x86_64-unknown-linux-musl/release/scryer-prolog
+
+# Start building the final image
+FROM scratch
+WORKDIR /home/rust/
+COPY --from=builder /home/rust/target/x86_64-unknown-linux-musl/release/scryer-prolog .
+ENTRYPOINT ["./scryer-prolog"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:slim
+
+WORKDIR ~/scryer-prolog
+COPY . .
+
+RUN cargo --version
+RUN cargo install --path .
+
+CMD ["scryer-prolog"]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ strings.
 
 ## Installing Scryer Prolog
 
+### Native Install (Unix Only)
+
 First, install the latest stable version of
 [Rust](https://www.rust-lang.org/en-US/install.html) using your
 preferred method. Scryer tends to use features from newer Rust
@@ -125,6 +127,26 @@ $> cargo run [--release]
 
 The optional `--release` flag will perform various optimizations,
 producing a faster executable.
+
+### Docker Install (All Platforms)
+
+To automatically download, install, and run Scryer Prolog via Docker,
+simply run:
+```
+$> docker run -it mthom/scryer-prolog
+```
+
+To be able to load your program files, bind mount your programs folder
+as a Docker volume:
+
+```
+$> docker run -v /home/user/prolog:/mnt -it mthom/scryer-prolog
+?- consult('mnt/program.pl').
+true.
+```
+
+[Docker](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
+is currently the only way to run scryer-prolog on Windows.
 
 ## Tutorial
 


### PR DESCRIPTION
Deploying scryer-prolog to Docker will allow it to reach a farther audience and open up the possibility of building Docker applications based on it.

It also opens it up to Windows folks (I run it just fine through [Docker Desktop for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)).

I played around with the Dockerfile until I got the image down to 77MB, which is not bad.

If deploying to Docker seems like a good idea, let's discuss the best way to do it. I don't want you to have to spend hours deploying crates, docker images, etc. Maybe setting up Travis CI is a good idea? It's free for open source projects.

Let me know what you think!