### PR TITLE
Fix char_code/2 predicate failure instead of exception on non-integer second argument

### DIFF
--- a/src/lib/builtins.pl
+++ b/src/lib/builtins.pl
@@ -1293,7 +1293,12 @@ char_code(Char, Code) :-
        ;  throw(error(type_error(integer, Code), char_code/2))
        )
     ;  atom_length(Char, 1) ->
-       '$char_code'(Char, Code)
+       (  var(Code) ->
+          '$char_code'(Char, Code)
+       ;  integer(Code) ->
+          '$char_code'(Char, Code)
+       ;  throw(error(type_error(integer, Code), char_code/2))
+       )
     ;  throw(error(type_error(character, Char), char_code/2))
     ).
 


### PR DESCRIPTION
With this pull request, a goal such as `char_code(a,x)` will throw the expected `type_error(integer,x)` error instead of failing. With this fix, all `logtalk3/tests/prolog/predicates/char_code_2` tests pass.