### PR TITLE
Adjust rust-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 keywords = ["prolog", "prolog-interpreter", "prolog-system"]
 categories = ["command-line-utilities"]
 build = "build/main.rs"
-rust-version = "1.57"
+rust-version = "1.61"
 
 [features]
 num = ["num-rug-adapter"]


### PR DESCRIPTION
I noticed that CI is failing because the version declared no longer actually works.
So this PR adjusts the declared rust-version to to the earliest working one.