### PR TITLE
Improvements to needs_bracketing/2

### DIFF
--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -211,16 +211,12 @@ needs_bracketing(Value, Op) :-
     current_op(FPrec, FSpec, F),
     current_op(EqPrec, EqSpec, Op),
     arity_specifier(Arity, FSpec),
-    (  Arity =:= 0 ->
-       true
-    ;  EqPrec < FPrec ->
-       true
-    ;  FPrec > 0, F == Value, graphic_token_char(F) ->
-       true
-    ;  F \== '.', '$quoted_token'(F) ->
-       true
-    ;  EqPrec == FPrec,
-       memberchk(EqSpec, [fx,xfx,yfx])
+    (  Arity =:= 0
+    ;  EqPrec < FPrec
+    ;  FPrec > 0, F == Value, graphic_token_char(F)
+    ;  F \== '.', '$quoted_token'(F)
+    ;  EqPrec =:= FPrec,
+       member(EqSpec, [fx,xfx,yfx])
     ).
 
 arity_specifier(0, _).

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -213,7 +213,6 @@ needs_bracketing(Value, Op) :-
     arity_specifier(Arity, FSpec),
     (  Arity =:= 0
     ;  EqPrec < FPrec
-    ;  F \== '.', '$quoted_token'(F)
     ;  EqPrec =:= FPrec,
        member(EqSpec, [fx,xfx,yfx])
     ).

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -213,7 +213,6 @@ needs_bracketing(Value, Op) :-
     arity_specifier(Arity, FSpec),
     (  Arity =:= 0
     ;  EqPrec < FPrec
-    ;  FPrec > 0, F == Value, graphic_token_char(F)
     ;  F \== '.', '$quoted_token'(F)
     ;  EqPrec =:= FPrec,
        member(EqSpec, [fx,xfx,yfx])

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -208,8 +208,9 @@ needs_bracketing(Value, Op) :-
     nonvar(Value),
     \+ integer(Value),
     functor(Value, F, Arity),
-    current_op(FPrec, _, F),
+    current_op(FPrec, FSpec, F),
     current_op(EqPrec, EqSpec, Op),
+    arity_specifier(Arity, FSpec),
     (  Arity =:= 0 ->
        true
     ;  EqPrec < FPrec ->
@@ -221,6 +222,10 @@ needs_bracketing(Value, Op) :-
     ;  EqPrec == FPrec,
        memberchk(EqSpec, [fx,xfx,yfx])
     ).
+
+arity_specifier(0, _).
+arity_specifier(1, S) :- atom_chars(S, [_,_]).
+arity_specifier(2, S) :- atom_chars(S, [_,_,_]).
 
 write_goal(G, VarList, MaxDepth) :-
     (  G = (Var = Value) ->


### PR DESCRIPTION
Here are a few further improvements to `needs_bracketing/2`.

Notably, we now get for example:

<pre>
<b>?- X = -->(a,b,c).</b>
   X = -->(a,b,c).
</pre>

Also, I removed 2 branches that I think are not necessary.

In addition, I have switched the if-then-else to disjunctions to make the code shorter and more readable, without introducing any non-determinism in the toplevel itself, because `needs_bracketing/2` is always used in a "cutting" context, where alternative solutions are not considered anyways.

Please review, and merge if applicable. Many thanks!