### PR TITLE
FIXED: reliably write all characters when using format/3

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -2137,7 +2137,7 @@ impl MachineState {
                     bytes = string.into_bytes();
                 }
 
-                match stream.write(&bytes) {
+                match stream.write_all(&bytes) {
                     Ok(_) => {
                         return return_from_clause!(self.last_call, self);
                     }


### PR DESCRIPTION
This addresses #693.

Many thanks to @notoria for a brilliant test case, and the
suggestion of this correction!