### PR TITLE
FIXED: load_html/3: use str_loc_as_cell! to store attribute structures

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -6035,7 +6035,7 @@ impl Machine {
                         &mut self.machine_st.atom_tbl,
                     );
 
-                    avec.push(heap_loc_as_cell!(self.machine_st.heap.len()));
+                    avec.push(str_loc_as_cell!(self.machine_st.heap.len()));
 
                     self.machine_st.heap.push(atom_as_cell!(atom!("="), 2));
                     self.machine_st.heap.push(atom_as_cell!(name));


### PR DESCRIPTION
`library(sgml)` now works correctly in `rebis-dev`.