### PR TITLE
Add lcm arithmetic function

### DIFF
--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -681,6 +681,8 @@ enum InstructionTemplate {
     Rem(ArithmeticTerm, ArithmeticTerm, usize),
     #[strum_discriminants(strum(props(Arity = "2", Name = "gcd")))]
     Gcd(ArithmeticTerm, ArithmeticTerm, usize),
+    #[strum_discriminants(strum(props(Arity = "2", Name = "lcm")))]
+    Lcm(ArithmeticTerm, ArithmeticTerm, usize),
     #[strum_discriminants(strum(props(Arity = "1", Name = "sign")))]
     Sign(ArithmeticTerm, usize),
     #[strum_discriminants(strum(props(Arity = "1", Name = "cos")))]
@@ -1349,6 +1351,9 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::Gcd(ref at_1, ref at_2, t) => {
                         arith_instr_bin_functor(h, atom!("gcd"), arena, at_1, at_2, t)
                     }
+		    &Instruction::Lcm(ref at_1, ref at_2, t) => {
+			arith_instr_bin_functor(h, atom!("lcm"), arena, at_1, at_2, t)
+		    }
                     &Instruction::Sign(ref at, t) => {
                         arith_instr_unary_functor(h, atom!("sign"), arena, at, t)
                     }

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -239,6 +239,7 @@ impl<'a> ArithmeticEvaluator<'a> {
             atom!("mod") => Ok(Instruction::Mod(a1, a2, t)),
             atom!("rem") => Ok(Instruction::Rem(a1, a2, t)),
             atom!("gcd") => Ok(Instruction::Gcd(a1, a2, t)),
+	    atom!("lcm") => Ok(Instruction::Lcm(a1, a2, t)),
             atom!("atan2") => Ok(Instruction::ATan2(a1, a2, t)),
             _ => Err(ArithmeticError::NonEvaluableFunctor(Literal::Atom(name), 2)),
         }

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -677,6 +677,17 @@ impl Machine {
 
                     self.machine_st.p += 1;
                 }
+		&Instruction::Lcm(ref a1, ref a2, t) => {
+		    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+		    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+		    self.machine_st.interms[t - 1] = try_or_throw_gen!(
+			&mut self.machine_st,
+			lcm(n1, n2, &mut self.machine_st.arena)
+		    );
+
+		    self.machine_st.p += 1;
+		}
                 &Instruction::Pow(ref a1, ref a2, t) => {
                     let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
                     let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));


### PR DESCRIPTION
This function is less used and can be defined with gcd (in fact internally, I use gcd too) but Haskell, SWI-Prolog, C++17 and Python >= 3.8, have it.

Please, merge if you think it's worth adding to Scryer