### PR TITLE
Add statistics/2 (cputime and inferences)

### DIFF
--- a/src/clause_types.rs
+++ b/src/clause_types.rs
@@ -274,6 +274,7 @@ pub enum SystemClauseType {
     InstallNewBlock,
     Maybe,
     CpuNow,
+    Inferences,
     CurrentTime,
     QuotedToken,
     ReadTermFromChars,
@@ -429,6 +430,7 @@ impl SystemClauseType {
             &SystemClauseType::LiftedHeapLength => clause_name!("$lh_length"),
             &SystemClauseType::Maybe => clause_name!("maybe"),
             &SystemClauseType::CpuNow => clause_name!("$cpu_now"),
+            &SystemClauseType::Inferences => clause_name!("$inferences"),
             &SystemClauseType::CurrentTime => clause_name!("$current_time"),
             &SystemClauseType::ModuleAssertDynamicPredicateToFront => {
                 clause_name!("$module_asserta")
@@ -628,6 +630,7 @@ impl SystemClauseType {
             ("$lh_length", 1) => Some(SystemClauseType::LiftedHeapLength),
             ("$maybe", 0) => Some(SystemClauseType::Maybe),
             ("$cpu_now", 1) => Some(SystemClauseType::CpuNow),
+            ("$inferences", 1) => Some(SystemClauseType::Inferences),
             ("$current_time", 1) => Some(SystemClauseType::CurrentTime),
             ("$module_exists", 1) => Some(SystemClauseType::ModuleExists),
             ("$module_of", 2) => Some(SystemClauseType::ModuleOf),

--- a/src/lib/statistics.pl
+++ b/src/lib/statistics.pl
@@ -1,0 +1,9 @@
+:- module(statistics, [
+    statistics/2
+]).
+
+statistics(cputime, T) :-
+    '$cpu_now'(T).
+
+statistics(inferences, I) :-
+    '$inferences'(I).

--- a/src/lib/time.pl
+++ b/src/lib/time.pl
@@ -49,6 +49,7 @@
 :- use_module(library(error)).
 :- use_module(library(dcgs)).
 :- use_module(library(lists)).
+:- use_module(library(statistics)).
 :- use_module(library(charsio), [read_term_from_chars/2]).
 
 current_time(T) :-
@@ -80,10 +81,8 @@ sleep(T) :-
     ).
 
 
-% '$cpu_now' can be replaced by statistics/2 once that is implemented.
-
 time(Goal) :-
-        '$cpu_now'(T0),
+        statistics(cputime, T0),
         setup_call_cleanup(true,
                            (   Goal,
                                report_time(T0)
@@ -91,7 +90,7 @@ time(Goal) :-
                            report_time(T0)).
 
 report_time(T0) :-
-        '$cpu_now'(T),
+        statistics(cputime, T),
         Time is T - T0,
         (   bb_get('$first_answer', true) ->
             format("   % CPU time: ~3f seconds~n", [Time])

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -609,7 +609,8 @@ pub struct MachineState {
     pub(super) last_call: bool,
     pub(crate) heap_locs: HeapVarDict,
     pub(crate) flags: MachineFlags,
-    pub(crate) at_end_of_expansion: bool
+    pub(crate) at_end_of_expansion: bool,
+    pub(crate) inferences: Integer,
 }
 
 impl MachineState {

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -1220,6 +1220,8 @@ pub(crate) trait CallPolicy: Any + fmt::Debug {
             }
         }
 
+        machine_st.inferences += 1;
+
         Ok(())
     }
 
@@ -1249,6 +1251,8 @@ pub(crate) trait CallPolicy: Any + fmt::Debug {
                 machine_st.execute_at_index(arity, LocalCodePtr::InSituDirEntry(p));
             }
         }
+
+        machine_st.inferences += 1;
 
         Ok(())
     }

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -63,7 +63,8 @@ impl MachineState {
             last_call: false,
             heap_locs: HeapVarDict::new(),
             flags: MachineFlags::default(),
-            at_end_of_expansion: false
+            at_end_of_expansion: false,
+            inferences: Integer::from(0),
         }
     }
 
@@ -93,7 +94,8 @@ impl MachineState {
             last_call: false,
             heap_locs: HeapVarDict::new(),
             flags: MachineFlags::default(),
-            at_end_of_expansion: false
+            at_end_of_expansion: false,
+            inferences: Integer::from(0),
         }
     }
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -868,6 +868,7 @@ impl MachineState {
         current_input_stream: &mut Stream,
         current_output_stream: &mut Stream,
     ) {
+        self.inferences += 1;
         match instr {
             &Line::Arithmetic(ref arith_instr) => {
                 self.execute_arith_instr(arith_instr)

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -868,7 +868,6 @@ impl MachineState {
         current_input_stream: &mut Stream,
         current_output_stream: &mut Stream,
     ) {
-        self.inferences += 1;
         match instr {
             &Line::Arithmetic(ref arith_instr) => {
                 self.execute_arith_instr(arith_instr)

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -3392,6 +3392,12 @@ impl MachineState {
 
                 self.unify(a1, addr);
             }
+            &SystemClauseType::Inferences => {
+                let a1 = self[temp_v!(1)];
+                let addr = self.heap.put_constant(Constant::Integer(Rc::new(self.inferences.clone())));
+
+                self.unify(a1, addr);
+            }
             &SystemClauseType::CurrentTime => {
                 let str = self.systemtime_to_timestamp(SystemTime::now());
                 self.unify(self[temp_v!(1)], str);


### PR DESCRIPTION
I'm not very sure that I'm counting inferences in the right place (I'm a noob in WAM things). I've seen that CallPolicy has an inference counter also, but it is designed to count only if it has been configured first.