### PR TITLE
in projection of residual goals, mark considered propagators as processed

### DIFF
--- a/src/lib/clpb.pl
+++ b/src/lib/clpb.pl
@@ -211,7 +211,7 @@ Here is an example session with a few queries and their answers:
    T = 1, clpb:sat(X=:=X*Y), clpb:sat(Y=:=Y*Z).
 
 ?- sat(1#X#a#b).
-   sat(X=:=a#b).
+   clpb:sat(X=:=a#b).
 ```
 
 The pending residual goals constrain remaining variables to Boolean
@@ -348,7 +348,7 @@ does compute =|XOR|= as intended:
 
 ```
 ?- xor(x, y, Z).
-sat(Z=:=x#y).
+   clpb:sat(Z=:=x#y).
 ```
 
 ## Acknowledgments

--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -7711,7 +7711,7 @@ attributes_goals([]) --> [].
 attributes_goals([propagator(P, State)|As]) -->
         (   { ground(State) } -> []
         ;   { phrase(attribute_goal_(P), Gs) } ->
-            { % del_attr(State, clpz_aux), State = processed,
+            { del_attr(State, clpz_aux), State = processed,
               (   monotonic ->
                   maplist(unwrap_with(bare_integer), Gs, Gs1)
               ;   maplist(unwrap_with(=), Gs, Gs1)
@@ -7822,7 +7822,7 @@ conjunction(A, B, G, D) -->
 
 original_goal(original_goal(State, Goal)) -->
         (   { var(State) } ->
-%            { State = processed },
+            { State = processed },
             [Goal]
         ;   []
         ).


### PR DESCRIPTION
This is to avoid duplicated goals with the new projection mechanism.