### PR TITLE
Use newly available seq//1 and ... //0 in several libraries

### DIFF
--- a/src/lib/http/http_open.pl
+++ b/src/lib/http/http_open.pl
@@ -33,7 +33,7 @@
 http_open(Address, Stream, Options) :-
         must_be(list, Options),
         must_be(list, Address),
-        once(phrase((list(SchemeCs), "://", list(Rest)), Address)),
+        once(phrase((seq(SchemeCs), "://", seq(Rest)), Address)),
         atom_chars(Scheme, SchemeCs),
         chars_host_url(Rest, Host, URL),
         connect(Scheme, Host, Stream0),
@@ -48,14 +48,11 @@ Connection: close\r\n\r\n\
         read_header_lines(Stream0, HeaderLines),
         handle_response(D1, HeaderLines, Stream0, Stream).
 
-list([]) --> [].
-list([L|Ls]) --> [L], list(Ls).
-
 handle_response('2', _, Stream, Stream).              % ok
 handle_response('3', HeaderLines, Stream0, Stream) :- % redirect
         close(Stream0),
         once((member(Line, HeaderLines),
-              phrase(("Location: ",list(Location),"\r\n"), Line))),
+              phrase(("Location: ",seq(Location),"\r\n"), Line))),
         http_open(Location, Stream, []).
 
 % Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
@@ -69,7 +66,7 @@ read_header_lines(Stream, Hs) :-
         ).
 
 chars_host_url(Cs, Host, [/|Us]) :-
-        (   phrase((list(Hs),"/",list(Us)), Cs) ->
+        (   phrase((seq(Hs),"/",seq(Us)), Cs) ->
             true
         ;   Hs = Cs,
             Us = []

--- a/src/lib/sgml.pl
+++ b/src/lib/sgml.pl
@@ -64,9 +64,6 @@ load_html(Source, Es, Options) :-
 load_xml(Source, Es, Options) :-
         load_structure_(Source, Es, Options, xml).
 
-list([]) --> [].
-list([L|Ls]) --> [L], list(Ls).
-
 load_structure_([], [], _, _).
 load_structure_([C|Cs], [E], Options, What) :-
         load_(What, [C|Cs], E, Options).
@@ -74,7 +71,7 @@ load_structure_(file(Fs), [E], Options, What) :-
         must_be(list, Options),
         must_be(list, Fs),
         atom_chars(File, Fs),
-        once(phrase_from_file(list(Cs), File)),
+        once(phrase_from_file(seq(Cs), File)),
         load_(What, Cs, E, Options).
 load_structure_(stream(Stream), [E], Options, What) :-
         must_be(list, Options),

--- a/src/lib/time.pl
+++ b/src/lib/time.pl
@@ -59,14 +59,11 @@ format_time([], _) --> [].
 format_time(['%','%'|Fs], T) --> !, "%", format_time(Fs, T).
 format_time(['%',Spec|Fs], T) --> !,
         (   { member(Spec=Value, T) } ->
-            list(Value)
+            seq(Value)
         ;   { domain_error(time_specifier, Spec, format_time//2) }
         ),
         format_time(Fs, T).
 format_time([F|Fs], T) --> [F], format_time(Fs, T).
-
-list([]) --> [].
-list([L|Ls]) --> [L], list(Ls).
 
 max_sleep_time(0xfffffffffffffbff).
 

--- a/src/lib/xpath.pl
+++ b/src/lib/xpath.pl
@@ -540,7 +540,7 @@ xpath_condition(contains(Haystack, Needle), Value) :-          % contains(Haysta
     !,
     val_or_function(Haystack, Value, HaystackValue),
     val_or_function(Needle, Value, NeedleValue),
-    (   phrase((list(_),list(NeedleValue),list(_)), HaystackValue)
+    (   phrase((...,seq(NeedleValue),...), HaystackValue)
     ->  true
     ).
 xpath_condition(Spec, Dom) :-
@@ -626,10 +626,7 @@ text_of_list([H|T]) -->
 
 text_of_1(element(_,_,Content)) -->
         text_of_list(Content).
-text_of_1([C|Cs]) --> list([C|Cs]).
-
-list([]) --> [].
-list([L|Ls]) --> [L], list(Ls).
+text_of_1([C|Cs]) --> seq([C|Cs]).
 
 % For now, we use number_chars/2 to parse XML numbers.
 % If the need arises, we can extend this to additional


### PR DESCRIPTION
This pull requests changes a few definitions and occurrences of `list//1` to `seq//1` and `... //0`, which are now available in `library(dcgs)`.