### PR TITLE
Fixes for retract predicates

### DIFF
--- a/src/lib/builtins.pl
+++ b/src/lib/builtins.pl
@@ -1016,7 +1016,7 @@ retract(Clause) :-
 :- meta_predicate retractall(0).
 
 retractall(Head) :-
-   retract((Head :- _)),
+   retract_clause(Head, _),
    false.
 retractall(_).
 

--- a/src/lib/builtins.pl
+++ b/src/lib/builtins.pl
@@ -985,13 +985,8 @@ retract_clause(Head, Body) :-
        (  Name == (:),
           Arity =:= 2 ->
           arg(1, Head, Module),
-          arg(2, Head, HeadAndBody),
-          (  HeadAndBody = (F :- Body1) ->
-             true
-          ;  F = HeadAndBody,
-             Body1 = true
-          ),
-          retract_module_clause(F, Body1, Module)
+          arg(2, Head, Head1),
+          retract_module_clause(Head1, Body, Module)
        ;  '$no_such_predicate'(user, Head) ->
           '$fail'
        ;  '$head_is_dynamic'(user, Head) ->


### PR DESCRIPTION
This pull requests fixes the `retractall/1` predicate to retract both facts and rules. All Logtalk compliance tests now pass.

This pull request also fixes some of the bugs with `retract/1` when retracting rules. But there are still seven compliance bugs that need fixing (run the Logtalk compliance tests for the predicate for details).