### PR TITLE
ENHANCED: Use '$skip_max_list'/4 for greater efficiency of nth0/3.

### DIFF
--- a/src/lib/lists.pl
+++ b/src/lib/lists.pl
@@ -247,15 +247,9 @@ nth0(N, Es, E) :-
         can_be(integer, N),
         can_be(list, Es),
         (   integer(N) ->
-            nth0_index(N, Es, E)
+            '$skip_max_list'(N, N, Es, [E|_])
         ;   nth0_search(N, Es, E)
         ).
-
-nth0_index(0, [E|_], E) :- !.
-nth0_index(N, [_|Es], E) :-
-        N > 0,
-        N1 is N - 1,
-        nth0_index(N1, Es, E).
 
 nth0_search(N, Es, E) :-
         nth0_search(0, N, Es, E).


### PR DESCRIPTION
This is now possible due to 4c7e2eb8614da9c04f2286f6116b468017fb442c.

See #1529 for the suggestion by @UWN.

<s>**Warning**: *This does not yet work.* Which the patch applied, I get:

<pre>
<b>$ scryer-prolog</b>
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: CompilationError(ParserError(IncompleteReduction(252, 0)))', src/machine/mod.rs:500:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
</pre></s>

**Update**: This works as intended now. Example:

<pre>
<b>?- nth0(3, "abcdefg", E).</b>
   E = d.
</pre>