### PR TITLE
ADDED: ... //0, describing an arbitrary number of elements

### DIFF
--- a/src/lib/dcgs.pl
+++ b/src/lib/dcgs.pl
@@ -3,7 +3,9 @@
 		   phrase/2,
 		   phrase/3,
                    seq//1,
-                   seqq//1]).
+                   seqq//1,
+                   ... //0
+           ]).
 
 :- use_module(library(error)).
 :- use_module(library(lists), [append/3]).
@@ -188,3 +190,6 @@ seq([E|Es]) --> [E], seq(Es).
 % Describes a sequence of sequences
 seqq([]) --> [].
 seqq([Es|Ess]) --> seq(Es), seqq(Ess).
+
+% Describes an arbitrary number of elements
+... --> [] | [_], ... .


### PR DESCRIPTION
I propose to add **`... //0`** to `library(dcgs)` so that it is more readily available.

This is a very versatile nonterminal. For instance, repeated elements in a list can be described like this:

<pre>
<b>?- phrase((...,[E],...,[E],...), "hello!!").</b>
%@    E = l
%@ ;  E = !
%@ ;  false.
</pre>

Many beginners will benefit from this nonterminal, especially when defining predicates that involve lists. For instance, the last element of a list can be described like this:

<pre>
<b>?- phrase((...,[L]), "abc").</b>
%@    L = c
%@ ;  false.
</pre>

Are there any opinions on this? Feedback is highly welcome!