### PR TITLE
Completion of predicates in repl

### DIFF
--- a/build/static_string_indexing.rs
+++ b/build/static_string_indexing.rs
@@ -170,7 +170,7 @@ pub fn index_static_strings(instruction_rs_path: &std::path::Path) -> TokenStrea
             #((#static_strs) => { Atom { index: #indices_iter } };)*
         }
 
-        static STATIC_ATOMS_MAP: phf::Map<&'static str, Atom> = phf::phf_map! {
+        pub static STATIC_ATOMS_MAP: phf::Map<&'static str, Atom> = phf::phf_map! {
             #(#static_strs => { Atom { index: #indices } },)*
         };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod iterators;
 pub mod machine;
 mod raw_block;
 pub mod read;
+mod repl_helper;
 mod targets;
 pub mod types;
 

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -454,13 +454,15 @@ impl MachineState {
         self.b0 = self.b;
     }
 
+    // Safety: the atom_tbl lives for the lifetime of the machine, as does the helper, so the ptr
+    // will always be valid.
     pub fn read_term_from_user_input(&mut self, stream: Stream, indices: &mut IndexStore) -> CallResult {
-        let atoms: Vec<_> = self.atom_tbl.table.iter().map(|a| a.as_str().to_string()).collect();
+        let atoms_ptr = (&self.atom_tbl.table) as *const indexmap::IndexSet<Atom>;
 
         if let Stream::Readline(ptr) = stream {
             unsafe {
                 let readline = ptr.as_ptr().as_mut().unwrap();
-                readline.set_atoms_for_completion(atoms);
+                readline.set_atoms_for_completion(atoms_ptr);
                 let ret = self.read_term(stream, indices);
                 return ret
             }

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -454,6 +454,21 @@ impl MachineState {
         self.b0 = self.b;
     }
 
+    pub fn read_term_from_user_input(&mut self, stream: Stream, indices: &mut IndexStore) -> CallResult {
+        let atoms: Vec<_> = self.atom_tbl.table.iter().map(|a| a.as_str().to_string()).collect();
+
+        if let Stream::Readline(ptr) = stream {
+            unsafe {
+                let readline = ptr.as_ptr().as_mut().unwrap();
+                readline.set_atoms_for_completion(atoms);
+                let ret = self.read_term(stream, indices);
+                return ret
+            }
+        }
+
+        unreachable!("Stream must be a Stream::Readline(_)")
+    }
+
     pub fn read_term(&mut self, stream: Stream, indices: &mut IndexStore) -> CallResult {
         fn push_var_eq_functors<'a>(
             heap: &mut Heap,

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4239,7 +4239,8 @@ impl Machine {
         self.user_input.reset();
 
         set_prompt(true);
-        let result = self.machine_st.read_term(self.user_input, &mut self.indices);
+        // let result = self.machine_st.read_term(self.user_input, &mut self.indices);
+        let result = self.machine_st.read_term_from_user_input(self.user_input, &mut self.indices);
         set_prompt(false);
 
         match result {

--- a/src/read.rs
+++ b/src/read.rs
@@ -14,6 +14,7 @@ use crate::types::*;
 
 use fxhash::FxBuildHasher;
 
+use indexmap::IndexSet;
 use rustyline::error::ReadlineError;
 use rustyline::{Config, Editor};
 
@@ -108,7 +109,7 @@ impl ReadlineStream {
         }
     }
 
-    pub fn set_atoms_for_completion(&mut self, atoms: Vec<String>) {
+    pub fn set_atoms_for_completion(&mut self, atoms: *const IndexSet<Atom>) {
         let helper = self.rl.helper_mut().unwrap();
         helper.atoms = atoms;
     }

--- a/src/repl_helper.rs
+++ b/src/repl_helper.rs
@@ -1,0 +1,136 @@
+use rustyline::completion::Completer;
+use rustyline::hint::Hinter;
+use rustyline::validate::Validator;
+use rustyline::highlight::{MatchingBracketHighlighter, Highlighter};
+use rustyline::{Helper as RlHelper, Result, Context};
+
+// pub struct Atoms {
+//     atoms: *const *const str,
+//     len: usize,
+// }
+
+// impl Atoms {
+//     pub fn new() -> Self {
+//         Self {
+//             atoms: std::ptr::null(),
+//             len: 0,
+//         }
+//     }
+// }
+
+// pub struct AtomsIterator<'a> {
+//     atoms: &'a Atoms,
+//     idx: usize,
+// }
+
+// impl<'a> Iterator for AtomsIterator<'a> {
+//     type Item = &'a str;
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         self.idx += 1;
+
+//         if self.idx == self.atoms.len {
+//             None
+//         } else {
+//             unsafe {
+//                 let next = self.atoms.atoms.offset(self.idx as isize);
+//                 (*next).as_ref()
+//             }
+//         }
+//     }
+// }
+
+// impl<'a> IntoIterator for &'a Atoms {
+//     type Item = &'a str;
+//     type IntoIter = AtomsIterator<'a>;
+
+//     fn into_iter(self) -> Self::IntoIter {
+//         Self::IntoIter {
+//             atoms: self,
+//             idx: 0,
+//         }
+//     }
+// }
+
+// TODO: Maybe add validation to the helper
+pub struct Helper {
+    highligher: MatchingBracketHighlighter,
+    pub atoms: Vec<String>,
+}
+
+impl Helper {
+    pub fn new() -> Self {
+        Self {
+            highligher: MatchingBracketHighlighter::new(),
+            atoms: vec![],
+        }
+    }
+
+    // pub fn set_atoms(&mut self, atoms_ptr: *const *const str, len: usize) {
+    //     self.atoms.atoms = atoms_ptr;
+    //     self.atoms.len = len;
+    // }
+}
+
+impl RlHelper for Helper {}
+
+fn get_prefix(line: &str, pos: usize) -> Option<usize> {
+    let mut start_of_atom = None;
+    let mut first_letter = true;
+
+    for (i, char) in line.chars().enumerate() {
+        if first_letter {
+            if char.is_alphabetic() && char.is_lowercase() {
+                start_of_atom = Some(i);
+            }
+
+            first_letter = false;
+        }
+
+        if !char.is_alphanumeric() && char != '_' {
+            first_letter = true;
+            start_of_atom = None;
+        }
+
+        if i == pos {
+            break
+        }
+    }
+
+    if first_letter || pos == 0 {
+        start_of_atom = Some(pos)
+    }
+
+    start_of_atom
+}
+
+impl Completer for Helper {
+    type Candidate = String;
+
+    fn complete(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Result<(usize, Vec<Self::Candidate>)> {
+        let start_of_prefix = get_prefix(line, pos);
+        if let Some(idx) = start_of_prefix {
+            let sub_str = line.get(idx..pos).unwrap();
+            let matching = self.atoms.iter().filter(|a| a.starts_with(sub_str)).map(|s| s.to_string()).collect();
+            Ok((idx, matching))
+        } else {
+            Ok((0, vec![]))
+        }
+    }
+}
+
+impl Highlighter for Helper {
+    fn highlight<'l>(&self, line: &'l str, pos: usize) -> std::borrow::Cow<'l, str> {
+        self.highligher.highlight(line, pos)
+    }
+
+    fn highlight_char(&self, line: &str, pos: usize) -> bool {
+        self.highligher.highlight_char(line, pos)
+    }
+}
+
+impl Validator for Helper {}
+
+impl Hinter for Helper {
+    type Hint = String;
+}


### PR DESCRIPTION
This pull request adds tab completion of predicates and highlighting of matching brackets to the repl. There is a lot of raw pointer use in order to get around the Stream abstraction, from what I could gather, in order to change this to safe rust, this abstraction would need to be changed and explicit life times added to a few structs. I think the dereferencing of pointers is all valid, but I am not certain due to my limited understanding of the code base. I also think there are a few atoms in the `atom_tbl` which we do not want in the completion list, such as the directory of the executable, but I could not find a way to filter them out.