### PR TITLE
ADDED: library(options)

### DIFF
--- a/src/lib/charsio.pl
+++ b/src/lib/charsio.pl
@@ -11,6 +11,7 @@
 :- use_module(library(iso_ext)).
 :- use_module(library(error)).
 :- use_module(library(lists)).
+:- use_module(library(options)).
 :- use_module(library(iso_ext), [partial_string/1,partial_string/3]).
 
 fabricate_var_name(VarType, VarName, N) :-
@@ -241,16 +242,8 @@ read_to_eof(Stream, Cs) :-
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 chars_base64(Cs, Bs, Options) :-
-        must_be(list, Options),
-        (   member(O, Options), var(O) ->
-            instantiation_error(chars_base64/3)
-        ;   (   member(padding(Padding), Options) -> true
-            ;   Padding = true
-            ),
-            (   member(charset(Charset), Options) -> true
-            ;   Charset = standard
-            )
-        ),
+        option(padding(Padding), Options, true),
+        option(charset(Charset), Options, standard),
         must_be(boolean, Padding),
         must_be(atom, Charset),
         (   member(Charset, [standard,url]) -> true

--- a/src/lib/crypto.pl
+++ b/src/lib/crypto.pl
@@ -46,6 +46,7 @@
 :- use_module(library(format)).
 :- use_module(library(charsio)).
 :- use_module(library(si)).
+:- use_module(library(options)).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    hex_bytes(?Hex, ?Bytes) is det.
@@ -288,15 +289,6 @@ crypto_data_hkdf(Data0, L, Bytes, Options0) :-
 hkdf_algorithm(sha256).
 hkdf_algorithm(sha384).
 hkdf_algorithm(sha512).
-
-option(What, Options, Default) :-
-        (   member(V, Options), var(V) ->
-            instantiation_error(option/3)
-        ;   true
-        ),
-        (   member(What, Options) -> true
-        ;   What =.. [_,Default]
-        ).
 
 chars_bytes_(Cs, Bytes, Context) :-
         must_be(list, Cs),

--- a/src/lib/options.pl
+++ b/src/lib/options.pl
@@ -1,0 +1,40 @@
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   library(options) simplifies option processing.
+
+   The most important, and currently only, predicate is option/3,
+   used as:
+
+       option(Option, Options, Default)
+
+   Options must be a list of options. An option is a non-variable term
+   of the form name(Value). If Options does not contain an option of
+   the specified name, then Default is used as Value.
+
+   Examples:
+
+      ?- option(tls(TLS), [], false).
+      %@    TLS = false.
+
+      ?- option(tls(TLS), [tls(true)], false).
+      %@    TLS = true.
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+:- module(options, [option/3]).
+
+:- use_module(library(error)).
+:- use_module(library(lists)).
+
+option(Option, Options, Default) :-
+        (   var(Option) ->
+            instantiation_error(option(Option))
+        ;   true
+        ),
+        must_be(list, Options),
+        (   member(Var, Options), var(Var) ->
+            instantiation_error(option(Var))
+        ;   true
+        ),
+        (   member(Option, Options) -> true
+        ;   Option =.. [_,Default]
+        ).


### PR DESCRIPTION
This library is mostly intended for authors of other *libraries*. I did not even mention it in the `README`, because it only contains a single predicate: `option/3`, to ask whether an option was specified, obtaining its value, and to use a default if the option is not stated explicitly.

Still, I think this is a useful building block, and makes option processing in various libraries easier, more correct, and less error-prone. I have used it in `library(crypto)` and `library(charsio)` to show how it works.