### PR TITLE
put_char/[1,2]: throw type errors for atoms that are not characters

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -1905,7 +1905,6 @@ impl MachineState {
                                         }
                                     }
                                     _ => {
-                                        unreachable!()
                                     }
                                 }
                             }


### PR DESCRIPTION
Example:

    ?- put_char(hello).
    %@ caught: error(type_error(character,hello),put_char/2)

Please review, and merge if applicable. Thank you a lot!