### PR TITLE
ENHANCED: flush output for impure I/O (format/[2,3], portray_clause/1 etc.)

### DIFF
--- a/src/lib/format.pl
+++ b/src/lib/format.pl
@@ -377,7 +377,8 @@ format(Stream, Fs, Args) :-
         % we use a specialised internal predicate that uses only a
         % single "write" operation for efficiency. It is equivalent to
         % maplist(put_char(Stream), Cs). It also works for binary streams.
-        '$put_chars'(Stream, Cs).
+        '$put_chars'(Stream, Cs),
+        flush_output(Stream).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ?- phrase(cells("hello", [], 0, []), Cs).


### PR DESCRIPTION
Without this, we do not get a (timely) prompt in cases like:

    ?- format("press a key: ", []), get_single_char(C).

whereas for example write/1 already works in such cases:

    ?- write('press a key: '), get_single_char(C).
    press a key: