### PR TITLE
Fixed imports for num-rug-adapter

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -6,7 +6,7 @@ use crate::read::*;
 
 use modular_bitfield::prelude::*;
 use ordered_float::OrderedFloat;
-use rug::{Integer, Rational};
+use crate::parser::rug::{Integer, Rational};
 
 use std::alloc;
 use std::fmt;
@@ -681,7 +681,7 @@ mod tests {
     use crate::machine::partial_string::*;
 
     use ordered_float::OrderedFloat;
-    use rug::{Integer, Rational};
+    use crate::parser::rug::{Integer, Rational};
 
     #[test]
     fn float_ptr_cast() {

--- a/src/machine/heap.rs
+++ b/src/machine/heap.rs
@@ -5,7 +5,7 @@ use crate::machine::partial_string::*;
 use crate::parser::ast::*;
 use crate::types::*;
 
-use rug::{Integer, Rational};
+use crate::parser::rug::{Integer, Rational};
 
 use std::convert::TryFrom;
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -11,7 +11,7 @@ use std::ops::Neg;
 use std::rc::Rc;
 use std::vec::Vec;
 
-use rug::{Integer, Rational};
+use crate::parser::rug::{Integer, Rational};
 
 use fxhash::FxBuildHasher;
 use indexmap::IndexMap;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "num-rug-adapter")]
-use num_rug_adapter as rug;
+pub use num_rug_adapter as rug;
+
 #[cfg(feature = "rug")]
 pub use rug;
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -4,7 +4,7 @@ use crate::parser::ast::*;
 use crate::parser::char_reader::*;
 use crate::parser::lexer::*;
 
-use rug::ops::NegAssign;
+use crate::parser::rug::ops::NegAssign;
 
 use std::cell::Cell;
 use std::mem;


### PR DESCRIPTION
Previously building with `cargo build --no-default-features --features num` was basically useless because the imports were not set up correctly. 
It still doesn't work though, but that's not because of this project.