### PR TITLE
FIXED: toplevel to use (newly renamed) read_from_chars/2

### DIFF
--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -112,7 +112,7 @@ run_goals([g(Gs0)|Goals]) :-
     (   ends_with_dot(Gs0) -> Gs1 = Gs0
     ;   append(Gs0, ".", Gs1)
     ),
-    read_term_from_chars(Gs1, Goal),
+    read_from_chars(Gs1, Goal),
     (   catch(
             user:Goal,
             Exception,


### PR DESCRIPTION
I have previously overlooked this change due to the now resolved problem described in #1227!