### PR TITLE
Optimize Test GH action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,66 +6,68 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
-        rust-version: [stable, beta]
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust-version }}
-          override: true
-      - name: Build lib
-        uses: actions-rs/cargo@v1
-        with:
-          command: rustc
-          args: --verbose --lib -- -D warnings
-      - name: Build bin
-        uses: actions-rs/cargo@v1
-        with:
-          command: rustc
-          args: --verbose --bin scryer-prolog -- -D warnings
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all
-      - name: Num tests
-        uses: actions-rs/cargo@v1
-        continue-on-error: true
-        with:
-          command: test
-          args: --verbose --all --no-default-features --features num
-  msrv:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-10.15]
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install cargo-msrv
-        uses: baptiste0928/cargo-install@v1.1.0
-        with:
-          crate: cargo-msrv
-      - name: Verify MSRV
-        run: cargo msrv --verify
-  windows:
-    runs-on: windows-latest
+        include:
+          - { os: windows-latest, rust-version: stable,  shell: 'msys2 {0}' }
+          - { os: macos-10.15,    rust-version: stable,  shell: bash }
+          - { os: ubuntu-20.04,   rust-version: stable,  shell: bash }
+          - { os: ubuntu-20.04,   rust-version: 1.63,    shell: bash }
+          - { os: ubuntu-20.04,   rust-version: beta,    shell: bash }
+          - { os: ubuntu-20.04,   rust-version: nightly, shell: bash }
     defaults:
       run:
-        shell: msys2 {0}
+        shell: ${{ matrix.shell }}
+    outputs:
+      os: ${{ matrix.os }}
+      rust-version: ${{ matrix.rust-version }}
     steps:
-      - name: Setup MSYS2
-        uses: msys2/setup-msys2@v2
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        if: "!startsWith(matrix.os, 'windows')"
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.rust-version }}
+          components: clippy, rustfmt
+      - uses: msys2/setup-msys2@v2
+        if: startsWith(matrix.os,'windows')
         with:
           update: true
           install: >-
             base-devel
             mingw-w64-x86_64-rust
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      - name: Test on Windows
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.os }}_rustc-${{ steps.toolchain.outputs.cachekey }}_cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Build and test.
+      - name: Build library
+        run: cargo rustc --verbose --lib -- -D warnings
+      - name: Test
         run: cargo test --verbose --all
