### PR TITLE
Change ref for `publish-unit-test-result-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           path: cargo_test_results.xml
       - name: Publish cargo test summary
         if: matrix.extra
-        uses: EnricoMi/publish-unit-test-result-action/composite@branch-publish-summary-on-fork
+        uses: EnricoMi/publish-unit-test-result-action/composite@master
         with:
           check_name: Cargo test summary
           files: cargo_test_results.xml
@@ -133,7 +133,7 @@ jobs:
           name: logtalk-test-results
           path: '${{ env.LOGTALKUSER }}/tests/prolog/**/*.xml'
       - name: Publish Logtalk test summary
-        uses: EnricoMi/publish-unit-test-result-action/composite@branch-publish-summary-on-fork
+        uses: EnricoMi/publish-unit-test-result-action/composite@master
         with:
           check_name: Logtalk test summary
           files: '${{ env.LOGTALKUSER }}/tests/prolog/**/*.xml'


### PR DESCRIPTION
I worked with the author of the `publish-unit-test-result-action` to deliver an enhancement that makes it work better for the scryer-prolog project, but I forgot to scrub the testing branch reference out of the action before it was merged. This is the cause of some of the [recent PR builds failing](https://github.com/mthom/scryer-prolog/actions/runs/4771903258/jobs/8484131136?pr=1792#logs):

> Error: Unable to resolve action `EnricoMi/publish-unit-test-result-action@branch-publish-summary-on-fork`, unable to find version `branch-publish-summary-on-fork`

This changes it to use the master branch again. Sorry!