### PR TITLE
ENHANCED: much faster format/3 for text streams

### DIFF
--- a/src/clause_types.rs
+++ b/src/clause_types.rs
@@ -229,8 +229,8 @@ pub enum SystemClauseType {
     PeekCode,
     PointsToContinuationResetMarker,
     PutByte,
-    PutBytes,
     PutChar,
+    PutChars,
     PutCode,
     REPL(REPLCodePtr),
     ReadQueryTerm,
@@ -419,11 +419,11 @@ impl SystemClauseType {
             &SystemClauseType::PutByte => {
                 clause_name!("$put_byte")
             }
-            &SystemClauseType::PutBytes => {
-                clause_name!("$put_bytes")
-            }
             &SystemClauseType::PutChar => {
                 clause_name!("$put_char")
+            }
+            &SystemClauseType::PutChars => {
+                clause_name!("$put_chars")
             }
             &SystemClauseType::PutCode => {
                 clause_name!("$put_code")
@@ -560,11 +560,11 @@ impl SystemClauseType {
             ("$put_byte", 2) => {
                 Some(SystemClauseType::PutByte)
             }
-            ("$put_bytes", 2) => {
-                Some(SystemClauseType::PutBytes)
-            }
             ("$put_char", 2) => {
                 Some(SystemClauseType::PutChar)
+            }
+            ("$put_chars", 2) => {
+                Some(SystemClauseType::PutChars)
             }
             ("$put_code", 2) => {
                 Some(SystemClauseType::PutCode)

--- a/src/lib/format.pl
+++ b/src/lib/format.pl
@@ -3,7 +3,7 @@
    Part of Scryer Prolog.
 
    This library provides the nonterminal format_//2 to describe
-   formatted strings. format/2 is provided for impure output.
+   formatted strings. format/[2,3] are provided for impure output.
 
    Usage:
    ======
@@ -369,17 +369,15 @@ digits(uppercase, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ").
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 format(Fs, Args) :-
-        phrase(format_(Fs, Args), Cs),
-        maplist(write, Cs).
+        current_output(Stream),
+        format(Stream, Fs, Args).
 
 format(Stream, Fs, Args) :-
         phrase(format_(Fs, Args), Cs),
-        (   stream_property(Stream, type(binary)) ->
-            % For binary streams, we use a specialised internal predicate
-            % that uses only a single "write" operation for efficiency.
-            '$put_bytes'(Stream, Cs)
-        ;   maplist(put_char(Stream), Cs)
-        ).
+        % we use a specialised internal predicate that uses only a
+        % single "write" operation for efficiency. It is equivalent to
+        % maplist(put_char(Stream), Cs). It also works for binary streams.
+        '$put_chars'(Stream, Cs).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ?- phrase(cells("hello", [], 0, []), Cs).


### PR DESCRIPTION
This is now also used by `format/2` to emit output on the terminal, and significantly speeds up toplevel output of long strings.

Please review, and merge if applicable. Thank you a lot!