### PR TITLE
MODIFIED: Rename two predicates in library(charsio)

### DIFF
--- a/src/lib/charsio.pl
+++ b/src/lib/charsio.pl
@@ -3,7 +3,7 @@
                     get_single_char/1,
                     read_n_chars/3,
                     read_line_to_chars/3,
-                    read_term_from_chars/2,
+                    read_from_chars/2,
                     write_term_to_chars/3,
                     chars_base64/3]).
 
@@ -113,17 +113,17 @@ get_single_char(C) :-
     ).
 
 
-read_term_from_chars(Chars, Term) :-
+read_from_chars(Chars, Term) :-
     (  var(Chars) ->
-       instantiation_error(read_term_from_chars/2)
+       instantiation_error(read_from_chars/2)
     ;  nonvar(Term) ->
-       throw(error(uninstantiation_error(Term), read_term_from_chars/2))
+       throw(error(uninstantiation_error(Term), read_from_chars/2))
     ;  '$skip_max_list'(_, -1, Chars, Chars0),
        Chars0 == [],
        partial_string(Chars) ->
        true
     ;
-       type_error(complete_string, Chars, read_term_from_chars/2)
+       type_error(complete_string, Chars, read_from_chars/2)
     ),
     '$read_term_from_chars'(Chars, Term).
 

--- a/src/lib/charsio.pl
+++ b/src/lib/charsio.pl
@@ -1,7 +1,7 @@
 :- module(charsio, [char_type/2,
                     chars_utf8bytes/2,
                     get_single_char/1,
-                    read_n_chars/3,
+                    get_n_chars/3,
                     read_line_to_chars/3,
                     read_from_chars/2,
                     write_term_to_chars/3,
@@ -205,7 +205,7 @@ read_line_to_chars(Stream, Cs0, Cs) :-
    characters read.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-read_n_chars(Stream, N, Cs) :-
+get_n_chars(Stream, N, Cs) :-
         can_be(integer, N),
         (   var(N) ->
             read_to_eof(Stream, Cs),

--- a/src/lib/files.pl
+++ b/src/lib/files.pl
@@ -174,7 +174,7 @@ file_creation_time(File, T) :-
 file_time_(File, Which, T) :-
         file_must_exist(File, file_time_/3),
         '$file_time'(File, Which, T0),
-        read_term_from_chars(T0, T).
+        read_from_chars(T0, T).
 
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/lib/pio.pl
+++ b/src/lib/pio.pl
@@ -21,7 +21,7 @@
 :- use_module(library(freeze)).
 :- use_module(library(iso_ext), [setup_call_cleanup/3, partial_string/3]).
 :- use_module(library(lists), [member/2, maplist/2]).
-:- use_module(library(charsio), [read_n_chars/3]).
+:- use_module(library(charsio), [get_n_chars/3]).
 
 :- meta_predicate(phrase_from_file(2, ?)).
 :- meta_predicate(phrase_from_file(2, ?, ?)).
@@ -62,7 +62,7 @@ reader_step(Stream, Pos, Xs0) :-
         set_stream_position(Stream, Pos),
         (   at_end_of_stream(Stream)
         ->  Xs0 = []
-        ;   read_n_chars(Stream, 4096, Cs),
+        ;   get_n_chars(Stream, 4096, Cs),
             partial_string(Cs, Xs0, Xs),
             stream_to_lazy_list(Stream, Xs)
         ).

--- a/src/lib/time.pl
+++ b/src/lib/time.pl
@@ -49,11 +49,11 @@
 :- use_module(library(error)).
 :- use_module(library(dcgs)).
 :- use_module(library(lists)).
-:- use_module(library(charsio), [read_term_from_chars/2]).
+:- use_module(library(charsio), [read_from_chars/2]).
 
 current_time(T) :-
         '$current_time'(T0),
-        read_term_from_chars(T0, T).
+        read_from_chars(T0, T).
 
 format_time([], _) --> [].
 format_time(['%','%'|Fs], T) --> !, "%", format_time(Fs, T).


### PR DESCRIPTION
Dear all,

unfortunately two predicates I requested for (#334) or added to (#1071) `library(charsio)` are not optimally named. Specificially:

- `read_term_from_chars/2` should have been called **`read_from_chars/2`** for compatibility with SICStus Prolog (in its `library(charsio)`) and GNU Prolog.
- `read_n_chars/3` should have been called **`get_n_chars/3`** because "read" is associated with reading general Prolog terms, whereas individual bytes and characters are always fetched with `get_...`.

I am filing this pull request to rename both predicates at once, to resolve this as soon as possible rather than later, when more applications are affected. The impact of this change should be rather limited: If you are using these predicates in your applications, please also consider `library(pio)`, since its `phrase_from_file/2` may be a better fit.

@pmoura, @aarroyoc, I hope you are OK with this change, in case your applications are affected.

Please forgive this backwards-incompatible change to these predicates, I hope it is acceptable.

Thank you and all the best,
Markus