### PR TITLE
Smaller documentation improvements to explain compilation and target directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ $> cargo build --release
 The `--release` flag performs various optimizations, producing a
 faster executable.
 
+After compilation, the executable `scryer-prolog` is available in the
+directory&nbsp;`target/release` and can be invoked to run the system.
+
 On Windows, Scryer Prolog is easier to build inside a [MSYS2](https://www.msys2.org/)
 environment as some crates may require native C compilation. However, 
 the resulting binary does not need MSYS2 to run. When executing Scryer in a shell, it is recommended to use a more advanced shell than mintty (the default MSYS2 shell). The [Windows Terminal](https://github.com/microsoft/terminal) works correctly.

--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ can be done as follows:
 ```
 $> git clone https://github.com/mthom/scryer-prolog
 $> cd scryer-prolog
-$> cargo build [--release]
+$> cargo build --release
 ```
 
-The optional `--release` flag will perform various optimizations,
-producing a faster executable.
+The `--release` flag performs various optimizations, producing a
+faster executable.
 
 On Windows, Scryer Prolog is easier to build inside a [MSYS2](https://www.msys2.org/)
 environment as some crates may require native C compilation. However, 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Extend Scryer Prolog to include the following, among other features:
   - [x] Support for `attribute_goals/2` and `project_attributes/2`
   - [x] `call_residue_vars/2`
 - [x] `if_/3` and related predicates, following the developments of the
-      paper "Indexing `dif/2`".
+      paper "[Indexing `dif/2`](https://arxiv.org/abs/1607.01590)".
 - [x] All-solutions predicates (`findall/{3,4}`, `bagof/3`, `setof/3`, `forall/2`).
 - [x] Clause creation and destruction (`asserta/1`, `assertz/1`,
       `retract/1`, `abolish/1`) with logical update semantics.

--- a/README.md
+++ b/README.md
@@ -115,12 +115,13 @@ distribution should be uninstalled from your system before rustup is
 used.
 
 Currently the only way to install the latest version of Scryer is to
-clone directly from this git repository, which can be done as follows:
+clone directly from this git repository, and compile the system. This
+can be done as follows:
 
 ```
 $> git clone https://github.com/mthom/scryer-prolog
 $> cd scryer-prolog
-$> cargo run [--release]
+$> cargo build [--release]
 ```
 
 The optional `--release` flag will perform various optimizations,


### PR DESCRIPTION
This is motivated by a recent question on the `#scryer` IRC channel, "how can I run the scryer interpreter?", and, compellingly, "`scryer-prolog` is an unknown command".

In addition to explaining where the `scryer-prolog` executable is, this changes the documentation to use `cargo build` instead of `cargo run` so as to avoid unexpected invocation of the system, and decisively uses the `--release` flag so that the instructions can be used verbatim and the now documented path of the executable is correct.