### PR TITLE
Add --no-add-history flag

### DIFF
--- a/src/machine/args.rs
+++ b/src/machine/args.rs
@@ -1,0 +1,16 @@
+use std::collections::BTreeSet;
+use std::env;
+
+#[derive(Debug)]
+pub struct MachineArgs {
+    pub add_history: bool,
+}
+
+impl MachineArgs {
+    pub fn new() -> Self {
+        let args: BTreeSet<String> = env::args().collect();
+        Self {
+            add_history: !args.contains("--no-add-history"),
+        }
+    }
+}

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -1,3 +1,4 @@
+pub mod args;
 pub mod arithmetic_ops;
 pub mod attributed_variables;
 pub mod code_walker;
@@ -25,6 +26,7 @@ use crate::arithmetic::*;
 use crate::atom_table::*;
 use crate::forms::*;
 use crate::instructions::*;
+use crate::machine::args::*;
 use crate::machine::compile::*;
 use crate::machine::copier::*;
 use crate::machine::heap::*;
@@ -396,9 +398,10 @@ impl Machine {
     pub fn new() -> Self {
         use ref_thread_local::RefThreadLocal;
 
+        let args = MachineArgs::new();
         let mut machine_st = MachineState::new();
 
-        let user_input = Stream::stdin(&mut machine_st.arena);
+        let user_input = Stream::stdin(&mut machine_st.arena, args.add_history);
         let user_output = Stream::stdout(&mut machine_st.arena);
         let user_error = Stream::stderr(&mut machine_st.arena);
 

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -426,9 +426,9 @@ impl Stream {
     }
 
     #[inline]
-    pub fn stdin(arena: &mut Arena) -> Stream {
+    pub fn stdin(arena: &mut Arena, add_history: bool) -> Stream {
         Stream::Readline(arena_alloc!(
-            StreamLayout::new(ReadlineStream::new("")),
+            StreamLayout::new(ReadlineStream::new("", add_history)),
             arena
         ))
     }

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4094,7 +4094,7 @@ impl Machine {
         match result {
             Ok(()) => Ok(()),
             Err(e) => {
-                self.user_input = input_stream(&mut self.machine_st.arena);
+                self.user_input.reset();
                 return Err(e);
             }
         }

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -57,6 +57,7 @@ delegate_task([Arg0|Args], Goals0) :-
     ;   member(Arg0, ["-v", "--version"]) -> print_version
     ;   member(Arg0, ["-g", "--goal"]) -> gather_goal(g, Args, Goals0)
     ;   member(Arg0, ["-f"]) -> disable_init_file
+    ;   member(Arg0, ["--no-add-history"]) -> ignore_machine_arg
     ;   atom_chars(Mod, Arg0),
         catch(consult(Mod), E, print_exception(E))
     ),
@@ -73,7 +74,9 @@ print_help :-
     write('   -g, --goal GOAL        '),
     write('Run the query GOAL'), nl,
     write('   -f                     '),
-    write('Fast startup. Do not load initialization file (~/.scryerrc)'),nl,
+    write('Fast startup. Do not load initialization file (~/.scryerrc)'), nl,
+    write('   --no-add-history       '),
+    write('Prevent adding input to history file (~/.scryer_history)'), nl,
     % write('                        '),
     halt.
 
@@ -93,6 +96,8 @@ gather_goal(Type, Args0, Goals) :-
 
 disable_init_file :-
     asserta('disabled_init_file').
+
+ignore_machine_arg.
 
 arg_type(g).
 arg_type(t).

--- a/tests/scryer/helper.rs
+++ b/tests/scryer/helper.rs
@@ -65,6 +65,7 @@ pub fn run_top_level_test_with_args<
     Command::cargo_bin(SCRYER_PROLOG)
         .unwrap()
         .arg("-f")
+        .arg("--no-add-history")
         .args(args)
         .write_stdin(stdin)
         .assert()


### PR DESCRIPTION
Flag prevents the input stream from saving terms to ~/.scryer_history when set. Use the flag when running tests to increase test isolation.

Created a machine args module to handle the flag as the input stream is initialized prior to the toplevel cjode being run. Used a very simple method of dealing with the arguments but a library could be used later if the complexity of the args increases.

Switch to using the recently implemented `ReadlineStream::reset` instead of recreating the stream and removed the `input_stream` function which was only used for that purpose from what I can tell.

Happy for any and all feedback on this.