### PR TITLE
ENHANCED: Character type checks for get_char/[1,2].

### DIFF
--- a/src/lib/builtins.pl
+++ b/src/lib/builtins.pl
@@ -1311,10 +1311,12 @@ char_code(Char, Code) :-
     ).
 
 get_char(C) :-
+    error:can_be(character, C),
     current_input(S),
     '$get_char'(S, C).
 
 get_char(S, C) :-
+    error:can_be(character, C),
     '$get_char'(S, C).
 
 can_be_number(N, PI) :-


### PR DESCRIPTION
This addresses #906.