### PR TITLE
Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "scryer-prolog"
 version = "0.8.128"
 authors = ["Mark Thom <markjordanthom@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A modern Prolog implementation written mostly in Rust."
 readme = "README.md"
 repository = "https://github.com/mthom/scryer-prolog"

--- a/crates/num-rug-adapter/Cargo.toml
+++ b/crates/num-rug-adapter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "num-rug-adapter"
 version = "0.1.5"
 authors = ["Marco A L Barbosa <malbarbo@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "An adapter to use num crate where rug is needed."
 license = "MIT/Apache-2.0"
 repository = "https://github.com/malbarbo/num-rug-adapter"

--- a/crates/prolog_parser/Cargo.toml
+++ b/crates/prolog_parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prolog_parser"
 version = "0.8.68"
 authors = ["Mark Thom <markjordanthom@gmail.com>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/mthom/scryer-prolog"
 description = " An operator precedence parser for the Rebis development version of Scryer Prolog, an up and coming ISO Prolog implementation."
 license = "BSD-3-Clause"


### PR DESCRIPTION
Apparently, running `cargo fix --edition` did not change anything in the source files