### PR TITLE
Fix char_code/2 predicate wrong error term when the first argument is bound but is not an atom

### DIFF
--- a/src/lib/builtins.pl
+++ b/src/lib/builtins.pl
@@ -1296,6 +1296,8 @@ char_code(Char, Code) :-
           '$char_code'(Char, Code)
        ;  throw(error(type_error(integer, Code), char_code/2))
        )
+    ;  \+ atom(Char) ->
+       throw(error(type_error(character, Char), char_code/2))
     ;  atom_length(Char, 1) ->
        (  var(Code) ->
           '$char_code'(Char, Code)


### PR DESCRIPTION
Also updated the Logtalk git version with a new test for detecting this compliance bug.