### PR TITLE
FIXED: can_be(chars, [a,X]), i.e., if variables occur as elements

### DIFF
--- a/src/lib/error.pl
+++ b/src/lib/error.pl
@@ -1,5 +1,5 @@
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   Written September 2018 by Markus Triska (triska@metalevel.at)
+   Written 2018-2022 by Markus Triska (triska@metalevel.at)
    I place this code in the public domain. Use it in any way you want.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
@@ -48,6 +48,7 @@ must_be_(integer, Term) :- check_(integer, integer, Term).
 must_be_(atom, Term)    :- check_(atom, atom, Term).
 must_be_(character, T)  :- check_(error:character, character, T).
 must_be_(chars, Ls) :-
+        can_be(chars, Ls), % prioritize type errors over instantiation errors
         must_be(list, Ls),
         (   '$is_partial_string'(Ls) ->
             % The expected case (success) uses a very fast test.

--- a/src/lib/error.pl
+++ b/src/lib/error.pl
@@ -128,7 +128,11 @@ can_be(Type, Term) :-
 can_(integer, Term) :- integer(Term).
 can_(atom, Term)    :- atom(Term).
 can_(character, T)  :- character(T).
-can_(chars, Ls)     :- '$is_partial_string'(Ls).
+can_(chars, Ls)     :-
+        (   '$is_partial_string'(Ls) -> true
+        ;   can_be(list, Ls),
+            can_be_chars(Ls)
+        ).
 can_(list, Term)    :- list_or_partial_list(Term).
 can_(boolean, Term) :- boolean(Term).
 can_(term, Term)    :-
@@ -136,6 +140,12 @@ can_(term, Term)    :-
             true
         ;   type_error(term, Term, can_be/2)
         ).
+
+can_be_chars(Var) :- var(Var), !.
+can_be_chars([]).
+can_be_chars([X|Xs]) :-
+        can_be(character, X),
+        can_be_chars(Xs).
 
 list_or_partial_list(Ls) :-
         '$skip_max_list'(_, _, Ls, Rs),


### PR DESCRIPTION
This should simplify 2f3de51e554629d2e7b4ea023c9ef181c240692c and other cases like it.