### PR TITLE
ADDED: dif_si/2

### DIFF
--- a/src/lib/si.pl
+++ b/src/lib/si.pl
@@ -36,7 +36,8 @@
                integer_si/1,
                atomic_si/1,
                list_si/1,
-               chars_si/1]).
+               chars_si/1,
+               dif_si/2]).
 
 :- use_module(library(lists)).
 
@@ -64,3 +65,9 @@ list_si(L0) :-
 chars_si(Cs) :-
    list_si(Cs),
    '$is_partial_string'(Cs).
+
+dif_si(X, Y) :-
+   X \== Y,
+   ( X \= Y -> true
+   ; throw(error(instantiation_error,dif_si/2))
+   ).


### PR DESCRIPTION
Source: https://stackoverflow.com/questions/20223390/prolog-a-person-is-a-sibling-of-himself

In Scryer Prolog, this is actually not needed, since Scryer Prolog provides dif/2 in library(dif). However, it is still useful to provide dif_si/2 for two reasons:

  1) to more easily port code from systems where only dif_si/2 is available
  2) to provide correct disequality in other systems that adopt this library