### PR TITLE
Prevents panic in some strange cases. Seen in #721

### DIFF
--- a/crates/prolog_parser/src/parser.rs
+++ b/crates/prolog_parser/src/parser.rs
@@ -481,6 +481,10 @@ impl<'a, R: Read> Parser<'a, R> {
             return false;
         }
 
+        if self.terms.len() < 1 + arity {
+            return false;
+        }
+
         let stack_len = self.stack.len() - 2 * arity - 1;
         let idx = self.terms.len() - arity;
 
@@ -637,6 +641,13 @@ impl<'a, R: Read> Parser<'a, R> {
 
             term
         };
+
+        if arity > self.terms.len() {
+            return Err(ParserError::IncompleteReduction(
+                self.lexer.line_num,
+                self.lexer.col_num
+            ))
+        }
 
         let idx = self.terms.len() - arity;
 


### PR DESCRIPTION
I've tried to fix https://github.com/mthom/scryer-prolog/issues/721

Now, it doesn't panic in the examples in the issue but I do not know if this is the right fix or there's something flawed inside that needs to be changed so these checks aren't neccesary.