### PR TITLE
Add predicates for using library(debug) with DCGs

### DIFF
--- a/src/lib/debug.pl
+++ b/src/lib/debug.pl
@@ -6,7 +6,10 @@
     op(950, fy, *),
     (*)/1,
     ($)/1,
-    ($-)/1
+    ($-)/1,
+    (*)/3,
+    ($)/3,
+    ($-)/3
 ]).
 
 :- use_module(library(format), [portray_clause/1]).
@@ -24,3 +27,18 @@ $(G_0) :-
    portray_clause(exit:G_0).
 
 *(_).
+
+% Predicates adapted for use inside DCGs
+:- meta_predicate *(0, ?, ?).
+:- meta_predicate $(0, ?, ?).
+:- meta_predicate $-(0, ?, ?).
+
+$-(G_0, A, B) :-
+   catch(call(G_0, A, B), Ex, ( portray_clause(exception:Ex:G_0=(A,B)), throw(Ex) ) ).
+
+$(G_0, A, B) :-
+   portray_clause(call:G_0=(A,B)),
+   $-(G_0, A, B),
+   portray_clause(exit:G_0=(A,B)).
+
+*(_, A, A).


### PR DESCRIPTION
Enables easy tracing of DCGs:
```prolog
natural(N)   --> digit(D), $natural(D,N).
natural(A,N) --> digit(D), {A1 is A * 10 + D}, $natural(A1,N).
natural(N,N) --> [].
```