### PR TITLE
Add list_max & list_min to lists module

### DIFF
--- a/src/lib/lists.pl
+++ b/src/lib/lists.pl
@@ -2,7 +2,7 @@
 		  memberchk/2, reverse/2, length/2, maplist/2,
 		  maplist/3, maplist/4, maplist/5, maplist/6,
 		  maplist/7, maplist/8, maplist/9, same_length/2, nth0/3,
-		  sum_list/2, transpose/2, list_to_set/2]).
+		  sum_list/2, transpose/2, list_to_set/2, max_list/2, min_list/2]).
 
 
 :- use_module(library(error)).
@@ -200,3 +200,14 @@ nth0_search(N, N, [E|_], E).
 nth0_search(N0, N, [_|Es], E) :-
         N1 is N0 + 1,
         nth0_search(N1, N, Es, E).
+
+
+max_list([Max], Max).
+max_list([N|Ns], Max) :-
+    max_list(Ns, Maxs),!,
+    Max is max(N, Maxs).
+
+min_list([Min], Min).
+min_list([N|Ns], Min) :-
+    min_list(Ns, Mins),!,
+    Min is min(N, Mins).

--- a/src/lib/lists.pl
+++ b/src/lib/lists.pl
@@ -202,12 +202,15 @@ nth0_search(N0, N, [_|Es], E) :-
         nth0_search(N1, N, Es, E).
 
 
-max_list([Max], Max).
 max_list([N|Ns], Max) :-
-    max_list(Ns, Maxs),!,
-    Max is max(N, Maxs).
+    foldl(max_list_, Ns, N, Max).
 
-min_list([Min], Min).
+max_list_(N, Max0, Max) :-
+    Max is max(N, Max0).
+
 min_list([N|Ns], Min) :-
-    min_list(Ns, Mins),!,
-    Min is min(N, Mins).
+    foldl(min_list_, Ns, N, Min).
+
+min_list_(N, Min0, Min) :-
+    Min is min(N, Min0).
+

--- a/src/lib/lists.pl
+++ b/src/lib/lists.pl
@@ -2,7 +2,7 @@
 		  memberchk/2, reverse/2, length/2, maplist/2,
 		  maplist/3, maplist/4, maplist/5, maplist/6,
 		  maplist/7, maplist/8, maplist/9, same_length/2, nth0/3,
-		  sum_list/2, transpose/2, list_to_set/2, max_list/2, min_list/2]).
+		  sum_list/2, transpose/2, list_to_set/2, list_max/2, list_min/2]).
 
 
 :- use_module(library(error)).
@@ -202,15 +202,14 @@ nth0_search(N0, N, [_|Es], E) :-
         nth0_search(N1, N, Es, E).
 
 
-max_list([N|Ns], Max) :-
-    foldl(max_list_, Ns, N, Max).
+list_max([N|Ns], Max) :-
+    foldl(list_max_, Ns, N, Max).
 
-max_list_(N, Max0, Max) :-
+list_max_(N, Max0, Max) :-
     Max is max(N, Max0).
 
-min_list([N|Ns], Min) :-
-    foldl(min_list_, Ns, N, Min).
+list_min([N|Ns], Min) :-
+    foldl(list_min_, Ns, N, Min).
 
-min_list_(N, Min0, Min) :-
+list_min_(N, Min0, Min) :-
     Min is min(N, Min0).
-


### PR DESCRIPTION
I was doing Advent of Code in Prolog and while SWI and Tau define max_list and min_list, I found with a surprise that Scryer doesn't. They're very easy to implement by oneself and I don't know if it is the most efficient way, but I think it is useful to have them in the standard library.