### PR TITLE
push Docker image on new release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Docker Publish
+
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+
+env:
+  IMAGE_NAME: mjt128/scryer-prolog
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Extract Docker image tag from git tag. E.g. if git tag is "v0.19.1" then use 
+      # Docker image tag "0.19.1". Tag "latest" is automatically synced with newest
+      # version.
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: docker.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/LukeMathWalker/cargo-chef
-ARG RUST_VERSION=1.52.1-buster
+ARG RUST_VERSION=1.60-buster
 FROM rust:${RUST_VERSION} as planner
 WORKDIR /scryer-prolog
 RUN cargo install cargo-chef 


### PR DESCRIPTION
I wanted to play with the Docker image a bit and noticed that I couldn't import `library(debug)`. After a while I realised that the Docker image was last updated two years ago. So I thought it might be helpful to setup a GitHub action for this project that automatically builds and pushes new images 🙂 

I’m not sure what the release workflow is here. These Git tags (v0.9.0 etc) are created manually, right? The GitHub action is configured to run whenever such a tag is created and uses that tag (without the leading “v”) as the Docker image tag. Also the `latest` tag is kept in sync with the most recent version. 

To make it work, two secrets must be added: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. They can be added under:

*[this repository] > Settings > Secrets > Actions > New repository secret*

The value for `DOCKERHUB_TOKEN` can be retrieved from:

*hub.docker.com > Account Settings > Security > New Access Token*

I tested this on my fork. Here is [a successful build](https://github.com/gruhn/scryer-prolog/runs/6029699133?check_suite_focus=true) and here is [the pushed image](https://hub.docker.com/layers/scryer-prolog/gruhn/scryer-prolog/0.0.11/images/sha256-63b16c124d4eb96ac83d19b1635a325281721bb2da2938d627c19d805c9c47c5?context=explore).