### PR TITLE
Adjust Github Action: Docker Publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,10 +2,10 @@ name: Docker Publish
 
 on:
   push:
-    tags: [ 'v*.*.*' ]
-
-env:
-  IMAGE_NAME: mjt128/scryer-prolog
+    branches: 
+      - 'master'
+    tags: 
+      - 'v*.*.*'
 
 jobs:
   build:
@@ -18,33 +18,36 @@ jobs:
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        # https://github.com/docker/setup-buildx-action
+        uses: docker/setup-buildx-action@v2.2.1
 
       # Login against Docker registry
-      # https://github.com/docker/login-action
       - name: Log into registry
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        # https://github.com/docker/login-action
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract Docker image tag from git tag. E.g. if git tag is "v0.19.1" then use 
-      # Docker image tag "0.19.1". Tag "latest" is automatically synced with newest
-      # version.
-      # https://github.com/docker/metadata-action
+      # Docker image tag "0.19.1". The "latest" tag reflects the most recent build on
+      # master.
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        # https://github.com/docker/metadata-action
+        uses: docker/metadata-action@v4.1.1
         with:
-          images: docker.io/${{ env.IMAGE_NAME }}
+          images: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/scryer-prolog
           tags: |
             type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            # type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
 
       # Build and push Docker image with Buildx
-      # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        # https://github.com/docker/build-push-action
+        uses: docker/build-push-action@v3.2.0
         with:
           context: .
           push: true


### PR DESCRIPTION
I adjusted the docker-publish job to run on every push to master and update the `latest` tag Docker Hub. As before, all pushed git tags should also trigger the job and publish Docker images tagged with the corresponding version. I tested this on my fork and there it worked:

* [job triggered by push to master](https://github.com/gruhn/scryer-prolog/actions/runs/3472917386) and [resulting docker image](https://hub.docker.com/layers/gruhn/scryer-prolog/latest/images/sha256-749e26f4e08d06da53e9ddd06350c8b67da119e245c00512731436bdd0f10cf7?context=repo)
* [job triggered by push of git tag](https://github.com/gruhn/scryer-prolog/actions/runs/3481417402) and [resulting docker image](https://hub.docker.com/layers/gruhn/scryer-prolog/0.0.12/images/sha256-1e28835dadc2c6ed6eb9d86dc91dde70c41ca22152a986d8cc927f4c20168605?context=repo)

Incidentally, I updated the various actions (setup-buildx-action, login-action, metadata-action, ...) because they were printing  deprecation warnings (see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).