### PR TITLE
ENHANCED: Support also comments in integers with underscores

### DIFF
--- a/crates/prolog_parser/src/lexer.rs
+++ b/crates/prolog_parser/src/lexer.rs
@@ -564,11 +564,8 @@ impl<'a, R: Read> Lexer<'a, R> {
 
         if c == '_' {
             self.skip_char()?;
+            self.scan_for_layout()?;
             c = self.lookahead_char()?;
-            while layout_char!(c) {
-                self.skip_char()?;
-                c = self.lookahead_char()?;
-            }
 
             if decimal_digit_char!(c) {
                 Ok(c)

--- a/crates/prolog_parser/src/lexer.rs
+++ b/crates/prolog_parser/src/lexer.rs
@@ -791,7 +791,7 @@ impl<'a, R: Read> Lexer<'a, R> {
             let cr = self.lookahead_char();
 
             match cr {
-                Ok(c) if layout_char!(c) || new_line_char!(c) => {
+                Ok(c) if layout_char!(c) => {
                     self.skip_char()?;
                     layout_inserted = true;
                 }


### PR DESCRIPTION
This takes into account https://github.com/mthom/scryer-prolog/pull/1112#issuecomment-981540485.

Example:

    ?- X = 1_/**/2.
       X = 12.

In addition, I have simplified a test (`new line char` is a `layout char`).