### PR TITLE
Throw exception if closing a closed TCP stream #1046

### DIFF
--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -164,10 +164,10 @@ impl Drop for StreamInstance {
     fn drop(&mut self) {
         match self {
             StreamInstance::TcpStream(_, ref mut tcp_stream) => {
-                tcp_stream.shutdown(Shutdown::Both).unwrap();
+                tcp_stream.shutdown(Shutdown::Both).unwrap_or(())
             }
             StreamInstance::TlsStream(_, ref mut tls_stream) => {
-                tls_stream.shutdown().unwrap();
+                tls_stream.shutdown().unwrap_or(());
             }
             _ => {}
         }
@@ -633,6 +633,20 @@ impl Stream {
             | StreamInstance::Bytes(_)
             | StreamInstance::OutputFile(..) => true,
             _ => false,
+        }
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        match self.stream_inst.0.borrow_mut().stream_inst {
+            StreamInstance::Null => true,
+            StreamInstance::TcpStream(_, ref mut tcp_stream) => {
+                let mut buf = [0;8];
+                match tcp_stream.peek(&mut buf) {
+                    Ok(n_bytes) => n_bytes == 0,
+                    Err(_) => true
+                }
+            },
+            _ => false
         }
     }
 

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -2704,10 +2704,29 @@ impl MachineState {
                 }
 
                 if !stream.is_stdin() && !stream.is_stdout() && !stream.is_stderr() {
-                    stream.close();
+                    if stream.is_closed() {
+                        let stub = MachineError::functor_stub(
+                            clause_name!("close"),
+                            1,
+                        );
 
-                    if let Some(ref alias) = stream.options().alias {
-                        indices.stream_aliases.remove(alias);
+                        let addr = self.heap.to_unifiable(
+                            HeapCellValue::Stream(stream.clone()),
+                        );
+
+                        return Err(self.error_form(
+                            MachineError::existence_error(
+                                self.heap.h(),
+                                ExistenceError::Stream(addr),
+                            ),
+                            stub,
+                        ));
+                    } else {
+                        stream.close();
+
+                        if let Some(ref alias) = stream.options().alias {
+                            indices.stream_aliases.remove(alias);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It does two things:
- Disables panics if we're closing a closed TCP stream in Rust code
- Check that the stream called in `close/1` is not closed, otherwise, throws an exception.

Seems to fix #1046 on my tests