### PR TITLE
Set minimum rust version in Cargo.toml (Attempt 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,17 @@ jobs:
         with:
           command: test
           args: --verbose --all --no-default-features --features num
+  msrv:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install cargo-msrv
+        uses: baptiste0928/cargo-install@v1.1.0
+        with:
+          crate: cargo-msrv
+      - name: Verify MSRV
+        run: cargo msrv --verify

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "BSD-3-Clause"
 keywords = ["prolog", "prolog-interpreter", "prolog-system"]
 categories = ["command-line-utilities"]
 build = "build.rs"
+rust-version = "1.57"
 
 [workspace]
 members = ["crates/num-rug-adapter",


### PR DESCRIPTION
Based on the feedback to https://github.com/mthom/scryer-prolog/issues/1335#issuecomment-1062039516 this adds the rust-verrsion field in Cargo.toml and a CI job to check that it is still accurate.

Follow-up to #1347 This time without breaking CI