### PR TITLE
make rustfmt optional

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
-use std::process::{self, Command, Stdio};
+use std::process::{Command, Stdio};
 
 fn find_prolog_files(libraries: &mut File, prefix: &str, current_dir: &Path) {
     let entries = match current_dir.read_dir() {
@@ -103,13 +103,11 @@ fn format_generated_file(path: &Path) {
         .arg(path.as_os_str())
         .spawn()
         .unwrap_or_else(|err| {
-            eprintln!(
-                "{}: rustfmt (https://github.com/rust-lang/rustfmt) \
-                is required build time dependency and must be available \
-                in the environment's PATH variable.",
-                err
+            panic!(
+                "{}: rustfmt was detected as available, but failed to format generated file '{}'",
+                err,
+                path.display()
             );
-            process::exit(1);
         })
         .wait()
         .unwrap();

--- a/build/main.rs
+++ b/build/main.rs
@@ -1,15 +1,15 @@
-mod static_string_indexing;
 mod instructions_template;
+mod static_string_indexing;
 
-use static_string_indexing::index_static_strings;
 use instructions_template::generate_instructions_rs;
+use static_string_indexing::index_static_strings;
 
 use std::env;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
-use std::process::{self, Command};
+use std::process::{self, Command, Stdio};
 
 fn find_prolog_files(libraries: &mut File, prefix: &str, current_dir: &Path) {
     let entries = match current_dir.read_dir() {
@@ -42,6 +42,16 @@ fn find_prolog_files(libraries: &mut File, prefix: &str, current_dir: &Path) {
 }
 
 fn main() {
+    let has_rustfmt = Command::new("rustfmt")
+        .arg("--version")
+        .stdin(Stdio::inherit())
+        .status()
+        .is_ok();
+
+    if !has_rustfmt {
+        println!("Failed to run rustfmt, will skip formatting generated files.")
+    }
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("libraries.rs");
 
@@ -68,7 +78,9 @@ fn main() {
         .write_all(quoted_output.to_string().as_bytes())
         .unwrap();
 
-    format_generated_file(instructions_path.as_path());
+    if has_rustfmt {
+        format_generated_file(instructions_path.as_path());
+    }
 
     let static_atoms_path = Path::new(&out_dir).join("static_atoms.rs");
     let mut static_atoms_file = File::create(&static_atoms_path).unwrap();
@@ -79,7 +91,9 @@ fn main() {
         .write_all(quoted_output.to_string().as_bytes())
         .unwrap();
 
-    format_generated_file(static_atoms_path.as_path());
+    if has_rustfmt {
+        format_generated_file(static_atoms_path.as_path());
+    }
 
     println!("cargo:rerun-if-changed=src/");
 }


### PR DESCRIPTION
- when rustfmt is not detected (by attempting to run ``rustfmt --version)
  no formatting will be attempted
- this should resolve issue mthom/scryer-prolog#1504