### PR TITLE
Fix tags trigger; bump MSRV to 1.65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - { os: windows-latest, rust-version: stable,  shell: 'msys2 {0}' }
           - { os: macos-11,       rust-version: stable,  shell: bash }
           - { os: ubuntu-20.04,   rust-version: stable,  shell: bash, extra: true }
-          - { os: ubuntu-20.04,   rust-version: 1.63,    shell: bash }
+          - { os: ubuntu-20.04,   rust-version: 1.65,    shell: bash }
           - { os: ubuntu-20.04,   rust-version: beta,    shell: bash }
           - { os: ubuntu-20.04,   rust-version: nightly, shell: bash }
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: CI
+
 on:
   push:
     branches: [master]
+    tags:
+      - "v**"
   pull_request:
   schedule:
     - cron: '0 0 * * 3' # At 12:00 AM, only on Wednesday
-  label:
-    types: [created, edited]
+  workflow_dispatch:
 
 jobs:
   build-test:


### PR DESCRIPTION
Changes the CI trigger to automatically create release when a tag that matches `v*` is pushed to the repo.

Also bumps MSRV to 1.65, because  [the version of rug in cargo.lock was increased to 1.19](https://github.com/mthom/scryer-prolog/commit/7f45ac3f7a947e3d7b6556cddea9110622b675fd#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87eL1611-L1616), which [only supports rust 1.65 and newer](https://gitlab.com/tspiteri/rug#version-1190-news-2023-01-06). This was causing the build to fail.