### PR TITLE
add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.png binary
+*.pl text eol=lf
+*.rs text eol=lf diff=rust
+*.md text eol=lf diff=markdown


### PR DESCRIPTION
- this should stop problems such as mthom/scryer-prolog#1491 ,
  by specifying the line ending, as this should take precedence over the global config
  
Note: depending on whether `\r\n` line endings should be supported this might just hide the symptoms instead of fixing the underlying problem