### PR TITLE
WIP: Use term expansion for generated predicates.

### DIFF
--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -7763,11 +7763,10 @@ zo_t(1, true).
    Generated predicates
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-generated_clauses(Cs) :-
-        make_parse_clpz(Cs1),
-        make_parse_reified(Cs2),
-        make_matches(Cs3),
-        append([Cs1,Cs2,Cs3], Cs).
+term_expansion(make_parse_clpz, Clauses)    :- make_parse_clpz(Clauses).
+term_expansion(make_parse_reified, Clauses) :- make_parse_reified(Clauses).
+term_expansion(make_matches, Clauses)       :- make_matches(Clauses).
 
-:- initialization((generated_clauses(Cs),
-                   maplist(assertz, Cs))).
+make_parse_clpz.
+make_parse_reified.
+make_matches.


### PR DESCRIPTION
In this branch, I am trying to use `term_expansion/2` to enhance compilation speed of `library(clpz)`.

Indeed, the change improves the compilation speed. However, I get for example:

<pre>
<b>    ?- X #\= 3.</b>
    false.
</pre>

So, something does not work correctly yet. I would greatly appreciate any feedback and help with this. Does it work with the latest development prototype?