### PR TITLE
Allow all kinds of string to be processed in open/4

### DIFF
--- a/src/lib/builtins.pl
+++ b/src/lib/builtins.pl
@@ -1475,7 +1475,11 @@ open(SourceSink, Mode, Stream, StreamOptions) :-
        (   SourceSink = stream(S0) ->
            '$set_stream_options'(S0, Alias, EOFAction, Reposition, Type),
            Stream = S0
-       ;   '$open'(SourceSink, Mode, Stream, Alias, EOFAction, Reposition, Type)
+       ;   (
+                atom(SourceSink) ->
+                atom_chars(SourceSink, SourceSinkString)
+           ;    SourceSink = SourceSinkString
+           ), '$open'(SourceSinkString, Mode, Stream, Alias, EOFAction, Reposition, Type)
        )
     ).
 

--- a/src/loader.pl
+++ b/src/loader.pl
@@ -503,7 +503,7 @@ open_file(Path, Stream) :-
     (  atom_concat(_, '.pl', Path) ->
        open(Path, read, Stream)
     ;  catch(open(Path, read, Stream),
-             error(existence_error(source_sink, Path), _),
+             error(existence_error(source_sink, _), _),
              ( atom_concat(Path, '.pl', ExtendedPath),
                open(ExtendedPath, read, Stream) )
             )

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -3169,31 +3169,10 @@ impl MachineState {
 
                 let options = self.to_stream_options(alias, eof_action, reposition, stream_type);
 
-                let mut stream = match self.store(self.deref(self[temp_v!(1)])) {
-                    Addr::Con(h) if self.heap.atom_at(h) => match &self.heap[h] {
-                        &HeapCellValue::Atom(ref atom, _) => {
-                            self.stream_from_file_spec(atom.clone(), indices, &options)?
-                        }
-                        _ => {
-                            unreachable!()
-                        }
-                    },
-                    Addr::Char(c) => {
-                        let atom = clause_name!(c.to_string(), self.atom_tbl);
-                        self.stream_from_file_spec(atom, indices, &options)?
-                    }
-                    Addr::PStrLocation(h, n) => match &self.heap[h] {
-                        &HeapCellValue::PartialString(_, _has_tail @ false) => {
-                            let mut heap_pstr_iter = self.heap_pstr_iter(Addr::PStrLocation(h, n));
+                let mut iter = self.heap_pstr_iter(self[temp_v!(1)]);
+                let file_spec = clause_name!(iter.to_string(), self.atom_tbl);
 
-                            let file_spec = clause_name!(heap_pstr_iter.to_string(), self.atom_tbl);
-
-                            self.stream_from_file_spec(file_spec, indices, &options)?
-                        }
-                        _ => self.stream_from_file_spec(clause_name!(""), indices, &options)?,
-                    },
-                    _ => self.stream_from_file_spec(clause_name!(""), indices, &options)?,
-                };
+                let mut stream = self.stream_from_file_spec(file_spec, indices, &options)?;
 
                 *stream.options_mut() = options;
 


### PR DESCRIPTION
The problem in https://github.com/mthom/scryer-prolog/issues/1103 was that sometimes an `Addr::Lis` was passed to the open systemcall while it only expects Atom, Char and PStr. Here, we remove any special handling, and we just call heap_pstr_iter, which manages multiple representations of strings. How do we manage atoms? By converting them to strings in the builtin predicate. That way, the code is more simple and straightforward.

Here's an example of accepting and rejecting situations.
```
?- open(45, read, S).
caught: error(domain_error(source_sink,45),open/4)
?- open("ab", read, S).
   S = '$stream'(0x557ea00ac9f0).
?- open(ab, read, S).
   S = '$stream'(0x557ea00c0da0).
?- open([a,b], read, S).
   S = '$stream'(0x557ea01b51d0).
?- append("a", "b", F), open(F, read, S).
   F = "ab", S = '$stream'(0x557ea00f3290).
?- open([12,34], read, S).
caught: error(domain_error(source_sink,[12,34]),open/4)
?- open(X, read, S).
caught: error(instantiation_error,open/4)
?- 
```

