### PR TITLE
Fix the format/2-3 predicates missing the numbervars(true) option in the ~w and ~q formats

### DIFF
--- a/src/lib/format.pl
+++ b/src/lib/format.pl
@@ -165,10 +165,10 @@ cells([], Args, Tab, Es, _) --> !,
 cells([~,~|Fs], Args, Tab, Es, VNs) --> !,
         cells(Fs, Args, Tab, [chars("~")|Es], VNs).
 cells([~,w|Fs], [Arg|Args], Tab, Es, VNs) --> !,
-        { write_term_to_chars(Arg, [variable_names(VNs)], Chars) },
+        { write_term_to_chars(Arg, [numbervars(true),variable_names(VNs)], Chars) },
         cells(Fs, Args, Tab, [chars(Chars)|Es], VNs).
 cells([~,q|Fs], [Arg|Args], Tab, Es, VNs) --> !,
-        { write_term_to_chars(Arg, [quoted(true),variable_names(VNs)], Chars) },
+        { write_term_to_chars(Arg, [quoted(true),numbervars(true),variable_names(VNs)], Chars) },
         cells(Fs, Args, Tab, [chars(Chars)|Es], VNs).
 cells([~,a|Fs], [Arg|Args], Tab, Es, VNs) --> !,
         { atom_chars(Arg, Chars) },


### PR DESCRIPTION
With this fix:

```text
?- use_module(library(terms)).
   true.
?- use_module(library(format)).
   true.
?- T = a(A,B,A), numbervars(T, 0, _), format("~w", [T]), nl.
a(A,B,A)
   T = a('$VAR'(0),'$VAR'(1),'$VAR'(0)), A = '$VAR'(0), B = '$VAR'(1).
?- T = a(A,B,A), numbervars(T, 0, _), format("~q", [T]), nl.
a(A,B,A)
   T = a('$VAR'(0),'$VAR'(1),'$VAR'(0)), A = '$VAR'(0), B = '$VAR'(1).
```

Fixes #1081.