### PR TITLE
make double_quotes write option not dependent on double_quotes flag

### DIFF
--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -487,7 +487,6 @@ pub struct HCPrinter<'a, Outputter> {
     iter: StackfulPreOrderHeapIter<'a>,
     atom_tbl: &'a mut AtomTable,
     op_dir: &'a OpDir,
-    flags: MachineFlags,
     state_stack: Vec<TokenOrRedirect>,
     toplevel_spec: Option<DirectedOp>,
     last_item_idx: usize,
@@ -555,7 +554,6 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
         atom_tbl: &'a mut AtomTable,
         stack: &'a mut Stack,
         op_dir: &'a OpDir,
-        flags: MachineFlags,
         output: Outputter,
         cell: HeapCellValue,
     ) -> Self {
@@ -564,7 +562,6 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
             iter: stackful_preorder_iter(heap, stack, cell),
             atom_tbl,
             op_dir,
-            flags,
             state_stack: vec![],
             toplevel_spec: None,
             last_item_idx: 0,
@@ -1187,7 +1184,7 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
 
         let at_cdr = self.outputter.ends_with("|");
 
-        if self.double_quotes && self.flags.double_quotes == DoubleQuotes::Chars {
+        if self.double_quotes {
             if !at_cdr && !self.ignore_ops && end_cell.is_string_terminator(&self.iter.heap) {
                 self.remove_list_children(focus.value() as usize);
                 return self.print_proper_string(focus.value() as usize, max_depth);

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -786,7 +786,6 @@ impl MachineState {
                     &mut self.atom_tbl,
                     &mut self.stack,
                     op_dir,
-                    self.flags,
                     PrinterOutputter::new(),
                     term_to_be_printed,
                 );

--- a/src/machine/mock_wam.rs
+++ b/src/machine/mock_wam.rs
@@ -64,7 +64,6 @@ impl MockWAM {
             &mut self.machine_st.atom_tbl,
             &mut self.machine_st.stack,
             &self.op_dir,
-            self.machine_st.flags,
             PrinterOutputter::new(),
             heap_loc_as_cell!(term_write_result.heap_loc),
         );

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -221,7 +221,13 @@ arity_specifier(0, _).
 arity_specifier(1, S) :- atom_chars(S, [_,_]).
 arity_specifier(2, S) :- atom_chars(S, [_,_,_]).
 
+double_quotes_option(DQ) :-
+    (   current_prolog_flag(double_quotes, chars) -> DQ = true
+    ;   DQ = false
+    ).
+
 write_goal(G, VarList, MaxDepth) :-
+    double_quotes_option(DQ),
     (  G = (Var = Value) ->
        (  var(Value) ->
           select((Var = _), VarList, NewVarList)
@@ -231,16 +237,17 @@ write_goal(G, VarList, MaxDepth) :-
        write(' = '),
        (  needs_bracketing(Value, =) ->
           write('('),
-          write_term(Value, [quoted(true), variable_names(NewVarList), max_depth(MaxDepth), double_quotes(true)]),
+          write_term(Value, [quoted(true), variable_names(NewVarList), max_depth(MaxDepth), double_quotes(DQ)]),
           write(')')
-       ;  write_term(Value, [quoted(true), variable_names(NewVarList), max_depth(MaxDepth), double_quotes(true)])
+       ;  write_term(Value, [quoted(true), variable_names(NewVarList), max_depth(MaxDepth), double_quotes(DQ)])
        )
     ;  G == [] ->
        write('true')
-    ;  write_term(G, [quoted(true), variable_names(VarList), max_depth(MaxDepth), double_quotes(true)])
+    ;  write_term(G, [quoted(true), variable_names(VarList), max_depth(MaxDepth), double_quotes(DQ)])
     ).
 
 write_last_goal(G, VarList, MaxDepth) :-
+    double_quotes_option(DQ),
     (  G = (Var = Value) ->
        (  var(Value) ->
           select((Var = _), VarList, NewVarList)
@@ -250,9 +257,9 @@ write_last_goal(G, VarList, MaxDepth) :-
        write(' = '),
        (  needs_bracketing(Value, =) ->
           write('('),
-          write_term(Value, [quoted(true), variable_names(NewVarList), max_depth(MaxDepth), double_quotes(true)]),
+          write_term(Value, [quoted(true), variable_names(NewVarList), max_depth(MaxDepth), double_quotes(DQ)]),
           write(')')
-       ;  write_term(Value, [quoted(true), variable_names(NewVarList), max_depth(MaxDepth), double_quotes(true)]),
+       ;  write_term(Value, [quoted(true), variable_names(NewVarList), max_depth(MaxDepth), double_quotes(DQ)]),
           (  trailing_period_is_ambiguous(Value) ->
              write(' ')
           ;  true
@@ -260,7 +267,7 @@ write_last_goal(G, VarList, MaxDepth) :-
        )
     ;  G == [] ->
        write('true')
-    ;  write_term(G, [quoted(true), variable_names(VarList), max_depth(MaxDepth), double_quotes(true)])
+    ;  write_term(G, [quoted(true), variable_names(VarList), max_depth(MaxDepth), double_quotes(DQ)])
     ).
 
 write_eq((G1, G2), VarList, MaxDepth) :-


### PR DESCRIPTION
This gives consistent results without depending on another flag.

I think this semantics is better, since it gives more predictable results, and it also simplifies the internal implementation, letting us move more of the logic to Prolog.

Also, it now behaves as it was already documented.