### PR TITLE
ADDED: library(sgml), providing load_html/3 to parse HTML documents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ blake2 = "0.8.1"
 openssl = { version = "0.10.29", features = ["vendored"] }
 native-tls = "0.2.4"
 chrono = "0.4.11"
+select = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -422,6 +422,9 @@ The modules that ship with Scryer&nbsp;Prolog are also called
   Probabilistic predicates and random number generators.
 * [`http/http_open`](src/lib/http/http_open.pl) Open a stream to
   read answers from web&nbsp;servers. HTTPS is also supported.
+* [`sgml`](src/lib/sgml.pl)
+  `load_html/3` represents HTML&nbsp;documents as Prolog&nbsp;terms
+  for convenient and efficient reasoning.
 * [`sockets`](src/lib/sockets.pl)
   Predicates for opening and accepting TCP connections as streams.
   TLS negotiation is performed via the option `tls(true)` in

--- a/src/clause_types.rs
+++ b/src/clause_types.rs
@@ -298,7 +298,8 @@ pub enum SystemClauseType {
     Ed25519Sign,
     Ed25519Verify,
     Ed25519NewKeyPair,
-    Ed25519KeyPairPublicKey
+    Ed25519KeyPairPublicKey,
+    LoadHTML
 }
 
 impl SystemClauseType {
@@ -495,7 +496,8 @@ impl SystemClauseType {
             &SystemClauseType::Ed25519Sign => clause_name!("$ed25519_sign"),
             &SystemClauseType::Ed25519Verify => clause_name!("$ed25519_verify"),
             &SystemClauseType::Ed25519NewKeyPair => clause_name!("$ed25519_new_keypair"),
-            &SystemClauseType::Ed25519KeyPairPublicKey => clause_name!("$ed25519_keypair_public_key")
+            &SystemClauseType::Ed25519KeyPairPublicKey => clause_name!("$ed25519_keypair_public_key"),
+            &SystemClauseType::LoadHTML => clause_name!("$load_html"),
         }
     }
 
@@ -673,6 +675,7 @@ impl SystemClauseType {
             ("$ed25519_verify", 3) => Some(SystemClauseType::Ed25519Verify),
             ("$ed25519_new_keypair", 1) => Some(SystemClauseType::Ed25519NewKeyPair),
             ("$ed25519_keypair_public_key", 2) => Some(SystemClauseType::Ed25519KeyPairPublicKey),
+            ("$load_html", 3) => Some(SystemClauseType::LoadHTML),
             _ => None,
         }
     }

--- a/src/lib/sgml.pl
+++ b/src/lib/sgml.pl
@@ -1,0 +1,41 @@
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   Predicates for parsing markup documents.
+   Written June 2020 by Markus Triska (triska@metalevel.at)
+   Part of Scryer Prolog.
+
+   Currently, only a single predicate is provided:
+
+   load_html(+In, -Es, +Options)
+   =============================
+
+   In must be a stream, specified as stream(S), and Es is unified with
+   a list of elements of the form:
+
+   * a list of characters, representing text
+
+   * element(Name, Attrs, Children)
+     - Name is the name of the tag
+     - Attrs is a list of Key=Value pairs:
+       Key is an atom, and Value is a list of characters
+     - Children is a list of elements as specified here.
+
+   Currently, Options are ignored. In the future, more options may be
+   provided to control parsing.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+:- module(sgml, [load_html/3]).
+
+:- use_module(library(iso_ext)).
+:- use_module(library(error)).
+
+load_html(stream(Stream), [E], Options) :-
+        must_be(list, Options),
+        read_to_end(Stream, Cs),
+        '$load_html'(Cs, E, []).
+
+read_to_end(Stream, Cs) :-
+        '$get_n_chars'(Stream, 4096, Cs0),
+        (   Cs0 = [] -> Cs = []
+        ;   partial_string(Cs0, Cs, Rest),
+            read_to_end(Stream, Rest)
+        ).


### PR DESCRIPTION
We are now getting close to convenient reasoning about HTML files.

This library can be nicely used in tandem with `http_open/3` (see #592 ) to read an HTML file from a stream.

Please review, and merge if applicable. Thank you a lot!