### PR TITLE
Expand call goals as call goals so that goals in control constructs are qualified properly

### DIFF
--- a/src/loader.pl
+++ b/src/loader.pl
@@ -795,7 +795,7 @@ call_clause(G, G0) :-
        load_context(M)
     ;  true
     ),
-    expand_goal(M:G1, M, G0).
+    expand_goal(call(M:G1), M, call(G0)).
 
 
 call(G) :-
@@ -840,7 +840,7 @@ call_clause(G, Args, _, G0) :-
     ),
     append(As, Args, As1),
     G2 =.. [F | As1],
-    expand_goal(M:G2, M, G0).
+    expand_goal(call(M:G2), M, call(G0)).
 
 
 call(A,B) :-


### PR DESCRIPTION
This is in response to #1114. Note that

```
?- expand_goal(m:(length(_,_),true),m,G1).
   G1 = m:(length(_A,_B),true).
```
but
```
?- expand_goal(call((length(_,_),true)),m,call(G1)).
   G1 = m:(m:length(_A,_B),m:true).
```