### PR TITLE
Fix #1009 by providing a naive num-bigint implementation of count_ones

### DIFF
--- a/crates/num-rug-adapter/src/lib.rs
+++ b/crates/num-rug-adapter/src/lib.rs
@@ -117,6 +117,10 @@ impl Integer {
     pub fn gcd(&self, other: &Self) -> Self {
         Integer(num_integer::Integer::gcd(&self.0, &other.0))
     }
+
+    pub fn count_ones(&self) -> Option<u32> {
+        Some(self.0.to_u32_digits().1.iter().map(|&d| d.count_ones()).sum())
+    }
 }
 
 impl From<&Integer> for Integer {

--- a/crates/num-rug-adapter/src/lib.rs
+++ b/crates/num-rug-adapter/src/lib.rs
@@ -118,6 +118,7 @@ impl Integer {
         Integer(num_integer::Integer::gcd(&self.0, &other.0))
     }
 
+    #[inline]
     pub fn count_ones(&self) -> Option<u32> {
         Some(self.0.to_u32_digits().1.iter().map(|&d| d.count_ones()).sum())
     }


### PR DESCRIPTION
Solves https://github.com/mthom/scryer-prolog/issues/1009 and allows compiling again with the num feature