### PR TITLE
Do not throw exception on close/1 errors

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -2692,28 +2692,10 @@ impl MachineState {
                 }
 
                 if !stream.is_stdin() && !stream.is_stdout() && !stream.is_stderr() {
-                    let close_result = stream.close();
+                    let _ = stream.close();
 
                     if let Some(ref alias) = stream.options().alias {
                         indices.stream_aliases.remove(alias);
-                    }
-                    if let Err(_) = close_result {
-                        let stub = MachineError::functor_stub(
-                            clause_name!("close"),
-                            1,
-                        );
-
-                        let addr = self.heap.to_unifiable(
-                            HeapCellValue::Stream(stream.clone()),
-                        );
-
-                        return Err(self.error_form(
-                            MachineError::existence_error(
-                                self.heap.h(),
-                                ExistenceError::Stream(addr),
-                            ),
-                            stub,
-                        ));
                     }
                 }
             }


### PR DESCRIPTION
This PR https://github.com/mthom/scryer-prolog/pull/1051 removed the panic on closing a non-existing stream, throwing a Prolog exception instead. However, this also doesn't seem to be the right approach, since it is operating system dependant as seen here: https://github.com/mthom/scryer-prolog/issues/1133

This PR will ignore every error generated by `close/1` regarding TcpStream and TlsStream