### PR TITLE
Add preliminary current_module/1 predicate definition requiring a bound argument

### DIFF
--- a/src/loader.pl
+++ b/src/loader.pl
@@ -8,7 +8,8 @@
                    prolog_load_context/2,
                    strip_module/3,
                    use_module/1,
-                   use_module/2
+                   use_module/2,
+                   current_module/1
                   ]).
 
 
@@ -463,6 +464,14 @@ use_module(Module, Exports) :-
     (  Exports == [] ->
        remove_module(Module, Evacuable)
     ;  use_module(Module, Exports, Evacuable)
+    ).
+
+current_module(Module) :-
+    (  var(Module) ->
+       instantiation_error(current_module/1)
+    ;  \+ atom(Module) ->
+       type_error(atom, Module, current_module/1)
+    ;  '$module_exists'(Module)
     ).
 
 


### PR DESCRIPTION
Sample calls:

```text
$ scryer-prolog
?- use_module(library(lists)).
   true.
?- current_module(lists).
   true.
?- current_module(foobar).
false.
```

The current definition of the `'$module_exists'/1` internal predicate should eventually be updated to allow enumerating loaded modules by backtracking. When that is done, the definition of the `current_module/1` predicate in this pull request should be updated to:

```logtalk
current_module(Module) :-
    (  nonvar(Module), \+ atom(Module) ->
       type_error(atom, Module, current_module/1)
    ;  '$module_exists'(Module)
    ).
```

Still, this pull request allows using Logtalk's `lgtunit` to test module code without requiring turning off important linter warnings as discussed in #896.