### PR TITLE
Add iso prolog / logtalk tests to test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Test
         run: cargo test --verbose --all
 
-      # Only run formatting & style check on one job to not spam warnings.
+      # Run code formatting and style checks on one job to not spam warnings.
       - name: Check formatting
         if: startsWith(matrix.os,'ubuntu') && matrix.rust-version == 'stable'
         run: cargo fmt --check || echo "::warning ::cargo fmt found some formatting changes that may improve readability"
@@ -61,10 +61,26 @@ jobs:
       # TODO: Check that they actually work.
       - name: Build release binary
         if: matrix.rust-version == 'stable'
-        run: cargo rustc --verbose --bin scryer-prolog --release -- -D warnings
+        run: |
+          cargo rustc --verbose --bin scryer-prolog --release -- -D warnings
+          echo "$PWD/target/release" >> $GITHUB_PATH
       - name: Publish artifact
         if: matrix.rust-version == 'stable'
         uses: actions/upload-artifact@v3
         with:
           path: target/release/scryer-prolog*
           name: scryer-prolog_${{ matrix.os }}
+
+      # Run iso compliance tests.
+      - name: Install Logtalk
+        if: startsWith(matrix.os,'ubuntu') && matrix.rust-version == 'stable'
+        uses: logtalk-actions/setup-logtalk@master
+        with:
+          logtalk-version: git
+          logtalk-tool-dependencies: false
+      - name: Run compliance test suite
+        if: startsWith(matrix.os,'ubuntu') && matrix.rust-version == 'stable'
+        working-directory: /home/runner/logtalk/tests/prolog
+        run: |
+          scryer-prolog -v
+          logtalk_tester -p scryer -g "set_logtalk_flag(clean,off)" -w -t 360

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         include:
           - { os: windows-latest, rust-version: stable,  shell: 'msys2 {0}' }
-          - { os: macos-10.15,    rust-version: stable,  shell: bash }
+          - { os: macos-11,       rust-version: stable,  shell: bash }
           - { os: ubuntu-20.04,   rust-version: stable,  shell: bash }
           - { os: ubuntu-20.04,   rust-version: 1.63,    shell: bash }
           - { os: ubuntu-20.04,   rust-version: beta,    shell: bash }
@@ -16,9 +16,6 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.shell }}
-    outputs:
-      os: ${{ matrix.os }}
-      rust-version: ${{ matrix.rust-version }}
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -56,7 +53,7 @@ jobs:
         run: cargo fmt --check || echo "::warning ::cargo fmt found some formatting changes that may improve readability"
       - name: Check clippy
         if: startsWith(matrix.os,'ubuntu') && matrix.rust-version == 'stable'
-        run: cargo clippy || echo "::warning ::cargo clippy found some code style changes that may be more idiomatic"
+        run: cargo clippy --no-deps || echo "::warning ::cargo clippy found some code style changes that may be more idiomatic"
 
       # On stable rust builds, build a binary and publish as a github actions
       # artifact. These binaries could be useful for testing the pipeline but

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
           logtalk-tool-dependencies: false
       - name: Run compliance test suite
         if: startsWith(matrix.os,'ubuntu') && matrix.rust-version == 'stable'
+        continue-on-error: true
         working-directory: /home/runner/logtalk/tests/prolog
         run: |
           scryer-prolog -v


### PR DESCRIPTION
Based on discussion #996, installs @pmoura's logtalk3 and runs the prolog tests at the end of the `build (ubuntu-20.04, stable, bash)` job. Hopefully this would highlight changes that reduce iso compatibility before they cause a regression.

Other changes:
* switch to macos-11 image, the macos-10.15 is officially deprecated by github actions
* Misc cleanup

Here is an example run: https://github.com/infogulch/scryer-prolog/actions/runs/4591169519/jobs/8107155034

This increases the runtime of the selected job by 11 minutes, but since it runs in parallel with other jobs it doesn't change the overall walltime of the workflow. I think this is worth it.