### PR TITLE
Fix failing Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/LukeMathWalker/cargo-chef
-ARG RUST_VERSION=1.61-buster
+ARG RUST_VERSION=1-buster
 FROM rust:${RUST_VERSION} as planner
 WORKDIR /scryer-prolog
 RUN cargo install cargo-chef 


### PR DESCRIPTION
Apparently [the Docker build is failing again](https://github.com/mthom/scryer-prolog/actions/runs/3916277566/jobs/6695250146). With the error:

> error[E0658]: use of unstable library feature 'scoped_threads'

I don't know what that means but [a guy on StackOverflow claims, that this issue does not occur with Rust 1.63 anymore](https://stackoverflow.com/questions/74692232/cargo-use-of-unstable-library-feature-scoped-threads). 

I set the Rust version in the Dockerfile to the latest minor release now (currently 1.66). When I test it locally the build succeeds again.