### PR TITLE
ENHANCED: use call_residue_vars/2 to show all pending constraints

### DIFF
--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -1,6 +1,7 @@
 :- module('$toplevel', [argv/1,
                         copy_term/3]).
 
+:- use_module(library(atts), [call_residue_vars/2]).
 :- use_module(library(charsio)).
 :- use_module(library(error)).
 :- use_module(library(files)).
@@ -180,8 +181,8 @@ submit_query_and_print_results_(Term, VarList) :-
     '$get_b_value'(B),
     bb_put('$report_all', false),
     bb_put('$report_n_more', 0),
-    call(user:Term),
-    write_eqs_and_read_input(B, VarList),
+    atts:call_residue_vars(user:Term, AttrVars),
+    write_eqs_and_read_input(B, VarList, AttrVars),
     !.
 submit_query_and_print_results_(_, _) :-
     (   bb_get('$answer_count', 0) ->
@@ -286,11 +287,10 @@ trailing_period_is_ambiguous(Value) :-
 term_variables_under_max_depth(Term, MaxDepth, Vars) :-
     '$term_variables_under_max_depth'(Term, MaxDepth, Vars).
 
-write_eqs_and_read_input(B, VarList) :-
+write_eqs_and_read_input(B, VarList, AttrVars) :-
     gather_query_vars(VarList, OrigVars),
     % one layer of depth added for (=/2) functor
     '$term_variables_under_max_depth'(OrigVars, 22, Vars0),
-    '$term_attributed_variables'(VarList, AttrVars),
     '$project_atts':project_attributes(Vars0, AttrVars),
     copy_term(AttrVars, AttrVars, AttrGoals),
     term_variables(AttrGoals, AttrGoalVars),


### PR DESCRIPTION
Example:

    ?- freeze(_, false).
       freeze:freeze(_A,false).

This was originally added in 04ba9bc11af31780cd8fa259d78d151262c3c756, then reverted, and is now restored.