### PR TITLE
New types for library(error): octet_character, octet_chars

### DIFF
--- a/src/lib/charsio.pl
+++ b/src/lib/charsio.pl
@@ -251,7 +251,7 @@ chars_base64(Cs, Bs, Options) :-
             '$chars_base64'(Cs, Bs, Padding, Charset)
         ;   must_be(chars, Cs),
             (   '$first_non_octet'(Cs, N) ->
-                domain_error(byte_char, N, chars_base64/3)
+                domain_error(octet_character, N, chars_base64/3)
             ;   '$chars_base64'(Cs, Bs, Padding, Charset)
             )
         ).

--- a/src/lib/crypto.pl
+++ b/src/lib/crypto.pl
@@ -104,10 +104,10 @@ must_be_bytes(Bytes, Context) :-
         ).
 
 
-must_be_byte_chars(Chars, Context) :-
+must_be_octet_chars(Chars, Context) :-
         must_be(chars, Chars),
         (   '$first_non_octet'(Chars, F) ->
-            domain_error(byte_char, F, Context)
+            domain_error(octet_character, F, Context)
         ;   true
         ).
 
@@ -611,7 +611,7 @@ encoding_chars(octet, Bs, Cs) :-
             maplist(char_code, Cs, Bs)
         ;   Bs = Cs
         ),
-        must_be_byte_chars(Cs, crypto_encoding).
+        must_be_octet_chars(Cs, crypto_encoding).
 encoding_chars(utf8, Cs, Cs) :-
         must_be(chars, Cs).
 
@@ -652,17 +652,17 @@ ed25519_new_keypair(Pair) :-
         '$ed25519_new_keypair'(Pair).
 
 ed25519_keypair_public_key(Pair, PublicKey) :-
-        must_be_byte_chars(Pair, ed25519_keypair_public_key),
+        must_be_octet_chars(Pair, ed25519_keypair_public_key),
         '$ed25519_keypair_public_key'(Pair, PublicKey).
 
 ed25519_sign(Key, Data0, Signature, Options) :-
-        must_be_byte_chars(Key, ed25519_sign),
+        must_be_octet_chars(Key, ed25519_sign),
         options_data_chars(Options, Data0, Data, Encoding),
         '$ed25519_sign'(Key, Data, Encoding, Signature0),
         hex_bytes(Signature, Signature0).
 
 ed25519_verify(Key, Data0, Signature0, Options) :-
-        must_be_byte_chars(Key, ed25519_verify),
+        must_be_octet_chars(Key, ed25519_verify),
         options_data_chars(Options, Data0, Data, Encoding),
         hex_bytes(Signature0, Signature),
         '$ed25519_verify'(Key, Data, Encoding, Signature).

--- a/src/lib/error.pl
+++ b/src/lib/error.pl
@@ -35,6 +35,8 @@
        - in_character
        - integer
        - list
+       - octet_character
+       - octet_chars
        - term
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
@@ -62,6 +64,17 @@ must_be_(chars, Ls) :-
             % because that library itself imports library(error).
             true
         ;   all_characters(Ls)
+        ).
+must_be_(octet_character, C) :-
+        must_be(character, C),
+        (   octet_character(C) -> true
+        ;   domain_error(octet_character, C, must_be/2)
+        ).
+must_be_(octet_chars, Cs) :-
+        must_be(chars, Cs),
+        (   '$first_non_octet'(Cs, C) ->
+            domain_error(octet_character, C, must_be/2)
+        ;   true
         ).
 must_be_(list, Term)    :- check_(error:ilist, list, Term).
 must_be_(type, Term)    :- check_(error:type, type, Term).
@@ -94,6 +107,10 @@ character(C) :-
         atom(C),
         atom_length(C, 1).
 
+octet_character(C) :-
+        char_code(C, Code),
+        0 =< Code, Code =< 0xff.
+
 in_character(C) :-
         (   character(C)
         ;   C == end_of_file
@@ -111,6 +128,8 @@ type(integer).
 type(atom).
 type(character).
 type(in_character).
+type(octet_character).
+type(octet_chars).
 type(chars).
 type(list).
 type(var).
@@ -146,6 +165,17 @@ can_(chars, Ls)     :-
         (   '$is_partial_string'(Ls) -> true
         ;   can_be(list, Ls),
             can_be_chars(Ls)
+        ).
+can_(octet_character, C) :-
+        (   octet_character(C) -> true
+        ;   domain_error(octet_character, C, can_be/2)
+        ).
+can_(octet_chars, Cs) :-
+        can_be(chars, Cs),
+        (   '$skip_max_list'(_, _, Cs, []), % temporarily turn Cs into a list
+            '$first_non_octet'(Cs, C) ->
+            domain_error(octet_character, C, can_be/2)
+        ;   true
         ).
 can_(list, Term)    :- list_or_partial_list(Term).
 can_(boolean, Term) :- boolean(Term).

--- a/src/lib/pio.pl
+++ b/src/lib/pio.pl
@@ -91,7 +91,7 @@ phrase_to_stream(GRBody, Stream) :-
         must_be(chars, Cs),
         (   stream_property(Stream, type(binary)) ->
             (   '$first_non_octet'(Cs, N) ->
-                domain_error(byte_char, N, phrase_to_stream/2)
+                domain_error(octet_character, N, phrase_to_stream/2)
             ;   true
             )
         ;   true


### PR DESCRIPTION
See https://github.com/mthom/scryer-prolog/discussions/1555 and https://github.com/mthom/scryer-prolog/issues/1309.