### PR TITLE
fix type_error with instantiated EOF -1 byte literal in get_byte/2

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -2432,6 +2432,12 @@ impl Machine {
             addr
         } else {
             match Number::try_from(addr) {
+                Ok(Number::Integer(ref n)) if **n == -1_i64 => {
+                    fixnum_as_cell!(Fixnum::build_with(-1))
+                }
+                Ok(Number::Fixnum(n)) if n.get_num() == -1_i64 => {
+                    fixnum_as_cell!(Fixnum::build_with(-1))
+                }
                 Ok(Number::Integer(n)) => {
                     if let Some(nb) = n.to_u8() {
                         fixnum_as_cell!(Fixnum::build_with(nb as i64))


### PR DESCRIPTION
According to ISO Prolog, get_byte/2 predicate can receive an instantiated input byte:

http://www.gprolog.org/manual/html_node/gprolog037.html#sec156

    get_byte(+stream_or_alias, ?in_byte)

Since in_byte can be -1 if EOF is reached, instantiating it with -1 should work but does not because the implementation is trying to convert it to a u8 which is unsigned:

?- open("/dev/null", read, S, [type(binary)]), get_byte(S, -1).
   error(type_error(in_byte,-1),get_byte/2).

This commit adds an extra check for -1 before checking for a valid u8 instantiated value if in_byte is an input:

?- open("/dev/null", read, S, [type(binary)]), get_byte(S, -1).
   S = '$stream'(0x55601e65c998).

Closes #1625