### PR TITLE
FIXED: propagation for ground tuples

### DIFF
--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -4369,7 +4369,7 @@ tuple_domain([T|Ts], Relation0) -->
         tuple_domain(Ts, Relation1).
 
 tuple_freeze(Tuple, Relation) :-
-        (   ground(Tuple) -> true
+        (   ground(Tuple) -> memberchk(Tuple, Relation)
         ;   put_attr(R, clpz_relation, Relation),
             make_propagator(rel_tuple(R, Tuple), Prop),
             tuple_freeze_(Tuple, Prop)


### PR DESCRIPTION
Example:

    ?- tuples_in([[A,A]],[[0,1],[2,0]]).
       false.

See https://github.com/triska/clpz/issues/22.