+
+      # Only run formatting & style check on one job to not spam warnings.
+      - name: Check formatting
+        if: startsWith(matrix.os,'ubuntu') && matrix.rust-version == 'stable'
+        run: cargo fmt --check || echo "::warning ::cargo fmt found some formatting changes that may improve readability"
+      - name: Check clippy
+        if: startsWith(matrix.os,'ubuntu') && matrix.rust-version == 'stable'
+        run: cargo clippy || echo "::warning ::cargo clippy found some code style changes that may be more idiomatic"
+
+      # On stable rust builds, build a binary and publish as a github actions
+      # artifact. These binaries could be useful for testing the pipeline but
+      # are only retained by github for 90 days.
+      # TODO: Check that they actually work.
+      - name: Build release binary
+        if: matrix.rust-version == 'stable'
+        run: cargo rustc --verbose --bin scryer-prolog --release -- -D warnings
+      - name: Publish artifact
+        if: matrix.rust-version == 'stable'
+        uses: actions/upload-artifact@v3
+        with:
+          path: target/release/scryer-prolog*
+          name: scryer-prolog_${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 keywords = ["prolog", "prolog-interpreter", "prolog-system"]
 categories = ["command-line-utilities"]
 build = "build/main.rs"
-rust-version = "1.61"
+rust-version = "1.63"
 
 [features]
 default = ["rug"]
@@ -41,7 +41,7 @@ libc = "0.2.62"
 modular-bitfield = "0.11.2"
 ctrlc = "3.2.2"
 ordered-float = "2.6.0"
-phf = { version = "0.9",  features = ["macros"] }
+phf = { version = "0.9", features = ["macros"] }
 ref_thread_local = "0.0.0"
 rug = { version = "1.15.0", optional = true }
 rustyline = "9.0.0"
@@ -49,7 +49,7 @@ ring = "0.16.13"
 ripemd160 = "0.8.0"
 sha3 = "0.8.2"
 blake2 = "0.8.1"
-crrl ="0.2.0"
+crrl = "0.2.0"
 native-tls = "0.2.4"
 chrono = "0.4.11"
 select = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Extend Scryer Prolog to include the following, among other features:
       characters, using a packed internal representation.
 - [x] clp(B) and clp(ℤ) as builtin libraries.
 - [x] Streams and predicates for stream control.
-  - [x] A simple sockets library representing TCP connections as streams.  
+  - [x] A simple sockets library representing TCP connections as streams.
 - [x] Incremental compilation and loading process, newly written,
       primarily in Prolog.
 - [ ] Improvements to the WAM compiler and heap representation:
@@ -131,7 +131,7 @@ After compilation, the executable `scryer-prolog` is available in the
 directory&nbsp;`target/release` and can be invoked to run the system.
 
 On Windows, Scryer Prolog is easier to build inside a [MSYS2](https://www.msys2.org/)
-environment as some crates may require native C compilation. However, 
+environment as some crates may require native C compilation. However,
 the resulting binary does not need MSYS2 to run. When executing Scryer in a shell, it is recommended to use a more advanced shell than mintty (the default MSYS2 shell). The [Windows Terminal](https://github.com/microsoft/terminal) works correctly.
 
 To build a Windows Installer, you'll need first Scryer Prolog compiled in release mode, then, with WiX Toolset installed, execute:
@@ -141,7 +141,7 @@ light.exe scryer-prolog.wixobj
 ```
 It will generate a very basic MSI file which installs the main executable and a shortcut in the Start Menu. It can be installed with a double-click. To uninstall, go to the Control Panel and uninstall as usual.
 
-Scryer Prolog must be built with **Rust 1.61 and up**.
+Scryer Prolog must be built with **Rust 1.63 and up**.
 
 ### Docker Install
 

--- a/scryer-prolog.wxs
+++ b/scryer-prolog.wxs
@@ -4,7 +4,6 @@
     <Package Description="An open source industrial strength production environment for ISO Prolog that is also a testbed for bleeding edge research in logic and constraint programming, which is itself written in a high-level language." Platform="x64" Keywords="prolog" Id="*" Compressed="yes" InstallScope="perMachine" InstallerVersion="300" Languages="1033" SummaryCodepage="1252" Manufacturer="Scryer Prolog contributors"/>
     <Property Id="APPHELPLINK" Value="https://github.com/mthom/scryer-prolog"/>
     <Media Id="1" Cabinet="scryer.cab" EmbedCab="yes" />
-    
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFilesFolder" Name="PFiles">
         <Directory Id="INSTALLDIR" Name="Scryer Prolog">
@@ -14,18 +13,16 @@
         </Directory>
       </Directory>
       <Directory Id="ProgramMenuFolder">
-	<Component Id="ApplicationShortcut" Guid="8c9b14a3-e7b1-4d30-a892-61d7371dcae2">
+        <Component Id="ApplicationShortcut" Guid="8c9b14a3-e7b1-4d30-a892-61d7371dcae2">
           <Shortcut Id="ApplicationStarMenuShortcut" Name="Scryer Prolog" Description="Launch Scryer Prolog" Target="[#ScryerPrologEXE]" WorkingDirectory="INSTALLDIR"/>
-	  <RemoveFolder Id="ApplicationShortcut" On="uninstall"/>
-	  <RegistryValue Root="HKCU" Key="Software\Microsoft\ScryerProlog" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
-	</Component>
+          <RemoveFolder Id="ApplicationShortcut" On="uninstall"/>
+          <RegistryValue Root="HKCU" Key="Software\Microsoft\ScryerProlog" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+        </Component>
       </Directory>
     </Directory>
-
     <Feature Id="Complete" Level="1" Display="expand" ConfigurableDirectory="INSTALLDIR">
       <ComponentRef Id="MainExecutable"/>
       <ComponentRef Id="ApplicationShortcut"/>
     </Feature>
   </Product>
 </Wix>
-  


### PR DESCRIPTION
Hi! I was inspired to make improvements to the build/Test action, so here's a PR with the results.

The overall theme is reducing typical build and test times so contributors can iterate on PRs faster, and adding some nice-to-have build pipeline features like linting and publishing temporary build artifacts.

* Use `actions/cache@v3` action to cache builds of dependencies between runs to improve build times.
  * This means that the first build result is back in 2:40 (down from 12:00), the full job is completed in 16:00 (down from 25:00), and total 'vm time' is reduced from 1:45:00 to 40:00.
  * The cache is keyed off of `os + rustc version + cargo.lock contents`, so it should be invalidated correctly.
  * That said there is still a risk of cache issues. It's pretty easy to clear the cache though, just click to delete on this page: https://github.com/infogulch/scryer-prolog/actions/caches
  * If the cache misses (first build; new rustc; updated version; etc) then the build takes about 40 minutes. 
* Unify all platform targets into a single job matrix (including windows)
  * Windows uses a different rust toolchain installer; the correct installer for a platform is selected with step conditions (`if: ...`)
  * This works by setting `shell` as a matrix field and using that to set `defaults: run: shell:`
* Fix MSRV check, and bump MSRV to 1.63.
  * Apparently the previous github action was not working and failed to warn about dependencies that require NLL introduced in 1.63.
  * This fix removes the `cargo-msrv` tool (which did not work) and instead makes the MSRV just another platform target. This guarantees that the selected compiler version can still compile the code by actually compiling the code with that version.
* Adjust platform matrix to reduce redundancy and include nightly.
  * Build and test rust stable on all platforms
  * In addition, test 1.63 (MSRV), beta, and nightly on ubuntu.
  * I think this is a good tradeoff between validating that scryer still builds across rust versions without totally exploding the matrix. But that's just, like, my opinion, man.
  * While github actions do not have limits on job runtime for public projects, it does have a 10GB limit for caches which range from 0.2-1GB per platform target for scryer, which is another reason to reduce the width of the platform matrix a bit.
  * There's not really a nice way to declare this matrix in the 'usual' way (especially in combination with the shell workaround), so to me it looks nicer to just list every target platform explicitly. It's a *little* bit repetitive, but very clear.
* Add cargo fmt and clippy steps
  * This only runs on one of the jobs in the matrix so the warnings are only emitted once
  * These steps may print warnings, but do not fail the build
* Build a release binary on every platform, and publish it as a release artifact
  * Github release artifacts are temporary build outputs listed on the build that expire in 90 days
  * They are suitable for debugging the pipeline and quickly iterating on platforms that you don't have a good local dev setup for.
  * Note, the build time improvement mentioned above *includes* this additional step of building a release binary, and it's still 2-4x faster.

You can see example build runs on my fork where I've been testing these changes: https://github.com/infogulch/scryer-prolog/actions/workflows/test.yml The latest run: https://github.com/infogulch/scryer-prolog/actions/runs/4587475203 An uncached (partially successful) run: https://github.com/infogulch/scryer-prolog/actions/runs/4586639265
