### PR TITLE
ENHANCED: faster format/3 when writing to binary streams

### DIFF
--- a/src/lib/format.pl
+++ b/src/lib/format.pl
@@ -375,20 +375,9 @@ format(Fs, Args) :-
 format(Stream, Fs, Args) :-
         phrase(format_(Fs, Args), Cs),
         (   stream_property(Stream, type(binary)) ->
-            % maplist(char_code, Cs, Bytes) is currently a lot slower
-            % than first converting Cs to an atom, and then to codes.
-            % In the future, we can ideally avoid creating an atom here,
-            % since an atom leaves traces in the system.
-            atom_chars(A, Cs),
-            atom_codes(A, Bytes),
-            (   member(NonByte, Bytes), NonByte > 255 ->
-                char_code(Char, NonByte),
-                throw(error(representation_error(Char), format/3))
-            ;   true
-            ),
             % For binary streams, we use a specialised internal predicate
             % that uses only a single "write" operation for efficiency.
-            '$put_bytes'(Stream, Bytes)
+            '$put_bytes'(Stream, Cs)
         ;   maplist(put_char(Stream), Cs)
         ).
 

--- a/src/lib/format.pl
+++ b/src/lib/format.pl
@@ -460,7 +460,7 @@ portray_clause(Term) :-
 
 portray_clause(Stream, Term) :-
         phrase(portray_clause_(Term), Ls),
-        maplist(put_char(Stream), Ls).
+        format(Stream, "~s", [Ls]).
 
 portray_clause_(Term) -->
         { term_variables(Term, Vs),


### PR DESCRIPTION
This is also more secure, since it does not change the atom table and therefore leaves little trace of what was processed.

Please review, and merge if applicable. Many thanks!
