### PR TITLE
detect and prevent concurrent AtomTable use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.8",
+]
+
+[[package]]
 name = "dashu"
 version = "0.3.1"
 source = "git+https://github.com/coasys/dashu.git#ae7ee53fad213e09da5fe4b30e9e9e8bce96aedd"
@@ -795,6 +808,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,7 +1018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2050,24 +2069,27 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "0.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
 dependencies = [
+ "dashmap",
+ "futures",
  "lazy_static",
- "parking_lot 0.11.2",
+ "log",
+ "parking_lot 0.12.1",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "0.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.22",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ rand = "0.8.5"
 [dev-dependencies]
 assert_cmd = "1.0.3"
 predicates-core = "1.0.2"
-serial_test = "0.5.1"
+serial_test = "2.0.0"
 
 [patch.crates-io]
 modular-bitfield = { git = "https://github.com/mthom/modular-bitfield" }

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -259,15 +259,15 @@ pub struct AtomTable {
 }
 
 #[cold]
-fn atom_table_base_pointer_missmatch(expected: *const u8, got: *const u8) -> ! {
+fn atom_table_base_pointer_mismatch(expected: *const u8, got: *const u8) -> ! {
     assert_eq!(expected, got, "Overwriting atom table base pointer, expected old value to be {expected:p}, but found {got:p}");
-    unreachable!("This should only be called in a case of a missmatch as such the assert_eq should have failed!")
+    unreachable!("This should only be called in a case of a mismatch as such the assert_eq should have failed!")
 }
 
 impl Drop for AtomTable {
     fn drop(&mut self) {
         if let Err(got) = set_atom_tbl_buf_base(self.block.base, ptr::null()) {
-            atom_table_base_pointer_missmatch(self.block.base, got);
+            atom_table_base_pointer_mismatch(self.block.base, got);
         }
         self.block.deallocate();
     }
@@ -280,7 +280,7 @@ impl AtomTable {
 
         if let Err(got) = set_atom_tbl_buf_base(ptr::null(), block.base) {
             block.deallocate();
-            atom_table_base_pointer_missmatch(ptr::null(), got);
+            atom_table_base_pointer_mismatch(ptr::null(), got);
         }
 
         Self {
@@ -324,7 +324,7 @@ impl AtomTable {
                         let old_base = self.block.base;
                         self.block.grow();
                         if let Err(got) = set_atom_tbl_buf_base(old_base, self.block.base) {
-                            atom_table_base_pointer_missmatch(old_base, got);
+                            atom_table_base_pointer_mismatch(old_base, got);
                         }
                     } else {
                         break;

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -178,7 +178,7 @@ fn call_0() {
 #[should_panic(expected = "Overwriting atom table base pointer")]
 fn atomtable_is_not_concurrency_safe() {
     // this is basically the same test as scryer_prolog::atom_table::atomtable_is_not_concurrency_safe
-    // but for this integration test scryer_prolog is compiled with cfg!(not(test))  while for the unit test it is colpiled with cfg!(test)
+    // but for this integration test scryer_prolog is compiled with cfg!(not(test))  while for the unit test it is compiled with cfg!(test)
     // as the atom table implementation differ between cfg!(test) and cfg!(not(test)) both test serve a pourpose
     // Note: this integration test itself is compiled with cfg!(test) independent of scryer_prolog itself
     let _machine_a = Machine::with_test_streams();

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -1,4 +1,5 @@
 use crate::helper::{load_module_test, run_top_level_test_no_args, run_top_level_test_with_args};
+use scryer_prolog::machine::Machine;
 use serial_test::serial;
 
 // issue #857
@@ -128,10 +129,12 @@ fn compound_goal() {
 // issue #815
 #[test]
 fn no_stutter() {
-    run_top_level_test_no_args("write(a), write(b), false.\n\
+    run_top_level_test_no_args(
+        "write(a), write(b), false.\n\
                                 halt.\n\
                                 ",
-                               "ab   false.\n")
+        "ab   false.\n",
+    )
 }
 
 /*
@@ -167,4 +170,17 @@ fn call_0() {
         "tests-pl/issue831-call0.pl",
         "   error(existence_error(procedure,call/0),call/0).\n",
     );
+}
+
+// issue #1206
+#[serial]
+#[test]
+#[should_panic(expected = "Overwriting atom table base pointer")]
+fn atomtable_is_not_concurrency_safe() {
+    // this is basically the same test as scryer_prolog::atom_table::atomtable_is_not_concurrency_safe
+    // but for this integration test scryer_prolog is compiled with cfg!(not(test))  while for the unit test it is colpiled with cfg!(test)
+    // as the atom table implementation differ between cfg!(test) and cfg!(not(test)) both test serve a pourpose
+    // Note: this integration test itself is compiled with cfg!(test) independent of scryer_prolog itself
+    let _machine_a = Machine::with_test_streams();
+    let _machine_b = Machine::with_test_streams();
 }


### PR DESCRIPTION
The AtomTable currently uses a global variable to store the pointer to the AtomTable's block base. This means that only one AtomTable can be used at once as otherwise Atoms may be looked up in the wrong AtomTable. This PR adds logic to detect an AtomTable being created while one already exists. When this is detected it panics with a descriptive error message, to prevent more obscure problems.