### PR TITLE
Fix xor/2 type error reporting wrong argument

### DIFF
--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -793,7 +793,8 @@ pub(crate) fn xor(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
         (Number::Integer(_), n2) | (Number::Fixnum(_), n2) => {
             Err(numerical_type_error(ValidType::Integer, n2, stub_gen))
         }
-        _ => Err(numerical_type_error(ValidType::Integer, n2, stub_gen)),
+        (n1, Number::Integer(_)) => Err(numerical_type_error(ValidType::Integer, n1, stub_gen)),
+        _ => Err(numerical_type_error(ValidType::Integer, n1, stub_gen)),
     }
 }
 


### PR DESCRIPTION
If first argument n1 in xor/2 is of wrong numerical type, the match patterns fall through to a catch all case that reports the second argument in the type error.

Fixes #1626

`xor/2 function reports the wrong argument in type error #1626`

https://github.com/mthom/scryer-prolog/issues/1626