### PR TITLE
Generate into $OUT_DIR instead of src/

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -83,4 +83,6 @@ fn main() {
         .arg(static_atoms_path.as_os_str())
         .spawn().unwrap()
         .wait().unwrap();
+
+    println!("cargo:rerun-if-changed=src/");
 }

--- a/build.rs
+++ b/build.rs
@@ -56,7 +56,7 @@ fn main() {
     find_prolog_files(&mut libraries, "", &lib_path);
     libraries.write_all(b"\n        m\n    };\n}\n").unwrap();
 
-    let instructions_path = Path::new("src/instructions.rs");
+    let instructions_path = Path::new(&out_dir).join("instructions.rs");
     let mut instructions_file = File::create(&instructions_path).unwrap();
 
     let quoted_output = generate_instructions_rs();
@@ -70,10 +70,10 @@ fn main() {
         .spawn().unwrap()
         .wait().unwrap();
 
-    let static_atoms_path = Path::new("src/static_atoms.rs");
+    let static_atoms_path = Path::new(&out_dir).join("static_atoms.rs");
     let mut static_atoms_file = File::create(&static_atoms_path).unwrap();
 
-    let quoted_output = index_static_strings();
+    let quoted_output = index_static_strings(&instructions_path);
 
     static_atoms_file
         .write_all(quoted_output.to_string().as_bytes())

--- a/crates/instructions-template/src/lib.rs
+++ b/crates/instructions-template/src/lib.rs
@@ -3037,11 +3037,13 @@ pub fn generate_instructions_rs() -> TokenStream {
         }
 
         #[macro_export]
-        macro_rules! instr {
+        macro_rules! _instr {
             #(
                 #instr_macro_arms
             );*
         }
+
+        pub use _instr as instr; // https://github.com/rust-lang/rust/pull/52234#issuecomment-976702997
     }
 }
 

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -21,7 +21,7 @@ pub struct Atom {
 
 const_assert!(mem::size_of::<Atom>() == 8);
 
-include!("./static_atoms.rs");
+include!(concat!(env!("OUT_DIR"), "/static_atoms.rs"));
 
 impl<'a> From<&'a Atom> for Atom {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@ mod heap_iter;
 pub mod heap_print;
 mod indexing;
 #[macro_use]
-pub mod instructions;
+pub mod instructions {
+    include!(concat!(env!("OUT_DIR"), "/instructions.rs"));
+}
 mod iterators;
 pub mod machine;
 mod raw_block;
@@ -29,3 +31,5 @@ pub mod read;
 mod targets;
 pub mod types;
 pub mod write;
+
+use instructions::instr;


### PR DESCRIPTION
[Outputs of Build Script](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script) in the Cargo Book states that "Scripts should not modify any files outside of that directory"

Also adds a rerun-if instruction to the build scripts output to only rerun if something in src/ changes.
Changes to the build script or its dependencies still cause the build script to be recompiled and rerun.

