### PR TITLE
check for correct domain of integers in reifiable expressions also in the expanded code

### DIFF
--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -2982,7 +2982,7 @@ clpz_expansion(A #<==> B, Reif) :-
         phrase(expr_conds(Y0, Y), Cs),
         list_goal(Cs0, Cond),
         Expr =.. [F,X,Y],
-        expansion_simpler(( Cond, ( var(B) ; integer(B) ) ->
+        expansion_simpler(( Cond, ( var(B) ; integer(B), clpz:between(0, 1, B) ) ->
                             (   Expr ->
                                 B = 1
                             ;   B = 0


### PR DESCRIPTION
This is to preserve domain errors instead of failing silently. Example:

    ?- 5 #> 3 #<==> 2.
    %@ caught: error(domain_error(clpz_reifiable_expression,2),unknown(2)-1)