### PR TITLE
omit internal attributes in residual goals when using taut/2

### DIFF
--- a/src/lib/clpb.pl
+++ b/src/lib/clpb.pl
@@ -1558,9 +1558,10 @@ sats([]) --> [].
 sats([A|As]) --> [clpb:sat(A)], sats(As).
 
 booleans([]) --> [].
-booleans([B|Bs]) --> boolean(B), { del_clpb(B) }, booleans(Bs).
+booleans([B|Bs]) --> boolean(B), booleans(Bs).
 
 boolean(Var) -->
+        { del_clpb(Var) },
         (   { get_attr(Var, clpb_omit_boolean, true) } -> []
         ;   [clpb:sat(Var =:= Var)]
         ).


### PR DESCRIPTION
Examples:

    ?- taut(X=:=X,1).
       clpb:sat(X=:=X)
    ;  false.

    ?- taut(X=\=X,0).
       clpb:sat(X=:=X)
    ;  false.