### PR TITLE
ADDED: Encrypted client connections in library(sockets) via new option tls/1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ ripemd160 = "0.8.0"
 sha3 = "0.8.2"
 blake2 = "0.8.1"
 openssl = { version = "0.10.29", features = ["vendored"] }
+native-tls = "0.2.4"

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ The modules that ship with Scryer&nbsp;Prolog are also called
   Probabilistic predicates and random number generators.
 * [`sockets`](src/prolog/lib/sockets.pl)
   Predicates for opening and accepting TCP connections as streams.
+  TLS negotiation is performed via the option `tls(true)` in
+  `socket_client_open/3`, yielding secure encrypted connections.
 * [`crypto`](src/prolog/lib/crypto.pl)
   Cryptographically secure random numbers and hashes, HMAC-based
   key derivation (HKDF), password-based key derivation (PBKDF2),

--- a/src/prolog/clause_types.rs
+++ b/src/prolog/clause_types.rs
@@ -635,7 +635,7 @@ impl SystemClauseType {
             ("$set_seed", 1) => Some(SystemClauseType::SetSeed),
             ("$skip_max_list", 4) => Some(SystemClauseType::SkipMaxList),
             ("$sleep", 1) => Some(SystemClauseType::Sleep),
-            ("$socket_client_open", 7) => Some(SystemClauseType::SocketClientOpen),
+            ("$socket_client_open", 8) => Some(SystemClauseType::SocketClientOpen),
             ("$socket_server_open", 3) => Some(SystemClauseType::SocketServerOpen),
             ("$socket_server_accept", 7) => Some(SystemClauseType::SocketServerAccept),
             ("$socket_server_close", 1) => Some(SystemClauseType::SocketServerClose),

--- a/src/prolog/lib/error.pl
+++ b/src/prolog/lib/error.pl
@@ -27,7 +27,8 @@
 
        - integer
        - atom
-       - list.
+       - list
+       - boolean
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 must_be(Type, Term) :-
@@ -45,12 +46,15 @@ must_be_(integer, Term) :- check_(integer, integer, Term).
 must_be_(atom, Term)    :- check_(atom, atom, Term).
 must_be_(list, Term)    :- check_(ilist, list, Term).
 must_be_(type, Term)    :- check_(type, type, Term).
+must_be_(boolean, Term) :- check_(boolean, boolean, Term).
 
 check_(Pred, Type, Term) :-
         (   var(Term) -> instantiation_error(must_be/2)
         ;   call(Pred, Term) -> true
         ;   type_error(Type, Term, must_be/2)
         ).
+
+boolean(B) :- ( B == true ; B == false ).
 
 ilist(V) :- var(V), instantiation_error(must_be/2).
 ilist([]).
@@ -61,6 +65,7 @@ type(integer).
 type(atom).
 type(list).
 type(var).
+type(boolean).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    can_be(Type, Term)
@@ -86,6 +91,7 @@ can_be(Type, Term) :-
 can_(integer, Term) :- integer(Term).
 can_(atom, Term)    :- atom(Term).
 can_(list, Term)    :- list_or_partial_list(Term).
+can_(boolean, Term) :- boolean(Term).
 
 list_or_partial_list(Var) :- var(Var).
 list_or_partial_list([]).

--- a/src/prolog/lib/sockets.pl
+++ b/src/prolog/lib/sockets.pl
@@ -6,7 +6,16 @@
                     current_hostname/1]).
 
 :- use_module(library(error)).
+:- use_module(library(lists)).
 
+parse_socket_options_(tls(TLS), tls-TLS) :-
+    must_be(boolean, TLS), !.
+parse_socket_options_(Option, OptionPair) :-
+    builtins:parse_stream_options_(Option, OptionPair).
+
+parse_socket_options(Options, OptionValues, Stub) :-
+    DefaultOptions = [alias-[], eof_action-eof_code, reposition-false, tls-false, type-text],
+    builtins:parse_options_list(Options, parse_socket_options_, DefaultOptions, OptionValues, Stub).
 
 socket_client_open(Addr, Stream, Options) :-
     (  var(Addr) ->
@@ -23,10 +32,10 @@ socket_client_open(Addr, Stream, Options) :-
     ;
        throw(error(type_error(socket_address, Addr), socket_client_open/3))
     ),
-    builtins:parse_stream_options(Options,
-                                  [Alias, EOFAction, Reposition, Type],
-                                  socket_client_open/3),
-    '$socket_client_open'(Address, Port, Stream, Alias, EOFAction, Reposition, Type).
+    parse_socket_options(Options,
+                         [Alias, EOFAction, Reposition, TLS, Type],
+                         socket_client_open/3),
+    '$socket_client_open'(Address, Port, Stream, Alias, EOFAction, Reposition, Type, TLS).
 
 
 socket_server_open(Addr, ServerSocket) :-


### PR DESCRIPTION
Use `tls(true)` to negotiate an encrypted network connection via TLS.

This addresses #503.

The changes for supporting TLS seem quite small to me: If a better way to establish TLS client connections is implemented later, it will be easy to remove or adapt them. For now, I think it is good to be able to easily establish encrypted connections.

Example:

<pre>
<b>?- socket_client_open('metalevel.at':443, S, [tls(true)]),
   format(S, "GET / HTTP/1.1\r\nHost: www.metalevel.at\r\n\r\n", []),
   repeat,
   get_char(S, Char),
   write(Char),
   sleep(0.01),
   false.</b>
HTTP/1.1 200 OK
Date: Sun, 07 Jun 2020 21:18:22 GMT
Connection: Keep-Alive
Strict-Transport-Security: max-age=63072000; includeSubdomains
etc.
</pre>

Please review, and merge if applicable. Many thanks!