### PR TITLE
HTTP Server 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,12 +412,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -425,6 +441,34 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.17",
+ "syn 1.0.90",
+]
 
 [[package]]
 name = "futures-sink"
@@ -444,10 +488,16 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1628,6 +1678,7 @@ dependencies = [
  "ctrlc",
  "dirs-next",
  "divrem",
+ "futures",
  "fxhash",
  "git-version",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ ryu = "1.0.9"
 hyper = { version = "0.14", features = ["full"] }
 hyper-tls = "0.5.0"
 tokio = { version = "1", features = ["full"] }
+futures = "0.3"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -544,6 +544,12 @@ enum SystemClauseType {
     DeterministicLengthRundown,
     #[strum_discriminants(strum(props(Arity = "7", Name = "$http_open")))]
     HttpOpen,
+    #[strum_discriminants(strum(props(Arity = "2", Name = "$http_listen")))]
+    HttpListen,
+    #[strum_discriminants(strum(props(Arity = "7", Name = "$http_accept")))]
+    HttpAccept,
+    #[strum_discriminants(strum(props(Arity = "4", Name = "$http_answer")))]
+    HttpAnswer,
     #[strum_discriminants(strum(props(Arity = "3", Name = "$predicate_defined")))]
     PredicateDefined,
     #[strum_discriminants(strum(props(Arity = "3", Name = "$strip_module")))]
@@ -1686,6 +1692,9 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::CallCpuNow(_) |
                     &Instruction::CallDeterministicLengthRundown(_) |
                     &Instruction::CallHttpOpen(_) |
+                    &Instruction::CallHttpListen(_) |
+                    &Instruction::CallHttpAccept(_) |
+                    &Instruction::CallHttpAnswer(_) |
                     &Instruction::CallPredicateDefined(_) |
                     &Instruction::CallStripModule(_) |
                     &Instruction::CallCurrentTime(_) |
@@ -1895,6 +1904,9 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::ExecuteCpuNow(_) |
                     &Instruction::ExecuteDeterministicLengthRundown(_) |
                     &Instruction::ExecuteHttpOpen(_) |
+                    &Instruction::ExecuteHttpListen(_) |
+                    &Instruction::ExecuteHttpAccept(_) |
+                    &Instruction::ExecuteHttpAnswer(_) |
                     &Instruction::ExecutePredicateDefined(_) |
                     &Instruction::ExecuteStripModule(_) |
                     &Instruction::ExecuteCurrentTime(_) |

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,25 @@
+use std::sync::Arc;
+use std::convert::Infallible;
+
+use hyper::{Response, Request, Body};
+use tokio::sync::Mutex;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+
+pub struct HttpListener {
+    pub incoming: Receiver<HttpRequest>
+}
+
+#[derive(Debug)]
+pub struct HttpRequest {
+    pub request: Request<Body>,
+    pub response: HttpResponse,
+}
+
+pub type HttpResponse = Sender<Response<Body>>;
+
+pub async fn serve_req(req: Request<Body>, tx: Arc<Mutex<Sender<HttpRequest>>>) -> Result<Response<Body>, Infallible> {
+    let (response_tx, mut rx) = channel(1);
+    let http_request = HttpRequest { request: req, response: response_tx };
+    tx.lock().await.send(http_request).await.unwrap();
+    Ok(rx.recv().await.unwrap())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod fixtures;
 mod forms;
 mod heap_iter;
 pub mod heap_print;
+mod http;
 mod indexing;
 #[macro_use]
 pub mod instructions {

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -4197,6 +4197,30 @@ impl Machine {
                     try_or_throw!(self.machine_st, self.http_open());
                     step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                 }
+		&Instruction::CallHttpListen(_) => {
+		    try_or_throw!(self.machine_st, self.http_listen());
+		    step_or_fail!(self, self.machine_st.p += 1);
+		}
+		&Instruction::ExecuteHttpListen(_) => {
+		    try_or_throw!(self.machine_st, self.http_listen());
+		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+		}
+		&Instruction::CallHttpAccept(_) => {
+		    try_or_throw!(self.machine_st, self.http_accept());
+		    step_or_fail!(self, self.machine_st.p += 1);
+		}
+		&Instruction::ExecuteHttpAccept(_) => {
+		    try_or_throw!(self.machine_st, self.http_accept());
+		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+		}
+		&Instruction::CallHttpAnswer(_) => {
+		    try_or_throw!(self.machine_st, self.http_answer());
+		    step_or_fail!(self, self.machine_st.p += 1);
+		}
+		&Instruction::ExecuteHttpAnswer(_) => {
+		    try_or_throw!(self.machine_st, self.http_answer());
+		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+		}
                 &Instruction::CallCurrentTime(_) => {
                     self.current_time();
                     step_or_fail!(self, self.machine_st.p += 1);

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -431,9 +431,7 @@ impl Machine {
         let user_output = Stream::stdout(&mut machine_st.arena);
         let user_error = Stream::stderr(&mut machine_st.arena);
 
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
+        let runtime = tokio::runtime::Runtime::new()
             .unwrap();
 
         let mut wam = Machine {

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -26,6 +26,7 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 
 use native_tls::TlsStream;
+use hyper::body::{Bytes, Sender};
 
 #[derive(Debug, BitfieldSpecifier, Clone, Copy, PartialEq, Eq, Hash)]
 #[bits = 1]
@@ -249,21 +250,48 @@ impl Write for NamedTlsStream {
     }
 }
 
-pub struct NamedHttpClientStream {
+pub struct HttpReadStream {
     url: Atom,
     body_reader: Box<dyn BufRead>,
 }
 
-impl Debug for NamedHttpClientStream {
+impl Debug for HttpReadStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Http Client Stream [{}]", self.url.as_str())
+        write!(f, "Http Read Stream [{}]", self.url.as_str())
     }
 }
 
-impl Read for NamedHttpClientStream {
+impl Read for HttpReadStream {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.body_reader.read(buf)
+    }
+}
+
+pub struct HttpWriteStream {
+    body_writer: Sender,
+}
+
+impl Debug for HttpWriteStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+	write!(f, "Http Write Stream")
+    }
+}
+
+impl Write for HttpWriteStream {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+	let bytes = Bytes::copy_from_slice(buf);
+	let len = bytes.len();
+	match self.body_writer.try_send_data(bytes) {
+	    Ok(()) => Ok(len),
+	    Err(_) => Err(std::io::Error::from(ErrorKind::Interrupted))
+	}
+    }
+
+    #[inline]
+    fn flush(&mut self) -> std::io::Result<()> {
+	Ok(())
     }
 }
 
@@ -405,7 +433,8 @@ arena_allocated_impl_for_stream!(CharReader<InputFileStream>, InputFileStream);
 arena_allocated_impl_for_stream!(OutputFileStream, OutputFileStream);
 arena_allocated_impl_for_stream!(CharReader<NamedTcpStream>, NamedTcpStream);
 arena_allocated_impl_for_stream!(CharReader<NamedTlsStream>, NamedTlsStream);
-arena_allocated_impl_for_stream!(CharReader<NamedHttpClientStream>, NamedHttpClientStream);
+arena_allocated_impl_for_stream!(CharReader<HttpReadStream>, HttpReadStream);
+arena_allocated_impl_for_stream!(CharReader<HttpWriteStream>, HttpWriteStream);
 arena_allocated_impl_for_stream!(ReadlineStream, ReadlineStream);
 arena_allocated_impl_for_stream!(StaticStringStream, StaticStringStream);
 arena_allocated_impl_for_stream!(StandardOutputStream, StandardOutputStream);
@@ -419,7 +448,8 @@ pub enum Stream {
     StaticString(TypedArenaPtr<StreamLayout<StaticStringStream>>),
     NamedTcp(TypedArenaPtr<StreamLayout<CharReader<NamedTcpStream>>>),
     NamedTls(TypedArenaPtr<StreamLayout<CharReader<NamedTlsStream>>>),
-    NamedHttpClient(TypedArenaPtr<StreamLayout<CharReader<NamedHttpClientStream>>>),
+    HttpRead(TypedArenaPtr<StreamLayout<CharReader<HttpReadStream>>>),
+    HttpWrite(TypedArenaPtr<StreamLayout<CharReader<HttpWriteStream>>>),
     Null(StreamOptions),
     Readline(TypedArenaPtr<StreamLayout<ReadlineStream>>),
     StandardOutput(TypedArenaPtr<StreamLayout<StandardOutputStream>>),
@@ -474,7 +504,8 @@ impl Stream {
             }
             ArenaHeaderTag::NamedTcpStream => Stream::NamedTcp(TypedArenaPtr::new(ptr as *mut _)),
             ArenaHeaderTag::NamedTlsStream => Stream::NamedTls(TypedArenaPtr::new(ptr as *mut _)),
-            ArenaHeaderTag::NamedHttpClientStream => Stream::NamedHttpClient(TypedArenaPtr::new(ptr as *mut _)),
+            ArenaHeaderTag::HttpReadStream => Stream::HttpRead(TypedArenaPtr::new(ptr as *mut _)),
+	    ArenaHeaderTag::HttpWriteStream => Stream::HttpWrite(TypedArenaPtr::new(ptr as *mut _)),
             ArenaHeaderTag::ReadlineStream => Stream::Readline(TypedArenaPtr::new(ptr as *mut _)),
             ArenaHeaderTag::StaticStringStream => {
                 Stream::StaticString(TypedArenaPtr::new(ptr as *mut _))
@@ -527,7 +558,8 @@ impl Stream {
             Stream::StaticString(ptr) => ptr.header_ptr(),
             Stream::NamedTcp(ptr) => ptr.header_ptr(),
             Stream::NamedTls(ptr) => ptr.header_ptr(),
-            Stream::NamedHttpClient(ptr) => ptr.header_ptr(),
+            Stream::HttpRead(ptr) => ptr.header_ptr(),
+	    Stream::HttpWrite(ptr) => ptr.header_ptr(),
             Stream::Null(_) => ptr::null(),
             Stream::Readline(ptr) => ptr.header_ptr(),
             Stream::StandardOutput(ptr) => ptr.header_ptr(),
@@ -543,7 +575,8 @@ impl Stream {
             Stream::StaticString(ref ptr) => &ptr.options,
             Stream::NamedTcp(ref ptr) => &ptr.options,
             Stream::NamedTls(ref ptr) => &ptr.options,
-            Stream::NamedHttpClient(ref ptr) => &ptr.options,
+            Stream::HttpRead(ref ptr) => &ptr.options,
+	    Stream::HttpWrite(ref ptr) => &ptr.options,
             Stream::Null(ref options) => options,
             Stream::Readline(ref ptr) => &ptr.options,
             Stream::StandardOutput(ref ptr) => &ptr.options,
@@ -559,7 +592,8 @@ impl Stream {
             Stream::StaticString(ref mut ptr) => &mut ptr.options,
             Stream::NamedTcp(ref mut ptr) => &mut ptr.options,
             Stream::NamedTls(ref mut ptr) => &mut ptr.options,
-            Stream::NamedHttpClient(ref mut ptr) => &mut ptr.options,
+            Stream::HttpRead(ref mut ptr) => &mut ptr.options,
+            Stream::HttpWrite(ref mut ptr) => &mut ptr.options,	    
             Stream::Null(ref mut options) => options,
             Stream::Readline(ref mut ptr) => &mut ptr.options,
             Stream::StandardOutput(ref mut ptr) => &mut ptr.options,
@@ -576,7 +610,8 @@ impl Stream {
             Stream::StaticString(ptr) => ptr.lines_read += incr_num_lines_read,
             Stream::NamedTcp(ptr) => ptr.lines_read += incr_num_lines_read,
             Stream::NamedTls(ptr) => ptr.lines_read += incr_num_lines_read,
-            Stream::NamedHttpClient(ptr) => ptr.lines_read += incr_num_lines_read,
+            Stream::HttpRead(ptr) => ptr.lines_read += incr_num_lines_read,
+            Stream::HttpWrite(_) => {}	 
             Stream::Null(_) => {}
             Stream::Readline(ptr) => ptr.lines_read += incr_num_lines_read,
             Stream::StandardOutput(ptr) => ptr.lines_read += incr_num_lines_read,
@@ -593,7 +628,8 @@ impl Stream {
             Stream::StaticString(ptr) => ptr.lines_read = value,
             Stream::NamedTcp(ptr) => ptr.lines_read = value,
             Stream::NamedTls(ptr) => ptr.lines_read = value,
-            Stream::NamedHttpClient(ptr) => ptr.lines_read = value,
+            Stream::HttpRead(ptr) => ptr.lines_read = value,
+            Stream::HttpWrite(_) => {}	    
             Stream::Null(_) => {}
             Stream::Readline(ptr) => ptr.lines_read = value,
             Stream::StandardOutput(ptr) => ptr.lines_read = value,
@@ -610,7 +646,8 @@ impl Stream {
             Stream::StaticString(ptr) => ptr.lines_read,
             Stream::NamedTcp(ptr) => ptr.lines_read,
             Stream::NamedTls(ptr) => ptr.lines_read,
-            Stream::NamedHttpClient(ptr) => ptr.lines_read,
+            Stream::HttpRead(ptr) => ptr.lines_read,
+            Stream::HttpWrite(_) => 0,	  
             Stream::Null(_) => 0,
             Stream::Readline(ptr) => ptr.lines_read,
             Stream::StandardOutput(ptr) => ptr.lines_read,
@@ -625,13 +662,14 @@ impl CharRead for Stream {
             Stream::InputFile(file) => (*file).peek_char(),
             Stream::NamedTcp(tcp_stream) => (*tcp_stream).peek_char(),
             Stream::NamedTls(tls_stream) => (*tls_stream).peek_char(),
-            Stream::NamedHttpClient(http_stream) => (*http_stream).peek_char(),
+            Stream::HttpRead(http_stream) => (*http_stream).peek_char(),
             Stream::Readline(rl_stream) => (*rl_stream).peek_char(),
             Stream::StaticString(src) => (*src).peek_char(),
             Stream::Byte(cursor) => (*cursor).peek_char(),
             Stream::OutputFile(_) |
             Stream::StandardError(_) |
             Stream::StandardOutput(_) |
+	    Stream::HttpWrite(_) |
             Stream::Null(_) => Some(Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::ReadFromOutputStream,
@@ -644,13 +682,14 @@ impl CharRead for Stream {
             Stream::InputFile(file) => (*file).read_char(),
             Stream::NamedTcp(tcp_stream) => (*tcp_stream).read_char(),
             Stream::NamedTls(tls_stream) => (*tls_stream).read_char(),
-            Stream::NamedHttpClient(http_stream) => (*http_stream).read_char(),
+            Stream::HttpRead(http_stream) => (*http_stream).read_char(),
             Stream::Readline(rl_stream) => (*rl_stream).read_char(),
             Stream::StaticString(src) => (*src).read_char(),
             Stream::Byte(cursor) => (*cursor).read_char(),
             Stream::OutputFile(_) |
             Stream::StandardError(_) |
             Stream::StandardOutput(_) |
+	    Stream::HttpWrite(_) |
             Stream::Null(_) => Some(Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::ReadFromOutputStream,
@@ -663,13 +702,14 @@ impl CharRead for Stream {
             Stream::InputFile(file) => file.put_back_char(c),
             Stream::NamedTcp(tcp_stream) => tcp_stream.put_back_char(c),
             Stream::NamedTls(tls_stream) => tls_stream.put_back_char(c),
-            Stream::NamedHttpClient(http_stream) => http_stream.put_back_char(c),
+            Stream::HttpRead(http_stream) => http_stream.put_back_char(c),
             Stream::Readline(rl_stream) => rl_stream.put_back_char(c),
             Stream::StaticString(src) => src.put_back_char(c),
             Stream::Byte(cursor) => cursor.put_back_char(c),
             Stream::OutputFile(_) |
             Stream::StandardError(_) |
             Stream::StandardOutput(_) |
+	    Stream::HttpWrite(_) |
             Stream::Null(_) => {}
         }
     }
@@ -679,13 +719,14 @@ impl CharRead for Stream {
             Stream::InputFile(ref mut file) => file.consume(nread),
             Stream::NamedTcp(ref mut tcp_stream) => tcp_stream.consume(nread),
             Stream::NamedTls(ref mut tls_stream) => tls_stream.consume(nread),
-            Stream::NamedHttpClient(ref mut http_stream) => http_stream.consume(nread),
+            Stream::HttpRead(ref mut http_stream) => http_stream.consume(nread),
             Stream::Readline(ref mut rl_stream) => rl_stream.consume(nread),
             Stream::StaticString(ref mut src) => src.consume(nread),
             Stream::Byte(ref mut cursor) => cursor.consume(nread),
             Stream::OutputFile(_) |
             Stream::StandardError(_) |
             Stream::StandardOutput(_) |
+	    Stream::HttpWrite(_) |
             Stream::Null(_) => {}
         }
     }
@@ -698,13 +739,14 @@ impl Read for Stream {
             Stream::InputFile(file) => (*file).read(buf),
             Stream::NamedTcp(tcp_stream) => (*tcp_stream).read(buf),
             Stream::NamedTls(tls_stream) => (*tls_stream).read(buf),
-            Stream::NamedHttpClient(http_stream) => (*http_stream).read(buf),
+            Stream::HttpRead(http_stream) => (*http_stream).read(buf),
             Stream::Readline(rl_stream) => (*rl_stream).read(buf),
             Stream::StaticString(src) => (*src).read(buf),
             Stream::Byte(cursor) => (*cursor).read(buf),
             Stream::OutputFile(_)
             | Stream::StandardError(_)
-            | Stream::StandardOutput(_)
+	    | Stream::StandardOutput(_)
+	    | Stream::HttpWrite(_)
             | Stream::Null(_) => Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::ReadFromOutputStream,
@@ -724,7 +766,8 @@ impl Write for Stream {
             Stream::Byte(ref mut cursor) => cursor.get_mut().write(buf),
             Stream::StandardOutput(stream) => stream.write(buf),
             Stream::StandardError(stream) => stream.write(buf),
-            Stream::NamedHttpClient(_) |
+	    Stream::HttpWrite(ref mut stream) => stream.get_mut().write(buf),
+            Stream::HttpRead(_) |
             Stream::StaticString(_) |
             Stream::Readline(_) |
             Stream::InputFile(..) |
@@ -743,7 +786,8 @@ impl Write for Stream {
             Stream::Byte(ref mut cursor) => cursor.stream.get_mut().flush(),
             Stream::StandardError(stream) => stream.stream.flush(),
             Stream::StandardOutput(stream) => stream.stream.flush(),
-            Stream::NamedHttpClient(_) |
+	    Stream::HttpWrite(ref mut stream) => stream.stream.get_mut().flush(),
+            Stream::HttpRead(_) |
             Stream::StaticString(_) |
             Stream::Readline(_) |
             Stream::InputFile(_) |
@@ -868,7 +912,8 @@ impl Stream {
             Stream::StaticString(stream) => stream.past_end_of_stream,
             Stream::NamedTcp(stream) => stream.past_end_of_stream,
             Stream::NamedTls(stream) => stream.past_end_of_stream,
-            Stream::NamedHttpClient(stream) => stream.past_end_of_stream,
+            Stream::HttpRead(stream) => stream.past_end_of_stream,
+            Stream::HttpWrite(stream) => stream.past_end_of_stream,	    
             Stream::Null(_) => false,
             Stream::Readline(stream) => stream.past_end_of_stream,
             Stream::StandardOutput(stream) => stream.past_end_of_stream,
@@ -890,7 +935,8 @@ impl Stream {
             Stream::StaticString(stream) => stream.past_end_of_stream = value,
             Stream::NamedTcp(stream) => stream.past_end_of_stream = value,
             Stream::NamedTls(stream) => stream.past_end_of_stream = value,
-            Stream::NamedHttpClient(stream) => stream.past_end_of_stream = value,
+            Stream::HttpRead(stream) => stream.past_end_of_stream = value,
+            Stream::HttpWrite(stream) => stream.past_end_of_stream = value,	    
             Stream::Null(_) => {}
             Stream::Readline(stream) => stream.past_end_of_stream = value,
             Stream::StandardOutput(stream) => stream.past_end_of_stream = value,
@@ -956,11 +1002,11 @@ impl Stream {
             Stream::Byte(_)
             | Stream::Readline(_)
             | Stream::StaticString(_)
-            | Stream::NamedHttpClient(_)
+            | Stream::HttpRead(_)
             | Stream::InputFile(..) => atom!("read"),
             Stream::NamedTcp(..) | Stream::NamedTls(..) => atom!("read_append"),
             Stream::OutputFile(file) if file.is_append => atom!("append"),
-            Stream::OutputFile(_) | Stream::StandardError(_) | Stream::StandardOutput(_) => atom!("write"),
+            Stream::OutputFile(_) | Stream::StandardError(_) | Stream::StandardOutput(_) | Stream::HttpWrite(_) => atom!("write"),
             Stream::Null(_) => atom!(""),
         }
     }
@@ -1020,13 +1066,26 @@ impl Stream {
         http_stream: Box<dyn BufRead>,
         arena: &mut Arena,
     ) -> Self {
-        Stream::NamedHttpClient(arena_alloc!(
-            StreamLayout::new(CharReader::new(NamedHttpClientStream {
+        Stream::HttpRead(arena_alloc!(
+            StreamLayout::new(CharReader::new(HttpReadStream {
                 url,
                 body_reader: http_stream
             })),
             arena
         ))
+    }
+
+    #[inline]
+    pub(crate) fn from_http_sender(
+	body_writer: Sender,
+	arena: &mut Arena,
+    ) -> Self {
+	Stream::HttpWrite(arena_alloc!(
+	    StreamLayout::new(CharReader::new(HttpWriteStream {
+		body_writer
+	    })),
+	    arena
+	))
     }
 
     #[inline]
@@ -1065,7 +1124,7 @@ impl Stream {
             Stream::NamedTls(ref mut tls_stream) => {
                 tls_stream.inner_mut().tls_stream.shutdown()
             }
-            Stream::NamedHttpClient(ref mut http_stream) => {
+            Stream::HttpRead(ref mut http_stream) => {
                 unsafe {
                     http_stream.set_tag(ArenaHeaderTag::Dropped);
                     std::ptr::drop_in_place(&mut http_stream.inner_mut().body_reader as *mut _);
@@ -1073,6 +1132,14 @@ impl Stream {
 
                 Ok(())
             }
+	    Stream::HttpWrite(ref mut http_stream) => {
+                unsafe {
+                    http_stream.set_tag(ArenaHeaderTag::Dropped);
+                    std::ptr::drop_in_place(&mut http_stream.inner_mut().body_writer as *mut _);
+                }
+
+                Ok(())
+	    }
             Stream::InputFile(mut file_stream) => {
                 // close the stream by dropping the inner File.
                 unsafe {
@@ -1109,7 +1176,7 @@ impl Stream {
         match self {
             Stream::NamedTcp(..)
             | Stream::NamedTls(..)
-            | Stream::NamedHttpClient(..)
+            | Stream::HttpRead(..)
             | Stream::Byte(_)
             | Stream::Readline(_)
             | Stream::StaticString(_)
@@ -1124,7 +1191,8 @@ impl Stream {
             Stream::StandardError(_)
             | Stream::StandardOutput(_)
             | Stream::NamedTcp(..)
-            | Stream::NamedTls(..)
+	    | Stream::NamedTls(..)
+	    | Stream::HttpWrite(..)	
             | Stream::Byte(_)
             | Stream::OutputFile(..) => true,
             _ => false,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -272,6 +272,20 @@ macro_rules! match_untyped_arena_ptr_pat_body {
         #[allow(unused_braces)]
         $code
     }};
+    ($ptr:ident, HttpListener, $listener:ident, $code:expr) => {{
+        let payload_ptr = unsafe { std::mem::transmute::<_, *mut HttpListener>($ptr.payload_offset()) };
+        #[allow(unused_mut)]
+        let mut $listener = TypedArenaPtr::new(payload_ptr);
+        #[allow(unused_braces)]
+        $code
+    }};
+    ($ptr:ident, HttpResponse, $listener:ident, $code:expr) => {{
+        let payload_ptr = unsafe { std::mem::transmute::<_, *mut HttpResponse>($ptr.payload_offset()) };
+        #[allow(unused_mut)]
+        let mut $listener = TypedArenaPtr::new(payload_ptr);
+        #[allow(unused_braces)]
+        $code
+    }};
     ($ptr:ident, IndexPtr, $ip:ident, $code:expr) => {{
         #[allow(unused_mut)]
         let mut $ip = TypedArenaPtr::new(unsafe { std::mem::transmute::<_, *mut IndexPtr>($ptr.get_ptr()) });
@@ -291,7 +305,8 @@ macro_rules! match_untyped_arena_ptr_pat {
             | ArenaHeaderTag::OutputFileStream
             | ArenaHeaderTag::NamedTcpStream
             | ArenaHeaderTag::NamedTlsStream
-            | ArenaHeaderTag::NamedHttpClientStream
+            | ArenaHeaderTag::HttpReadStream
+	    | ArenaHeaderTag::HttpWriteStream
             | ArenaHeaderTag::ReadlineStream
             | ArenaHeaderTag::StaticStringStream
             | ArenaHeaderTag::ByteStream


### PR DESCRIPTION
This is the updated version of `library(http/http_server)`. It doesn't add any new feature on the API side (which keeps compatibility) but uses a completely different approach under the hood, by using the Hyper library (same as `library(http/http_open)`.

For a test, I share you my testing file:
```prolog
:- use_module(library(http/http_server)).
:- use_module(library(lists)).
:- use_module(library(dcgs)).
:- use_module(library(format)).

text_handler(Request, Response) :-
    http_status_code(Response, 200),
    http_body(Response, text("Welcome to Scryer Prolog!")).

sample_handler(Request, Response) :-
    http_headers(Request, Headers),
    member("user-agent"-UserAgent, Headers),
    http_body(Response, text(UserAgent)).

sample_body_handler(Request, Response) :-
    http_body(Request, bytes(Body)),
    http_body(Response, bytes(Body)),
    http_headers(Response, ["content-type"-"application/json"]).

text_echo_handler(Request, Response) :-
    http_body(Request, text(TextBody)),
    http_body(Response, text(TextBody)).

parameter_handler(User, Request, Response) :-
    http_body(Response, text(User)).

redirect(Request, Response) :-
    http_redirect(Response, "/").

search(Request, Response) :-
    http_query(Request, "q", SearchTerm),
    phrase(format_("Search term: ~s", [SearchTerm]), ResponseText),
    http_body(Response, text(ResponseText)).

file(Request, Response) :-
    http_body(Response, file("comuneros.jpg")).

form(Request, Response) :-
    http_body(Request, form(Form)),
    member("key2"-Value, Form),
    http_body(Response, text(Value)).

not_found(NotFound, Request, Response) :-
    http_status_code(Response, 404),
    phrase(format_("URL not found: ~s", [NotFound]), ResponseText),
    http_body(Response, text(ResponseText)).

run :-
    http_listen(7890, [
        get(/, text_handler),
        get('user-agent', sample_handler),
        post(echo, sample_body_handler),
        post('echo-text', text_echo_handler),
        get(user/User, parameter_handler(User)),
        get(redirectme, redirect),
        get(search, search),
        get(file, file),
        post(form, form),
        get(NotFound, not_found(NotFound))
    ]).
```
Some details may need some work later, like managing Ctrl-C (does it after a new request arrives) and a random crash that I'm not able to reproduce.
Also, the speed of the file and echo (with an image) endpoints is very slow. It may be worth to investigate why (more +16s for 158kb).

https://user-images.githubusercontent.com/3681517/184218594-7a3edfdb-b518-4361-9c03-797928630586.mp4

