### PR TITLE
Valid Dockerfile and README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target
+Dockerfile
+README.md
+.git
+.gitignore
+.gitmodules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Based on https://hub.docker.com/_/rust?tab=description and https://hub.docker.com/_/rust?tab=description
+# Based on https://hub.docker.com/_/rust?tab=description and https://blog.sedrik.se/posts/my-docker-setup-for-rust/
 
 # The first container is for build purposes only.
 FROM rust as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Based on https://hub.docker.com/_/rust?tab=description and https://hub.docker.com/_/rust?tab=description
+
+# The first container is for build purposes only.
+FROM rust as builder
+
+WORKDIR /usr/src/scryer-prolog
+
+# Using a dummy build.rs and src/main.rs with your Cargo.toml lets Docker cache your Rust dependencies and not rebuild
+# them every time.
+COPY Cargo.toml .
+COPY Cargo.lock .
+RUN mkdir -p src
+RUN echo "fn main() {}" > src/main.rs
+RUN echo "fn main() {}" > build.rs
+RUN cargo build --release
+
+# We need to touch our real main.rs and build.rs files or else
+# docker will use the cached ones.
+COPY . .
+RUN touch src/main.rs
+RUN touch build.rs
+
+RUN cargo build --release
+
+RUN ls ./target/release
+
+# Finally, copy the scryer-prolog executable to a slimmer container.
+FROM debian:buster-slim
+COPY --from=builder /usr/src/scryer-prolog/target/release/scryer-prolog /usr/local/bin/scryer-prolog
+CMD ["scryer-prolog"]

--- a/README.md
+++ b/README.md
@@ -130,23 +130,31 @@ producing a faster executable.
 
 ### Docker Install (All Platforms)
 
-To automatically download, install, and run Scryer Prolog via Docker,
-simply run:
+First, install [Docker](https://docs.docker.com/get-docker/) on Linux,
+Windows, or Mac.
+
+Once Docker is installed, you can automatically download, install, and
+run Scryer Prolog in a single command:
 ```
-$> docker run -it mthom/scryer-prolog
+$> docker run -it mjt128/scryer-prolog
 ```
 
-To be able to load your program files, bind mount your programs folder
-as a Docker volume:
+To consult your Prolog files, bind mount your programs folder as a
+[Docker volume](https://docs.docker.com/storage/volumes/):
 
 ```
-$> docker run -v /home/user/prolog:/mnt -it mthom/scryer-prolog
-?- consult('mnt/program.pl').
+$> docker run -v /home/user/prolog:/mnt -it mjt128/scryer-prolog
+?- consult('/mnt/program.pl').
 true.
 ```
 
-[Docker](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
-is currently the only way to run scryer-prolog on Windows.
+This works on Windows too:
+
+```
+$> docker run -v C:\Users\user\Documents\prolog:/mnt -it mjt128/scryer-prolog
+?- consult('/mnt/program.pl').
+true.
+```
 
 ## Tutorial
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ strings.
 
 ## Installing Scryer Prolog
 
+### Native Install (Unix Only)
+
 First, install the latest stable version of
 [Rust](https://www.rust-lang.org/en-US/install.html) using your
 preferred method. Scryer tends to use features from newer Rust
@@ -125,6 +127,26 @@ $> cargo run [--release]
 
 The optional `--release` flag will perform various optimizations,
 producing a faster executable.
+
+### Docker Install (All Platforms)
+
+To automatically download, install, and run Scryer Prolog via Docker,
+simply run:
+```
+$> docker run -it mthom/scryer-prolog
+```
+
+To be able to load your program files, bind mount your programs folder
+as a Docker volume:
+
+```
+$> docker run -v /home/user/prolog:/mnt -it mthom/scryer-prolog
+?- consult('mnt/program.pl').
+true.
+```
+
+[Docker](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
+is currently the only way to run scryer-prolog on Windows.
 
 ## Tutorial
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ producing a faster executable.
 First, install [Docker](https://docs.docker.com/get-docker/) on Linux,
 Windows, or Mac.
 
-Once Docker is installed, you can automatically download, install, and
-run Scryer Prolog in a single command:
+Once Docker is installed, you can download and run Scryer Prolog with a single
+command:
 ```
 $> docker run -it mjt128/scryer-prolog
 ```


### PR DESCRIPTION
I reran `docker build -t scryer-prolog .` on my Windows laptop and it works just fine!

Now that I think about it, I'm actually surprised that it works because only the compiled scryer-prolog executable is copied to the destination container, without any other files. That must mean that all the Prolog libraries that ship with Scryer Prolog are baked into the executable? I can certainly use them just fine from within Docker, so that must be the case.

The next step is to add the Docker build step to the Travis CI release process somehow, but it's not urgent.