### PR TITLE
pass -f to scryer-prolog in cargo test so that we ignore .scryerrc

### DIFF
--- a/tests/scryer/helper.rs
+++ b/tests/scryer/helper.rs
@@ -77,6 +77,7 @@ pub fn run_top_level_test_with_args<
 ) {
     Command::cargo_bin(SCRYER_PROLOG)
         .unwrap()
+        .arg("-f")
         .args(args)
         .write_stdin(stdin)
         .assert()


### PR DESCRIPTION
fixes issue #1085