### PR TITLE
Use --force to install cargo2junit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Test and report
         if: matrix.extra
         run: |
-          cargo install cargo2junit
+          cargo install cargo2junit --force
           cargo test --all -- -Z unstable-options --format json --report-time | cargo2junit > cargo_test_results.xml
       - name: Publish cargo test results artifact
         if: matrix.extra


### PR DESCRIPTION
This probably appeared now because it's the first time this tool was cached from a previous run.

This should fix the build for PR 1794: https://github.com/mthom/scryer-prolog/actions/runs/4774317135/jobs/8487922812?pr=1794