### PR TITLE
Add epsilon/0 arithmetic constant

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -290,6 +290,12 @@ impl<'a> ArithmeticEvaluator<'a> {
                         f64::consts::PI,
                     ))))
             }
+            &Constant::Atom(ref name, _) if name.as_str() == "epsilon" => {
+                self.interm
+                    .push(ArithmeticTerm::Number(Number::Float(OrderedFloat(
+                        f64::EPSILON,
+                    ))))
+            }
             _ => return Err(ArithmeticError::NonEvaluableFunctor(c.clone(), 0)),
         }
 

--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -227,6 +227,9 @@ impl MachineState {
                 &HeapCellValue::Atom(ref name, _) if name.as_str() == "e" => {
                     interms.push(Number::Float(OrderedFloat(f64::consts::E)))
                 }
+                &HeapCellValue::Atom(ref name, _) if name.as_str() == "epsilon" => {
+                    interms.push(Number::Float(OrderedFloat(f64::EPSILON)))
+                }
                 &HeapCellValue::NamedStr(arity, ref name, _) => {
                     let evaluable_stub = MachineError::functor_stub(name.clone(), arity);
 


### PR DESCRIPTION
This constant is used e.g. in Logtalk `lgtunit` tool for approximate float comparison when defining tests. It's also a de facto standard constant implemented by e.g. B-Prolog, CxProlog, GNU Prolog, LVM, SWI-Prolog, YAP, XSB, Tau Prolog, and Trealla Prolog.