### PR TITLE
HTTP Server: urlencoded forms and some syntax improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11.0]
+        os: [ubuntu-20.04, macos-10.15]
         rust-version: [stable, beta]
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Adds support for application/x-www-form-urlencoded forms (the default in HTML if there are no files) and tries to address some syntax issues discussed here: https://github.com/mthom/scryer-prolog/issues/763

Tests have been updated: https://github.com/aarroyoc/scryer-http-test/commit/45c86f2621c343e90f20338ddc75b19d17d11940