### PR TITLE
ENHANCED: format_string domain error for invalid radix in format string

### DIFF
--- a/src/lib/format.pl
+++ b/src/lib/format.pl
@@ -344,12 +344,16 @@ pow10(D, N0-Pow0, N-Pow) :-
         N is N0 + D*10^Pow0,
         Pow is Pow0 + 1.
 
+radix_error(lowercase, R) --> format_("~~~dr", [R]).
+radix_error(uppercase, R) --> format_("~~~dR", [R]).
+
 integer_to_radix(I0, R, Which, Cs) :-
         I is I0, % evaluate compound expression
         must_be(integer, I),
         must_be(integer, R),
         (   \+ between(2, 36, R) ->
-            domain_error(radix, R, format_//2)
+            phrase(radix_error(Which,R), Es),
+            domain_error(format_string, Es, format_//2)
         ;   true
         ),
         digits(Which, Ds),


### PR DESCRIPTION
This addresses #1024.

Example:

    ?- format("hello ~0r!", [12]).
    %@ caught: error(domain_error(format_string,"~0r"),format_//2)