### PR TITLE
Meta predicate corrections

### DIFF
--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -77,7 +77,7 @@ i_memberd_t([X|Xs], E, T) :-
 tmember(P_2, [X|Xs]) :-
    if_( call(P_2, X), true, tmember(P_2, Xs) ).
 
-:- meta_predicate tmember_t(1, ?).
+:- meta_predicate(tmember_t(2, ?, ?)).
 
 tmember_t(P_2, [X|Xs], T) :-
    if_( call(P_2, X), T = true, tmember_t(P_2, Xs, T) ).

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -28,7 +28,7 @@ dif(X, Y, T) :-
 non(true, false).
 non(false, true).
 
-:- meta_predicate tfilter(2, ?, ?).
+:- meta_predicate(tfilter(2, ?, ?)).
 
 tfilter(C_2, Es, Fs) :-
    i_tfilter(Es, C_2, Fs).

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -72,7 +72,7 @@ i_memberd_t([], _, false).
 i_memberd_t([X|Xs], E, T) :-
    if_( X = E, T = true, i_memberd_t(Xs, E, T) ).
 
-:- meta_predicate tmember(1, ?).
+:- meta_predicate(tmember(2, ?)).
 
 tmember(P_2, [X|Xs]) :-
    if_( call(P_2, X), true, tmember(P_2, Xs) ).

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -60,7 +60,7 @@ i_tpartition([X|Xs], P_2, Ts0, Fs0) :-
 ';'(A_1, B_1, T) :-
     if_(A_1, T = true, call(B_1, T)).
 
-:- meta_predicate cond_t(0, 0, ?).
+:- meta_predicate(cond_t(1, 0, ?)).
 
 cond_t(If_1, Then_0, T) :-
    if_(If_1, ( Then_0, T = true ), T = false ).

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -38,7 +38,7 @@ i_tfilter([E|Es], C_2, Fs0) :-
    if_(call(C_2, E), Fs0 = [E|Fs], Fs0 = Fs),
    i_tfilter(Es, C_2, Fs).
 
-:- meta_predicate tpartition(1, ?, ?).
+:- meta_predicate(tpartition(2, ?, ?, ?)).
 
 tpartition(P_2, Xs, Ts, Fs) :-
    i_tpartition(Xs, P_2, Ts, Fs).

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -28,7 +28,7 @@ dif(X, Y, T) :-
 non(true, false).
 non(false, true).
 
-:- meta_predicate tfilter(1, ?, ?).
+:- meta_predicate tfilter(2, ?, ?).
 
 tfilter(C_2, Es, Fs) :-
    i_tfilter(Es, C_2, Fs).

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -4,7 +4,7 @@
 
 :- use_module(library(dif)).
 
-:- meta_predicate if_(1, 0, 0).
+:- meta_predicate(if_(1, 0, 0)).
 
 if_(If_1, Then_0, Else_0) :-
     call(If_1, T),
@@ -50,12 +50,12 @@ i_tpartition([X|Xs], P_2, Ts0, Fs0) :-
       , ( Fs0 = [X|Fs], Ts0 = Ts ) ),
    i_tpartition(Xs, P_2, Ts, Fs).
 
-:- meta_predicate ','(0, 0, ?).
+:- meta_predicate(','(1, 1, ?)).
 
 ','(A_1, B_1, T) :-
     if_(A_1, call(B_1, T), T = false).
 
-:- meta_predicate ';'(0, 0, ?).
+:- meta_predicate(';'(1, 1, ?)).
 
 ';'(A_1, B_1, T) :-
     if_(A_1, T = true, call(B_1, T)).


### PR DESCRIPTION
This corrects a few arguments, and consistently uses round brackets in `meta_predicate/1` declarations because `meta_predicate` is not a standard operator.