### PR TITLE
make AtomTable consurrency safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - { os: macos-11,       rust-version: stable,  shell: bash, target: 'x86_64-apple-darwin' }
           - { os: ubuntu-20.04,   rust-version: stable,  shell: bash, extra: true, target: 'x86_64-unknown-linux-gnu' }
           - { os: ubuntu-20.04,   rust-version: stable,  shell: bash, target: 'i686-unknown-linux-gnu' }
-          - { os: ubuntu-20.04,   rust-version: 1.65,    shell: bash, target: 'x86_64-unknown-linux-gnu'}
+          - { os: ubuntu-20.04,   rust-version: "1.70",    shell: bash, target: 'x86_64-unknown-linux-gnu'}
           - { os: ubuntu-20.04,   rust-version: beta,    shell: bash, target: 'x86_64-unknown-linux-gnu'}
           - { os: ubuntu-20.04,   rust-version: nightly, shell: bash, target: 'x86_64-unknown-linux-gnu'}
     defaults:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ repl = ["dep:crossterm", "dep:ctrlc", "dep:rustyline"]
 hostname = ["dep:hostname"]
 tls = ["dep:native-tls"]
 http = ["dep:hyper", "dep:reqwest"]
+rust_beta_channel = []
 
 [build-dependencies]
 indexmap = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 keywords = ["prolog", "prolog-interpreter", "prolog-system"]
 categories = ["command-line-utilities"]
 build = "build/main.rs"
-rust-version = "1.63"
+rust-version = "1.70"
 
 [features]
 default = ["ffi", "repl", "hostname", "tls", "http"]

--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -590,7 +590,10 @@ enum SystemClauseType {
     UnattributedVar,
     #[strum_discriminants(strum(props(Arity = "4", Name = "$get_db_refs")))]
     GetDBRefs,
-    #[strum_discriminants(strum(props(Arity = "2", Name = "$keysort_with_constant_var_ordering")))]
+    #[strum_discriminants(strum(props(
+        Arity = "2",
+        Name = "$keysort_with_constant_var_ordering"
+    )))]
     KeySortWithConstantVarOrdering,
     REPL(REPLCodePtr),
 }
@@ -801,7 +804,7 @@ enum InstructionTemplate {
 }
 
 fn derive_input(ty: &Type) -> Option<DeriveInput> {
-    let clause_type: Type = parse_quote!{ ClauseType };
+    let clause_type: Type = parse_quote! { ClauseType };
     let built_in_clause_type: Type = parse_quote! { BuiltInClauseType };
     let inlined_clause_type: Type = parse_quote! { InlinedClauseType };
     let system_clause_type: Type = parse_quote! { SystemClauseType };
@@ -847,7 +850,8 @@ fn add_discriminant_data<DiscriminantT>(
     prefix: &'static str,
     variant_data: &mut Vec<(&'static str, Arity, Variant)>,
 ) -> (&'static str, Arity)
-    where DiscriminantT: FromStr + strum::EnumProperty + std::fmt::Debug
+where
+    DiscriminantT: FromStr + strum::EnumProperty + std::fmt::Debug,
 {
     let name = prop_from_ident::<DiscriminantT>(&variant.ident, "Name");
     let arity = Arity::from(prop_from_ident::<DiscriminantT>(&variant.ident, "Arity"));
@@ -1699,7 +1703,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::CallMakeDirectoryPath |
                     &Instruction::CallDeleteFile |
                     &Instruction::CallRenameFile |
-		            &Instruction::CallFileCopy |
+                    &Instruction::CallFileCopy |
                     &Instruction::CallWorkingDirectory |
                     &Instruction::CallDeleteDirectory |
                     &Instruction::CallPathCanonical |
@@ -1793,9 +1797,9 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::CallHttpListen |
                     &Instruction::CallHttpAccept |
                     &Instruction::CallHttpAnswer |
-		            &Instruction::CallLoadForeignLib |
-		            &Instruction::CallForeignCall |
-		            &Instruction::CallDefineForeignStruct |
+                    &Instruction::CallLoadForeignLib |
+                    &Instruction::CallForeignCall |
+                    &Instruction::CallDefineForeignStruct |
                     &Instruction::CallPredicateDefined |
                     &Instruction::CallStripModule |
                     &Instruction::CallCurrentTime |
@@ -1927,7 +1931,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::ExecuteMakeDirectoryPath |
                     &Instruction::ExecuteDeleteFile |
                     &Instruction::ExecuteRenameFile |
-		            &Instruction::ExecuteFileCopy |
+                    &Instruction::ExecuteFileCopy |
                     &Instruction::ExecuteWorkingDirectory |
                     &Instruction::ExecuteDeleteDirectory |
                     &Instruction::ExecutePathCanonical |
@@ -2021,9 +2025,9 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::ExecuteHttpListen |
                     &Instruction::ExecuteHttpAccept |
                     &Instruction::ExecuteHttpAnswer |
-		            &Instruction::ExecuteLoadForeignLib |
-		            &Instruction::ExecuteForeignCall |
-		            &Instruction::ExecuteDefineForeignStruct |
+                    &Instruction::ExecuteLoadForeignLib |
+                    &Instruction::ExecuteForeignCall |
+                    &Instruction::ExecuteDefineForeignStruct |
                     &Instruction::ExecutePredicateDefined |
                     &Instruction::ExecuteStripModule |
                     &Instruction::ExecuteCurrentTime |
@@ -2300,7 +2304,8 @@ pub fn generate_instructions_rs() -> TokenStream {
 
     instr_data.generate_instruction_enum_loop(input);
 
-    let instr_variants: Vec<_> = instr_data.instr_variants
+    let instr_variants: Vec<_> = instr_data
+        .instr_variants
         .iter()
         .cloned()
         .map(|(_, _, _, variant)| variant)
@@ -2339,7 +2344,8 @@ pub fn generate_instructions_rs() -> TokenStream {
     for (name, arity, variant) in instr_data.compare_number_variants {
         let ident = variant.ident.clone();
 
-        let variant_fields: Vec<_> = variant.fields
+        let variant_fields: Vec<_> = variant
+            .fields
             .into_iter()
             .map(|field| {
                 let ty = field.ty;
@@ -2378,29 +2384,23 @@ pub fn generate_instructions_rs() -> TokenStream {
         let ident = variant.ident;
         let instr_ident = format_ident!("Call{}", ident);
 
-        let placeholder_ids: Vec<_> = (0 .. variant_fields.len())
+        let placeholder_ids: Vec<_> = (0..variant_fields.len())
             .map(|n| format_ident!("f_{}", n))
             .collect();
 
-        clause_type_to_instr_arms.push(
-            quote! {
-                ClauseType::Inlined(
-                    InlinedClauseType::CompareNumber(CompareNumber::#ident(#(#placeholder_ids),*))
-                ) => Instruction::#instr_ident(#(*#placeholder_ids),*)
-            }
-        );
+        clause_type_to_instr_arms.push(quote! {
+            ClauseType::Inlined(
+                InlinedClauseType::CompareNumber(CompareNumber::#ident(#(#placeholder_ids),*))
+            ) => Instruction::#instr_ident(#(*#placeholder_ids),*)
+        });
 
-        is_inbuilt_arms.push(
-            quote! {
-                (atom!(#name), #arity) => true
-            }
-        );
+        is_inbuilt_arms.push(quote! {
+            (atom!(#name), #arity) => true
+        });
 
-        is_inlined_arms.push(
-            quote! {
-                (atom!(#name), #arity) => true
-            }
-        );
+        is_inlined_arms.push(quote! {
+            (atom!(#name), #arity) => true
+        });
     }
 
     for (name, arity, variant) in instr_data.compare_term_variants {
@@ -2412,36 +2412,31 @@ pub fn generate_instructions_rs() -> TokenStream {
             )
         });
 
-        clause_type_name_arms.push(
-            quote! {
-                ClauseType::BuiltIn(
-                    BuiltInClauseType::CompareTerm(CompareTerm::#ident)
-                ) => atom!(#name)
-            }
-        );
+        clause_type_name_arms.push(quote! {
+            ClauseType::BuiltIn(
+                BuiltInClauseType::CompareTerm(CompareTerm::#ident)
+            ) => atom!(#name)
+        });
 
         let ident = variant.ident;
         let instr_ident = format_ident!("Call{}", ident);
 
-        clause_type_to_instr_arms.push(
-            quote! {
-                ClauseType::BuiltIn(
-                    BuiltInClauseType::CompareTerm(CompareTerm::#ident)
-                ) => Instruction::#instr_ident
-            }
-        );
+        clause_type_to_instr_arms.push(quote! {
+            ClauseType::BuiltIn(
+                BuiltInClauseType::CompareTerm(CompareTerm::#ident)
+            ) => Instruction::#instr_ident
+        });
 
-        is_inbuilt_arms.push(
-            quote! {
-                (atom!(#name), #arity) => true
-            }
-        );
+        is_inbuilt_arms.push(quote! {
+            (atom!(#name), #arity) => true
+        });
     }
 
     for (name, arity, variant) in instr_data.builtin_type_variants {
         let ident = variant.ident.clone();
 
-        let variant_fields: Vec<_> = variant.fields
+        let variant_fields: Vec<_> = variant
+            .fields
             .into_iter()
             .map(|field| {
                 let ty = field.ty;
@@ -2480,7 +2475,7 @@ pub fn generate_instructions_rs() -> TokenStream {
         let ident = variant.ident;
         let instr_ident = format_ident!("Call{}", ident);
 
-        let placeholder_ids: Vec<_> = (0 .. variant_fields.len())
+        let placeholder_ids: Vec<_> = (0..variant_fields.len())
             .map(|n| format_ident!("f_{}", n))
             .collect();
 
@@ -2498,17 +2493,16 @@ pub fn generate_instructions_rs() -> TokenStream {
             }
         });
 
-        is_inbuilt_arms.push(
-            quote! {
-                (atom!(#name), #arity) => true
-            }
-        );
+        is_inbuilt_arms.push(quote! {
+            (atom!(#name), #arity) => true
+        });
     }
 
     for (name, arity, variant) in instr_data.inlined_type_variants {
         let ident = variant.ident.clone();
 
-        let variant_fields: Vec<_> = variant.fields
+        let variant_fields: Vec<_> = variant
+            .fields
             .into_iter()
             .map(|field| {
                 if field.ty.type_id() == TypeId::of::<usize>() {
@@ -2551,35 +2545,30 @@ pub fn generate_instructions_rs() -> TokenStream {
         let ident = variant.ident;
         let instr_ident = format_ident!("Call{}", ident);
 
-        let placeholder_ids: Vec<_> = (0 .. variant_fields.len())
+        let placeholder_ids: Vec<_> = (0..variant_fields.len())
             .map(|n| format_ident!("f_{}", n))
             .collect();
 
-        clause_type_to_instr_arms.push(
-            quote! {
-                ClauseType::Inlined(
-                    InlinedClauseType::#ident(#(#placeholder_ids),*)
-                ) => Instruction::#instr_ident(*#(#placeholder_ids),*)
-            }
-        );
+        clause_type_to_instr_arms.push(quote! {
+            ClauseType::Inlined(
+                InlinedClauseType::#ident(#(#placeholder_ids),*)
+            ) => Instruction::#instr_ident(*#(#placeholder_ids),*)
+        });
 
-        is_inbuilt_arms.push(
-            quote! {
-                (atom!(#name), #arity) => true
-            }
-        );
+        is_inbuilt_arms.push(quote! {
+            (atom!(#name), #arity) => true
+        });
 
-        is_inlined_arms.push(
-            quote! {
-                (atom!(#name), #arity) => true
-            }
-        );
+        is_inlined_arms.push(quote! {
+            (atom!(#name), #arity) => true
+        });
     }
 
     for (name, arity, variant) in instr_data.system_clause_type_variants {
         let ident = variant.ident.clone();
 
-        let variant_fields: Vec<_> = variant.fields
+        let variant_fields: Vec<_> = variant
+            .fields
             .into_iter()
             .map(|field| {
                 if field.ty == parse_quote! { usize } {
@@ -2647,7 +2636,7 @@ pub fn generate_instructions_rs() -> TokenStream {
             ident.clone()
         };
 
-        let placeholder_ids: Vec<_> = (0 .. variant_fields.len())
+        let placeholder_ids: Vec<_> = (0..variant_fields.len())
             .map(|n| format_ident!("f_{}", n))
             .collect();
 
@@ -2665,23 +2654,22 @@ pub fn generate_instructions_rs() -> TokenStream {
             }
         });
 
-        is_inbuilt_arms.push(
-            if let Arity::Ident("arity") = &arity {
-                quote! {
-                    (atom!(#name), _arity) => true
-                }
-            } else {
-                quote! {
-                    (atom!(#name), #arity) => true
-                }
+        is_inbuilt_arms.push(if let Arity::Ident("arity") = &arity {
+            quote! {
+                (atom!(#name), _arity) => true
             }
-        );
+        } else {
+            quote! {
+                (atom!(#name), #arity) => true
+            }
+        });
     }
 
     for (name, arity, variant) in instr_data.repl_code_ptr_variants {
         let ident = variant.ident.clone();
 
-        let variant_fields: Vec<_> = variant.fields
+        let variant_fields: Vec<_> = variant
+            .fields
             .into_iter()
             .map(|field| {
                 if field.ty.type_id() == TypeId::of::<usize>() {
@@ -2724,7 +2712,7 @@ pub fn generate_instructions_rs() -> TokenStream {
         let ident = variant.ident;
         let instr_ident = format_ident!("Call{}", ident);
 
-        let placeholder_ids: Vec<_> = (0 .. variant_fields.len())
+        let placeholder_ids: Vec<_> = (0..variant_fields.len())
             .map(|n| format_ident!("f_{}", n))
             .collect();
 
@@ -2742,11 +2730,9 @@ pub fn generate_instructions_rs() -> TokenStream {
             }
         });
 
-        is_inbuilt_arms.push(
-            quote! {
-                (atom!(#name), #arity) => true
-            }
-        );
+        is_inbuilt_arms.push(quote! {
+            (atom!(#name), #arity) => true
+        });
     }
 
     for (name, arity, variant) in instr_data.clause_type_variants {
@@ -2768,7 +2754,8 @@ pub fn generate_instructions_rs() -> TokenStream {
             continue;
         }
 
-        let variant_fields: Vec<_> = variant.fields
+        let variant_fields: Vec<_> = variant
+            .fields
             .into_iter()
             .map(|field| {
                 if field.ty == parse_quote! { usize } {
@@ -2802,7 +2789,7 @@ pub fn generate_instructions_rs() -> TokenStream {
 
         let ident = variant.ident;
 
-        let placeholder_ids: Vec<_> = (0 .. variant_fields.len())
+        let placeholder_ids: Vec<_> = (0..variant_fields.len())
             .map(|n| format_ident!("f_{}", n))
             .collect();
 
@@ -2817,14 +2804,13 @@ pub fn generate_instructions_rs() -> TokenStream {
             }
         });
 
-        is_inbuilt_arms.push(
-            quote! {
-                (atom!(#name), _arity) => true
-            }
-        );
+        is_inbuilt_arms.push(quote! {
+            (atom!(#name), _arity) => true
+        });
     }
 
-    let to_execute_arms: Vec<_> = instr_data.instr_variants
+    let to_execute_arms: Vec<_> = instr_data
+        .instr_variants
         .iter()
         .cloned()
         .filter_map(|(_, _, _, variant)| {
@@ -2837,12 +2823,11 @@ pub fn generate_instructions_rs() -> TokenStream {
                 0
             };
 
-            let placeholder_ids: Vec<_> = (0 .. enum_arity)
-                .map(|n| format_ident!("f_{}", n))
-                .collect();
+            let placeholder_ids: Vec<_> =
+                (0..enum_arity).map(|n| format_ident!("f_{}", n)).collect();
 
             if variant_string.starts_with("Call") {
-                let execute_ident = format_ident!("Execute{}", variant_string["Call".len() ..]);
+                let execute_ident = format_ident!("Execute{}", variant_string["Call".len()..]);
 
                 Some(if enum_arity == 0 {
                     quote! {
@@ -2857,7 +2842,7 @@ pub fn generate_instructions_rs() -> TokenStream {
                 })
             } else if variant_string.starts_with("DefaultCall") {
                 let execute_ident =
-                    format_ident!("DefaultExecute{}", variant_string["DefaultCall".len() ..]);
+                    format_ident!("DefaultExecute{}", variant_string["DefaultCall".len()..]);
 
                 Some(if enum_arity == 0 {
                     quote! {
@@ -2876,7 +2861,8 @@ pub fn generate_instructions_rs() -> TokenStream {
         })
         .collect();
 
-    let is_execute_arms: Vec<_> = instr_data.instr_variants
+    let is_execute_arms: Vec<_> = instr_data
+        .instr_variants
         .iter()
         .cloned()
         .filter_map(|(_, _, _, variant)| {
@@ -2919,7 +2905,8 @@ pub fn generate_instructions_rs() -> TokenStream {
         })
         .collect();
 
-    let to_default_arms: Vec<_> = instr_data.instr_variants
+    let to_default_arms: Vec<_> = instr_data
+        .instr_variants
         .iter()
         .cloned()
         .filter_map(|(_, _, countable_inference, variant)| {
@@ -2936,9 +2923,8 @@ pub fn generate_instructions_rs() -> TokenStream {
                     0
                 };
 
-                let placeholder_ids: Vec<_> = (0 .. enum_arity)
-                    .map(|n| format_ident!("f_{}", n))
-                    .collect();
+                let placeholder_ids: Vec<_> =
+                    (0..enum_arity).map(|n| format_ident!("f_{}", n)).collect();
 
                 Some(if enum_arity == 0 {
                     quote! {
@@ -2957,7 +2943,8 @@ pub fn generate_instructions_rs() -> TokenStream {
         })
         .collect();
 
-    let control_flow_arms: Vec<_> = instr_data.instr_variants
+    let control_flow_arms: Vec<_> = instr_data
+        .instr_variants
         .iter()
         .cloned()
         .filter_map(|(_, _, _, variant)| {
@@ -2985,7 +2972,8 @@ pub fn generate_instructions_rs() -> TokenStream {
         })
         .collect();
 
-    let instr_macro_arms: Vec<_> = instr_data.instr_variants
+    let instr_macro_arms: Vec<_> = instr_data
+        .instr_variants
         .iter()
         .rev() // produce default, execute & default & execute cases first.
         .cloned()
@@ -2994,7 +2982,7 @@ pub fn generate_instructions_rs() -> TokenStream {
             let variant_string = variant.ident.to_string();
             let arity = match arity {
                 Arity::Static(arity) => arity,
-                _ => 1
+                _ => 1,
             };
 
             Some(if variant_string.starts_with("Execute") {
@@ -3071,9 +3059,10 @@ pub fn generate_instructions_rs() -> TokenStream {
         })
         .collect();
 
-    let name_and_arity_arms: Vec<_> = instr_data.instr_variants
+    let name_and_arity_arms: Vec<_> = instr_data
+        .instr_variants
         .into_iter()
-        .map(|(name,arity,_,variant)| {
+        .map(|(name, arity, _, variant)| {
             let ident = &variant.ident;
 
             let enum_arity = if let Fields::Unnamed(fields) = &variant.fields {
@@ -3303,8 +3292,10 @@ pub fn generate_instructions_rs() -> TokenStream {
 fn is_callable(id: &Ident) -> bool {
     let id = id.to_string();
 
-    id.starts_with("Call") || id.starts_with("Execute") || id.starts_with("DefaultCall") ||
-        id.starts_with("DefaultExecute")
+    id.starts_with("Call")
+        || id.starts_with("Execute")
+        || id.starts_with("DefaultCall")
+        || id.starts_with("DefaultExecute")
 }
 
 fn is_non_default_callable(id: &Ident) -> bool {
@@ -3325,7 +3316,8 @@ fn create_instr_variant(id: Ident, mut variant: Variant) -> Variant {
 }
 
 fn prop_from_ident<DiscriminantT>(id: &Ident, key: &'static str) -> &'static str
-   where DiscriminantT: FromStr + strum::EnumProperty + std::fmt::Debug
+where
+    DiscriminantT: FromStr + strum::EnumProperty + std::fmt::Debug,
 {
     let disc = match DiscriminantT::from_str(id.to_string().as_str()) {
         Ok(disc) => disc,
@@ -3345,7 +3337,7 @@ fn prop_from_ident<DiscriminantT>(id: &Ident, key: &'static str) -> &'static str
 #[derive(Clone, Copy)]
 enum Arity {
     Static(usize),
-    Ident(&'static str)
+    Ident(&'static str),
 }
 
 impl From<&'static str> for Arity {
@@ -3437,9 +3429,13 @@ impl InstructionData {
 
             (name, arity, CountableInference::NotCounted)
         } else if id == "InstructionTemplate" {
-            ( prop_from_ident::<InstructionTemplateDiscriminants>(&variant.ident, "Name"),
-              Arity::from(prop_from_ident::<InstructionTemplateDiscriminants>(&variant.ident, "Arity")),
-              CountableInference::NotCounted
+            (
+                prop_from_ident::<InstructionTemplateDiscriminants>(&variant.ident, "Name"),
+                Arity::from(prop_from_ident::<InstructionTemplateDiscriminants>(
+                    &variant.ident,
+                    "Arity",
+                )),
+                CountableInference::NotCounted,
             )
         } else if id == "ClauseType" {
             let (name, arity) = add_discriminant_data::<ClauseTypeDiscriminants>(
@@ -3456,19 +3452,16 @@ impl InstructionData {
         let v_string = variant.ident.to_string();
 
         let v_ident = if v_string.starts_with("Call") {
-            format_ident!("{}", v_string["Call".len() ..])
+            format_ident!("{}", v_string["Call".len()..])
         } else {
             variant.ident.clone()
         };
 
-        let generated_variant = create_instr_variant(
-            format_ident!("{}{}", prefix, v_ident),
-            variant.clone(),
-        );
+        let generated_variant =
+            create_instr_variant(format_ident!("{}{}", prefix, v_ident), variant.clone());
 
-        self.instr_variants.push(
-            (name, arity, countable_inference, generated_variant)
-        );
+        self.instr_variants
+            .push((name, arity, countable_inference, generated_variant));
     }
 
     fn generate_instruction_enum_loop(&mut self, input: syn::DeriveInput) {
@@ -3490,10 +3483,10 @@ impl InstructionData {
                 self.label_variant(&input.ident, "Call", variant.clone());
                 self.label_variant(&input.ident, "Execute", variant.clone());
 
-                if input.ident == "BuiltInClauseType" ||
-                    input.ident == "CompareNumber" ||
-                    input.ident == "CompareTerm" ||
-                    input.ident == "ClauseType"
+                if input.ident == "BuiltInClauseType"
+                    || input.ident == "CompareNumber"
+                    || input.ident == "CompareTerm"
+                    || input.ident == "ClauseType"
                 {
                     self.label_variant(&input.ident, "DefaultCall", variant.clone());
                     self.label_variant(&input.ident, "DefaultExecute", variant);

--- a/build/static_string_indexing.rs
+++ b/build/static_string_indexing.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
-use syn::*;
 use syn::parse::*;
 use syn::visit::*;
+use syn::*;
 
 use indexmap::IndexSet;
 
@@ -11,7 +11,9 @@ struct StaticStrVisitor {
 
 impl StaticStrVisitor {
     fn new() -> Self {
-        Self { static_strs: IndexSet::new() }
+        Self {
+            static_strs: IndexSet::new(),
+        }
     }
 }
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -70,12 +70,6 @@ pub struct F64Table {
     block: RawBlock<F64Table>,
 }
 
-impl Drop for F64Table {
-    fn drop(&mut self) {
-        self.block.deallocate();
-    }
-}
-
 #[cfg(test)]
 fn set_f64_tbl_buf_base(ptr: *const u8) {
     F64_TABLE_BUF_BASE.with(|f64_table_buf_base| {

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -1003,11 +1003,8 @@ mod tests {
 
         // complete string
 
-        let pstr_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "ronan",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "ronan", &wam.machine_st.atom_tbl);
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
         assert_eq!(pstr_cell.get_tag(), HeapCellValueTag::PStr);

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -965,8 +965,8 @@ mod tests {
         let f_atom = atom!("f");
         let g_atom = atom!("g");
 
-        assert_eq!(f_atom.as_str(), "f");
-        assert_eq!(g_atom.as_str(), "g");
+        assert_eq!(&*f_atom.as_str(), "f");
+        assert_eq!(&*g_atom.as_str(), "g");
 
         let f_atom_cell = atom_as_cell!(f_atom);
         let g_atom_cell = atom_as_cell!(g_atom);
@@ -976,7 +976,7 @@ mod tests {
         match f_atom_cell.to_atom() {
             Some(atom) => {
                 assert_eq!(f_atom, atom);
-                assert_eq!(atom.as_str(), "f");
+                assert_eq!(&*atom.as_str(), "f");
             }
             None => {
                 assert!(false);
@@ -987,7 +987,7 @@ mod tests {
             (HeapCellValueTag::Atom, (atom, arity)) => {
                 assert_eq!(f_atom, atom);
                 assert_eq!(arity, 0);
-                assert_eq!(atom.as_str(), "f");
+                assert_eq!(&*atom.as_str(), "f");
             }
             _ => { unreachable!() }
         );
@@ -996,7 +996,7 @@ mod tests {
             (HeapCellValueTag::Atom, (atom, arity)) => {
                 assert_eq!(g_atom, atom);
                 assert_eq!(arity, 0);
-                assert_eq!(atom.as_str(), "g");
+                assert_eq!(&*atom.as_str(), "g");
             }
             _ => { unreachable!() }
         );
@@ -1006,7 +1006,7 @@ mod tests {
         let pstr_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "ronan",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
@@ -1014,7 +1014,7 @@ mod tests {
 
         match pstr_cell.to_pstr() {
             Some(pstr) => {
-                assert_eq!(pstr.as_str_from(0), "ronan");
+                assert_eq!(&*pstr.as_str_from(0), "ronan");
             }
             None => {
                 assert!(false);
@@ -1024,7 +1024,7 @@ mod tests {
         read_heap_cell!(pstr_cell,
             (HeapCellValueTag::PStr, pstr_atom) => {
                 let pstr = PartialString::from(pstr_atom);
-                assert_eq!(pstr.as_str_from(0), "ronan");
+                assert_eq!(&*pstr.as_str_from(0), "ronan");
             }
             _ => { unreachable!() }
         );
@@ -1133,7 +1133,7 @@ mod tests {
         read_heap_cell!(cell,
             (HeapCellValueTag::Atom, (el, _arity)) => {
                 assert_eq!(el.flat_index(), empty_list_as_cell!().get_value());
-                assert_eq!(el.as_str(), "[]");
+                assert_eq!(&*el.as_str(), "[]");
             }
             _ => { unreachable!() }
         );

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -158,13 +158,13 @@ fn push_literal(interm: &mut Vec<ArithmeticTerm>, c: &Literal) -> Result<(), Ari
         Literal::Float(n) => interm.push(ArithmeticTerm::Number(Number::Float(*n.as_ptr()))),
         Literal::Rational(n) => interm.push(ArithmeticTerm::Number(Number::Rational(*n))),
         Literal::Atom(name) if name == &atom!("e") => interm.push(ArithmeticTerm::Number(
-            Number::Float(OrderedFloat(std::f64::consts::E))
+            Number::Float(OrderedFloat(std::f64::consts::E)),
         )),
         Literal::Atom(name) if name == &atom!("pi") => interm.push(ArithmeticTerm::Number(
-            Number::Float(OrderedFloat(std::f64::consts::PI))
+            Number::Float(OrderedFloat(std::f64::consts::PI)),
         )),
         Literal::Atom(name) if name == &atom!("epsilon") => interm.push(ArithmeticTerm::Number(
-            Number::Float(OrderedFloat(std::f64::EPSILON))
+            Number::Float(OrderedFloat(std::f64::EPSILON)),
         )),
         _ => return Err(ArithmeticError::NonEvaluableFunctor(*c, 0)),
     }
@@ -326,23 +326,14 @@ impl<'a> ArithmeticEvaluator<'a> {
                     let var_num = name.to_var_num().unwrap();
 
                     let r = if lvl == Level::Shallow {
-                        self.marker.mark_non_callable(
-                            var_num,
-                            arg,
-                            term_loc,
-                            cell,
-                            &mut code,
-                        )
+                        self.marker
+                            .mark_non_callable(var_num, arg, term_loc, cell, &mut code)
                     } else if term_loc.is_last() || cell.get().norm().reg_num() == 0 {
                         let r = self.marker.get_binding(var_num);
 
                         if r.reg_num() == 0 {
                             self.marker.mark_var::<QueryInstruction>(
-                                var_num,
-                                lvl,
-                                cell,
-                                term_loc,
-                                &mut code,
+                                var_num, lvl, cell, term_loc, &mut code,
                             );
                             cell.get().norm()
                         } else {
@@ -434,7 +425,7 @@ fn classify_float(f: f64) -> Result<f64, EvalError> {
             }
         }
         FpCategory::Nan => Err(EvalError::Undefined),
-        _ => Ok(f)
+        _ => Ok(f),
     }
 }
 
@@ -549,8 +540,12 @@ impl PartialEq for Number {
             (&Number::Fixnum(n1), &Number::Float(n2)) => OrderedFloat(n1.get_num() as f64).eq(&n2),
             (&Number::Float(n1), &Number::Fixnum(n2)) => n1.eq(&OrderedFloat(n2.get_num() as f64)),
             (&Number::Integer(ref n1), &Number::Integer(ref n2)) => n1.eq(n2),
-            (&Number::Integer(ref n1), Number::Float(n2)) => OrderedFloat(n1.to_f64().value()).eq(n2),
-            (&Number::Float(n1), &Number::Integer(ref n2)) => n1.eq(&OrderedFloat(n2.to_f64().value())),
+            (&Number::Integer(ref n1), Number::Float(n2)) => {
+                OrderedFloat(n1.to_f64().value()).eq(n2)
+            }
+            (&Number::Float(n1), &Number::Integer(ref n2)) => {
+                n1.eq(&OrderedFloat(n2.to_f64().value()))
+            }
             (&Number::Integer(ref n1), &Number::Rational(ref n2)) => {
                 #[cfg(feature = "num")]
                 {
@@ -571,8 +566,12 @@ impl PartialEq for Number {
                     &**n1 == &**n2
                 }
             }
-            (&Number::Rational(ref n1), &Number::Float(n2)) => OrderedFloat(n1.to_f64().value()).eq(&n2),
-            (&Number::Float(n1), &Number::Rational(ref n2)) => n1.eq(&OrderedFloat(n2.to_f64().value())),
+            (&Number::Rational(ref n1), &Number::Float(n2)) => {
+                OrderedFloat(n1.to_f64().value()).eq(&n2)
+            }
+            (&Number::Float(n1), &Number::Rational(ref n2)) => {
+                n1.eq(&OrderedFloat(n2.to_f64().value()))
+            }
             (&Number::Float(f1), &Number::Float(f2)) => f1.eq(&f2),
             (&Number::Rational(ref r1), &Number::Rational(ref r2)) => r1.eq(&r2),
         }
@@ -641,7 +640,9 @@ impl Ord for Number {
             (&Number::Float(n1), &Number::Fixnum(n2)) => n1.cmp(&OrderedFloat(n2.get_num() as f64)),
             (&Number::Integer(n1), &Number::Integer(n2)) => (*n1).cmp(&*n2),
             (&Number::Integer(n1), Number::Float(n2)) => OrderedFloat(n1.to_f64().value()).cmp(n2),
-            (&Number::Float(n1), &Number::Integer(ref n2)) => n1.cmp(&OrderedFloat(n2.to_f64().value())),
+            (&Number::Float(n1), &Number::Integer(ref n2)) => {
+                n1.cmp(&OrderedFloat(n2.to_f64().value()))
+            }
             (&Number::Integer(n1), &Number::Rational(n2)) => {
                 #[cfg(feature = "num")]
                 {
@@ -662,8 +663,12 @@ impl Ord for Number {
                     (&*n1).partial_cmp(&*n2).unwrap_or(Ordering::Less)
                 }
             }
-            (&Number::Rational(n1), &Number::Float(n2)) => OrderedFloat(n1.to_f64().value()).cmp(&n2),
-            (&Number::Float(n1), &Number::Rational(n2)) => n1.cmp(&OrderedFloat(n2.to_f64().value())),
+            (&Number::Rational(n1), &Number::Float(n2)) => {
+                OrderedFloat(n1.to_f64().value()).cmp(&n2)
+            }
+            (&Number::Float(n1), &Number::Rational(n2)) => {
+                n1.cmp(&OrderedFloat(n2.to_f64().value()))
+            }
             (&Number::Float(f1), &Number::Float(f2)) => f1.cmp(&f2),
             (&Number::Rational(r1), &Number::Rational(r2)) => (*r1).cmp(&*r2),
         }

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -33,7 +33,11 @@ impl<'a> From<&'a Atom> for Atom {
 impl From<bool> for Atom {
     #[inline]
     fn from(value: bool) -> Self {
-        if value { atom!("true") } else { atom!("false") }
+        if value {
+            atom!("true")
+        } else {
+            atom!("false")
+        }
     }
 }
 
@@ -50,10 +54,10 @@ static ATOM_TABLE_BUF_BASE: std::sync::atomic::AtomicPtr<u8> =
     std::sync::atomic::AtomicPtr::new(ptr::null_mut());
 
 fn set_atom_tbl_buf_base(old_ptr: *const u8, new_ptr: *const u8) -> Result<(), *const u8> {
-#[cfg(test)]
+    #[cfg(test)]
     {
-    ATOM_TABLE_BUF_BASE.with(|atom_table_buf_base| {
-        let mut borrow = atom_table_buf_base.borrow_mut();
+        ATOM_TABLE_BUF_BASE.with(|atom_table_buf_base| {
+            let mut borrow = atom_table_buf_base.borrow_mut();
             if *borrow != old_ptr {
                 Err(*borrow)
             } else {
@@ -79,9 +83,9 @@ fn set_atom_tbl_buf_base(old_ptr: *const u8, new_ptr: *const u8) -> Result<(), *
 pub(crate) fn get_atom_tbl_buf_base() -> *const u8 {
     #[cfg(test)]
     {
-    ATOM_TABLE_BUF_BASE.with(|atom_table_buf_base| *atom_table_buf_base.borrow())
-}
-#[cfg(not(test))]
+        ATOM_TABLE_BUF_BASE.with(|atom_table_buf_base| *atom_table_buf_base.borrow())
+    }
+    #[cfg(not(test))]
     {
         ATOM_TABLE_BUF_BASE.load(std::sync::atomic::Ordering::Relaxed)
     }
@@ -109,9 +113,11 @@ impl RawBlockTraits for AtomTable {
 #[bitfield]
 #[derive(Copy, Clone, Debug)]
 struct AtomHeader {
-    #[allow(unused)] m: bool,
+    #[allow(unused)]
+    m: bool,
     len: B50,
-    #[allow(unused)] padding: B13,
+    #[allow(unused)]
+    padding: B13,
 }
 
 impl AtomHeader {
@@ -164,7 +170,8 @@ impl Atom {
         if self.is_static() {
             ptr::null()
         } else {
-            (get_atom_tbl_buf_base() as usize + (self.index as usize) - (STRINGS.len() << 3)) as *const u8
+            (get_atom_tbl_buf_base() as usize + (self.index as usize) - (STRINGS.len() << 3))
+                as *const u8
         }
     }
 
@@ -194,7 +201,11 @@ impl Atom {
         let c1 = it.next();
         let c2 = it.next();
 
-        if c2.is_none() { c1 } else { None }
+        if c2.is_none() {
+            c1
+        } else {
+            None
+        }
     }
 
     #[inline]
@@ -301,7 +312,10 @@ impl AtomTable {
 
     #[inline(always)]
     fn lookup_str(&self, string: &str) -> Option<Atom> {
-        STATIC_ATOMS_MAP.get(string).or_else(|| self.table.get(string)).cloned()
+        STATIC_ATOMS_MAP
+            .get(string)
+            .or_else(|| self.table.get(string))
+            .cloned()
     }
 
     pub fn build_with(&mut self, string: &str) -> Atom {
@@ -355,9 +369,12 @@ impl AtomTable {
 pub struct AtomCell {
     name: B46,
     arity: B10,
-    #[allow(unused)] f: bool,
-    #[allow(unused)] m: bool,
-    #[allow(unused)] tag: B6,
+    #[allow(unused)]
+    f: bool,
+    #[allow(unused)]
+    m: bool,
+    #[allow(unused)]
+    tag: B6,
 }
 
 impl AtomCell {

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -60,7 +60,7 @@ fn global_atom_table() -> &'static RwLock<Weak<RwLock<AtomTable>>> {
     {
         // const Weak::new will be stabilized in 1.73 which is currently in beta,
         // till then we need a OnceLock for initialization
-        static GLOBAL_ATOM_TABLE: RwLock<Weak<RwLock<AtomTable>>> = RwLock::new(Weak::new());
+        static GLOBAL_ATOM_TABLE: RwLock<Weak<RwLock<AtomTable>>> = RwLock::const_new(Weak::new());
         &GLOBAL_ATOM_TABLE
     }
     #[cfg(not(feature = "rust_beta_channel"))]

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -388,6 +388,8 @@ impl AtomTable {
 
     pub fn build_with(atom_table: &RwLock<AtomTable>, string: &str) -> Atom {
         let mut atom_table = loop {
+            // we can't just use blocking_write as tokio's RwLock is fair
+            // and we can't block readers here as otherwise we will deadlock, see the guard downgrade below
             if let Ok(guard) = atom_table.try_write() {
                 break guard;
             }

--- a/src/bin/scryer-prolog.rs
+++ b/src/bin/scryer-prolog.rs
@@ -1,11 +1,12 @@
 fn main() -> std::process::ExitCode {
-    use std::sync::atomic::Ordering;
     use scryer_prolog::*;
+    use std::sync::atomic::Ordering;
 
     #[cfg(feature = "repl")]
     ctrlc::set_handler(move || {
         scryer_prolog::machine::INTERRUPT.store(true, Ordering::Relaxed);
-    }).unwrap();
+    })
+    .unwrap();
 
     let mut wam = machine::Machine::new();
     wam.run_top_level()

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -511,7 +511,7 @@ impl<'b> CodeGenerator<'b> {
                 TermRef::PartialString(lvl, cell, string, tail) => {
                     self.marker
                         .mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
-                    let atom = self.atom_tbl.blocking_write().build_with(&string);
+                    let atom = AtomTable::build_with(&self.atom_tbl, &string);
 
                     target.push_back(Target::to_pstr(lvl, atom, cell.get(), true));
                     self.subterm_to_instr::<Target>(tail, term_loc, &mut target);
@@ -1242,12 +1242,7 @@ impl<'b> CodeGenerator<'b> {
                 let index = code.len();
 
                 if clauses_len > 1 || self.settings.is_extensible {
-                    code_offsets.index_term(
-                        arg,
-                        index,
-                        &mut clause_index_info,
-                        &mut self.atom_tbl.blocking_write(),
-                    );
+                    code_offsets.index_term(arg, index, &mut clause_index_info, self.atom_tbl);
                 }
             }
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -18,8 +18,6 @@ use crate::machine::machine_errors::*;
 use fxhash::FxBuildHasher;
 use indexmap::IndexSet;
 
-use tokio::sync::RwLock;
-
 use std::cell::Cell;
 use std::collections::VecDeque;
 
@@ -264,7 +262,7 @@ impl CodeGenSettings {
 
 #[derive(Debug)]
 pub(crate) struct CodeGenerator<'a> {
-    pub(crate) atom_tbl: &'a RwLock<AtomTable>,
+    pub(crate) atom_tbl: &'a AtomTable,
     marker: DebrayAllocator,
     settings: CodeGenSettings,
     pub(crate) skeleton: PredicateSkeleton,
@@ -364,7 +362,7 @@ fn structure_cell(term: &Term) -> Option<&Cell<RegType>> {
 }
 
 impl<'b> CodeGenerator<'b> {
-    pub(crate) fn new(atom_tbl: &'b RwLock<AtomTable>, settings: CodeGenSettings) -> Self {
+    pub(crate) fn new(atom_tbl: &'b AtomTable, settings: CodeGenSettings) -> Self {
         CodeGenerator {
             atom_tbl,
             marker: DebrayAllocator::new(),

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,14 +1,14 @@
-use crate::atom_table::*;
-use crate::parser::ast::*;
-use crate::temp_v;
 use crate::allocator::*;
 use crate::arithmetic::*;
+use crate::atom_table::*;
 use crate::debray_allocator::*;
 use crate::forms::*;
 use crate::indexing::*;
 use crate::instructions::*;
 use crate::iterators::*;
+use crate::parser::ast::*;
 use crate::targets::*;
+use crate::temp_v;
 use crate::types::*;
 
 use crate::instr;
@@ -48,15 +48,20 @@ impl BranchCodeStack {
     }
 
     fn code<'a>(&'a mut self, default_code: &'a mut CodeDeque) -> &'a mut CodeDeque {
-        self.stack.last_mut()
+        self.stack
+            .last_mut()
             .and_then(|stack| stack.last_mut())
             .unwrap_or(default_code)
     }
 
-    fn push_missing_vars(&mut self, depth: usize, marker: &mut DebrayAllocator) -> SubsumedBranchHits {
+    fn push_missing_vars(
+        &mut self,
+        depth: usize,
+        marker: &mut DebrayAllocator,
+    ) -> SubsumedBranchHits {
         let mut subsumed_hits = SubsumedBranchHits::with_hasher(FxBuildHasher::default());
 
-        for idx in (self.stack.len() - depth .. self.stack.len()).rev() {
+        for idx in (self.stack.len() - depth..self.stack.len()).rev() {
             let branch = &mut marker.branch_stack[idx];
             let branch_hits = &branch.hits;
 
@@ -91,14 +96,14 @@ impl BranchCodeStack {
     fn push_jump_instrs(&mut self, depth: usize) {
         // add 2 in each arm length to compensate for each jump
         // instruction and each branch instruction not yet added.
-        let mut jump_span: usize = self.stack[self.stack.len() - depth ..]
+        let mut jump_span: usize = self.stack[self.stack.len() - depth..]
             .iter()
             .map(|branch| branch.iter().map(|code| code.len() + 2).sum::<usize>())
             .sum();
 
         jump_span -= depth;
 
-        for idx in self.stack.len() - depth .. self.stack.len() {
+        for idx in self.stack.len() - depth..self.stack.len() {
             let inner_len = self.stack[idx].len();
 
             for (inner_idx, code) in self.stack[idx].iter_mut().enumerate() {
@@ -117,9 +122,11 @@ impl BranchCodeStack {
     fn pop_branch(&mut self, depth: usize, settings: CodeGenSettings) -> CodeDeque {
         let mut combined_code = CodeDeque::new();
 
-        for mut branch_arm in self.stack.drain(self.stack.len() - depth ..).rev() {
+        for mut branch_arm in self.stack.drain(self.stack.len() - depth..).rev() {
             let num_branch_arms = branch_arm.len();
-            branch_arm.last_mut().map(|code| code.extend(combined_code.drain(..)));
+            branch_arm
+                .last_mut()
+                .map(|code| code.extend(combined_code.drain(..)));
 
             for (idx, code) in branch_arm.into_iter().enumerate() {
                 combined_code.push_back(if idx == 0 {
@@ -269,13 +276,7 @@ impl DebrayAllocator {
         vr: &Cell<VarReg>,
         code: &mut CodeDeque,
     ) -> RegType {
-        self.mark_var::<QueryInstruction>(
-            var_num,
-            Level::Shallow,
-            vr,
-            term_loc,
-            code,
-        );
+        self.mark_var::<QueryInstruction>(var_num, Level::Shallow, vr, term_loc, code);
 
         vr.get().norm()
     }
@@ -308,8 +309,8 @@ impl DebrayAllocator {
 // decrement the arity of the PutStructure instruction by 1.
 fn trim_structure_by_last_arg(instr: &mut Instruction, last_arg: &Term) {
     match instr {
-        Instruction::PutStructure(_, ref mut arity, _) |
-        Instruction::GetStructure(.., ref mut arity, _) => {
+        Instruction::PutStructure(_, ref mut arity, _)
+        | Instruction::GetStructure(.., ref mut arity, _) => {
             if let Term::Literal(_, Literal::CodeIndex(_)) = last_arg {
                 // it is acceptable if arity == 0 is the result of
                 // this decrement. call/N will have to read the index
@@ -352,10 +353,10 @@ impl<'a, 'b> AddToFreeList<'a, QueryInstruction> for CodeGenerator<'b> {
 
 fn structure_cell(term: &Term) -> Option<&Cell<RegType>> {
     match term {
-        &Term::Cons(ref cell, ..) |
-        &Term::Clause(ref cell, ..) |
-        Term::PartialString(ref cell, ..) |
-        Term::CompleteString(ref cell, ..) => Some(cell),
+        &Term::Cons(ref cell, ..)
+        | &Term::Clause(ref cell, ..)
+        | Term::PartialString(ref cell, ..)
+        | Term::CompleteString(ref cell, ..) => Some(cell),
         _ => None,
     }
 }
@@ -392,7 +393,8 @@ impl<'b> CodeGenerator<'b> {
         target: &mut CodeDeque,
     ) {
         if self.marker.var_data.records[var_num].num_occurrences > 1 {
-            self.marker.mark_var::<Target>(var_num, Level::Deep, cell, term_loc, target);
+            self.marker
+                .mark_var::<Target>(var_num, Level::Deep, cell, term_loc, target);
         } else {
             Self::add_or_increment_void_instr::<Target>(target);
         }
@@ -408,31 +410,33 @@ impl<'b> CodeGenerator<'b> {
             &Term::AnonVar => {
                 Self::add_or_increment_void_instr::<Target>(target);
             }
-            &Term::Cons(ref cell, ..) |
-            &Term::Clause(ref cell, ..) |
-            Term::PartialString(ref cell, ..) |
-            Term::CompleteString(ref cell, ..) => {
-                self.marker.mark_non_var::<Target>(Level::Deep, term_loc, cell, target);
+            &Term::Cons(ref cell, ..)
+            | &Term::Clause(ref cell, ..)
+            | Term::PartialString(ref cell, ..)
+            | Term::CompleteString(ref cell, ..) => {
+                self.marker
+                    .mark_non_var::<Target>(Level::Deep, term_loc, cell, target);
                 target.push_back(Target::clause_arg_to_instr(cell.get()));
             }
             &Term::Literal(_, ref constant) => {
                 target.push_back(Target::constant_subterm(constant.clone()));
             }
             &Term::Var(ref cell, ref var_ptr) => {
-                self.deep_var_instr::<Target>(cell, var_ptr.to_var_num().unwrap(), term_loc, target);
+                self.deep_var_instr::<Target>(
+                    cell,
+                    var_ptr.to_var_num().unwrap(),
+                    term_loc,
+                    target,
+                );
             }
         };
     }
 
-    fn compile_target<'a, Target, Iter>(
-        &mut self,
-        iter: Iter,
-        term_loc: GenContext,
-    ) -> CodeDeque
+    fn compile_target<'a, Target, Iter>(&mut self, iter: Iter, term_loc: GenContext) -> CodeDeque
     where
         Target: crate::targets::CompilationTarget<'a>,
         Iter: Iterator<Item = TermRef<'a>>,
-        CodeGenerator<'b>: AddToFreeList<'a, Target>
+        CodeGenerator<'b>: AddToFreeList<'a, Target>,
     {
         let mut target = CodeDeque::new();
 
@@ -442,14 +446,19 @@ impl<'b> CodeGenerator<'b> {
                     if let GenContext::Head = term_loc {
                         self.marker.advance_arg();
                     } else {
-                        self.marker.mark_anon_var::<Target>(lvl, term_loc, &mut target);
+                        self.marker
+                            .mark_anon_var::<Target>(lvl, term_loc, &mut target);
                     }
                 }
                 TermRef::Clause(lvl, cell, name, terms) => {
-                    self.marker.mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
+                    self.marker
+                        .mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
                     target.push_back(Target::to_structure(lvl, name, terms.len(), cell.get()));
 
-                    <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_term_to_free_list(self, cell.get());
+                    <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_term_to_free_list(
+                        self,
+                        cell.get(),
+                    );
 
                     if let Some(instr) = target.back_mut() {
                         if let Some(term) = terms.last() {
@@ -462,38 +471,52 @@ impl<'b> CodeGenerator<'b> {
                     }
 
                     for subterm in terms {
-                        <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_subterm_to_free_list(self, subterm);
+                        <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_subterm_to_free_list(
+                            self, subterm,
+                        );
                     }
                 }
                 TermRef::Cons(lvl, cell, head, tail) => {
-                    self.marker.mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
+                    self.marker
+                        .mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
                     target.push_back(Target::to_list(lvl, cell.get()));
 
-                    <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_term_to_free_list(self, cell.get());
+                    <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_term_to_free_list(
+                        self,
+                        cell.get(),
+                    );
 
                     self.subterm_to_instr::<Target>(head, term_loc, &mut target);
                     self.subterm_to_instr::<Target>(tail, term_loc, &mut target);
 
-                    <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_subterm_to_free_list(self, head);
-                    <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_subterm_to_free_list(self, tail);
+                    <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_subterm_to_free_list(
+                        self, head,
+                    );
+                    <CodeGenerator<'b> as AddToFreeList<'a, Target>>::add_subterm_to_free_list(
+                        self, tail,
+                    );
                 }
                 TermRef::Literal(lvl @ Level::Shallow, cell, Literal::String(ref string)) => {
-                    self.marker.mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
+                    self.marker
+                        .mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
                     target.push_back(Target::to_pstr(lvl, *string, cell.get(), false));
                 }
                 TermRef::Literal(lvl @ Level::Shallow, cell, constant) => {
-                    self.marker.mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
+                    self.marker
+                        .mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
                     target.push_back(Target::to_constant(lvl, *constant, cell.get()));
                 }
                 TermRef::PartialString(lvl, cell, string, tail) => {
-                    self.marker.mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
+                    self.marker
+                        .mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
                     let atom = self.atom_tbl.build_with(&string);
 
                     target.push_back(Target::to_pstr(lvl, atom, cell.get(), true));
                     self.subterm_to_instr::<Target>(tail, term_loc, &mut target);
                 }
                 TermRef::CompleteString(lvl, cell, atom) => {
-                    self.marker.mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
+                    self.marker
+                        .mark_non_var::<Target>(lvl, term_loc, cell, &mut target);
                     target.push_back(Target::to_pstr(lvl, atom, cell.get(), false));
                 }
                 TermRef::Var(lvl @ Level::Shallow, cell, var) => {
@@ -563,9 +586,9 @@ impl<'b> CodeGenerator<'b> {
                 compare_number_instr!(cmp, at_1, at_2)
             }
             &InlinedClauseType::IsAtom(..) => match &terms[0] {
-                &Term::Literal(_, Literal::Char(_)) |
-                &Term::Literal(_, Literal::Atom(atom!("[]"))) |
-                &Term::Literal(_, Literal::Atom(..)) => {
+                &Term::Literal(_, Literal::Char(_))
+                | &Term::Literal(_, Literal::Atom(atom!("[]")))
+                | &Term::Literal(_, Literal::Atom(..)) => {
                     instr!("$succeed")
                 }
                 &Term::Var(ref vr, ref name) => {
@@ -586,11 +609,11 @@ impl<'b> CodeGenerator<'b> {
                 }
             },
             &InlinedClauseType::IsAtomic(..) => match &terms[0] {
-                &Term::AnonVar |
-                &Term::Clause(..) |
-                &Term::Cons(..) |
-                &Term::PartialString(..) |
-                &Term::CompleteString(..) => {
+                &Term::AnonVar
+                | &Term::Clause(..)
+                | &Term::Cons(..)
+                | &Term::PartialString(..)
+                | &Term::CompleteString(..) => {
                     instr!("$fail")
                 }
                 &Term::Literal(_, Literal::String(_)) => {
@@ -614,11 +637,11 @@ impl<'b> CodeGenerator<'b> {
                 }
             },
             &InlinedClauseType::IsCompound(..) => match &terms[0] {
-                &Term::Clause(..) |
-                &Term::Cons(..) |
-                &Term::PartialString(..) |
-                &Term::CompleteString(..) |
-                &Term::Literal(_, Literal::String(..)) => {
+                &Term::Clause(..)
+                | &Term::Cons(..)
+                | &Term::PartialString(..)
+                | &Term::CompleteString(..)
+                | &Term::Literal(_, Literal::String(..)) => {
                     instr!("$succeed")
                 }
                 &Term::Var(ref vr, ref name) => {
@@ -644,7 +667,13 @@ impl<'b> CodeGenerator<'b> {
                 }
                 &Term::Var(ref vr, ref name) => {
                     self.marker.reset_arg(1);
-                    let r = self.marker.mark_non_callable(name.to_var_num().unwrap(), 1,  term_loc, vr, code);
+                    let r = self.marker.mark_non_callable(
+                        name.to_var_num().unwrap(),
+                        1,
+                        term_loc,
+                        vr,
+                        code,
+                    );
                     instr!("rational", r)
                 }
                 _ => {
@@ -673,10 +702,10 @@ impl<'b> CodeGenerator<'b> {
                 }
             },
             &InlinedClauseType::IsNumber(..) => match &terms[0] {
-                &Term::Literal(_, Literal::Float(_)) |
-                &Term::Literal(_, Literal::Rational(_)) |
-                &Term::Literal(_, Literal::Integer(_)) |
-                &Term::Literal(_, Literal::Fixnum(_)) => {
+                &Term::Literal(_, Literal::Float(_))
+                | &Term::Literal(_, Literal::Rational(_))
+                | &Term::Literal(_, Literal::Integer(_))
+                | &Term::Literal(_, Literal::Fixnum(_)) => {
                     instr!("$succeed")
                 }
                 &Term::Var(ref vr, ref name) => {
@@ -718,8 +747,7 @@ impl<'b> CodeGenerator<'b> {
                 }
             },
             &InlinedClauseType::IsInteger(..) => match &terms[0] {
-                &Term::Literal(_, Literal::Integer(_)) |
-                &Term::Literal(_, Literal::Fixnum(_)) => {
+                &Term::Literal(_, Literal::Integer(_)) | &Term::Literal(_, Literal::Fixnum(_)) => {
                     instr!("$succeed")
                 }
                 &Term::Var(ref vr, ref name) => {
@@ -740,11 +768,11 @@ impl<'b> CodeGenerator<'b> {
                 }
             },
             &InlinedClauseType::IsVar(..) => match &terms[0] {
-                &Term::Literal(..) |
-                &Term::Clause(..) |
-                &Term::Cons(..) |
-                &Term::PartialString(..) |
-                &Term::CompleteString(..) => {
+                &Term::Literal(..)
+                | &Term::Clause(..)
+                | &Term::Cons(..)
+                | &Term::PartialString(..)
+                | &Term::CompleteString(..) => {
                     instr!("$fail")
                 }
                 &Term::AnonVar => {
@@ -791,11 +819,11 @@ impl<'b> CodeGenerator<'b> {
         call_policy: CallPolicy,
     ) -> Result<(), CompilationError> {
         macro_rules! compile_expr {
-            ($self:expr, $terms:expr, $term_loc:expr, $code:expr) => ({
+            ($self:expr, $terms:expr, $term_loc:expr, $code:expr) => {{
                 let (acode, at) = $self.compile_arith_expr($terms, 1, $term_loc, 2)?;
                 $code.extend(acode.into_iter());
                 at
-            });
+            }};
         }
 
         self.marker.reset_arg(2);
@@ -843,10 +871,13 @@ impl<'b> CodeGenerator<'b> {
                     compile_expr!(self, &terms[1], term_loc, code)
                 }
             }
-            &Term::Literal(_, c @ Literal::Integer(_) |
-                              c @ Literal::Float(_) |
-                              c @ Literal::Rational(_) |
-                              c @ Literal::Fixnum(_)) => {
+            &Term::Literal(
+                _,
+                c @ Literal::Integer(_)
+                | c @ Literal::Float(_)
+                | c @ Literal::Rational(_)
+                | c @ Literal::Fixnum(_),
+            ) => {
                 let v = HeapCellValue::from(c);
                 code.push_back(instr!("put_constant", Level::Shallow, v, temp_v!(1)));
 
@@ -939,15 +970,29 @@ impl<'b> CodeGenerator<'b> {
                                 ClauseType::BuiltIn(BuiltInClauseType::Is(..)),
                                 ref terms,
                                 call_policy,
-                            ) => self.compile_is_call(terms, branch_code_stack.code(code), term_loc, call_policy)?,
+                            ) => self.compile_is_call(
+                                terms,
+                                branch_code_stack.code(code),
+                                term_loc,
+                                call_policy,
+                            )?,
                             &QueryTerm::Clause(_, ClauseType::Inlined(ref ct), ref terms, _) => {
-                                self.compile_inlined(ct, terms, term_loc, branch_code_stack.code(code))?
+                                self.compile_inlined(
+                                    ct,
+                                    terms,
+                                    term_loc,
+                                    branch_code_stack.code(code),
+                                )?
                             }
                             &QueryTerm::Fail => {
                                 branch_code_stack.code(code).push_back(instr!("$fail"));
                             }
                             term @ &QueryTerm::Clause(..) => {
-                                self.compile_query_line(term, term_loc, branch_code_stack.code(code));
+                                self.compile_query_line(
+                                    term,
+                                    term_loc,
+                                    branch_code_stack.code(code),
+                                );
 
                                 if self.marker.max_reg_allocated() > MAX_ARITY {
                                     return Err(CompilationError::ExceededMaxArity);
@@ -975,7 +1020,8 @@ impl<'b> CodeGenerator<'b> {
                 }
                 ClauseItem::BranchEnd(depth) => {
                     if !clause_iter.in_tail_position() {
-                        let subsumed_hits = branch_code_stack.push_missing_vars(depth, &mut self.marker);
+                        let subsumed_hits =
+                            branch_code_stack.push_missing_vars(depth, &mut self.marker);
                         self.marker.pop_branch(depth, subsumed_hits);
                         branch_code_stack.push_jump_instrs(depth);
                     } else {
@@ -1001,8 +1047,15 @@ impl<'b> CodeGenerator<'b> {
         Ok(())
     }
 
-    pub(crate) fn compile_rule(&mut self, rule: &Rule, var_data: VarData) -> Result<Code, CompilationError> {
-        let Rule { head: (_, args), clauses } = rule;
+    pub(crate) fn compile_rule(
+        &mut self,
+        rule: &Rule,
+        var_data: VarData,
+    ) -> Result<Code, CompilationError> {
+        let Rule {
+            head: (_, args),
+            clauses,
+        } = rule;
         self.marker.var_data = var_data;
         let mut code = VecDeque::new();
 
@@ -1023,7 +1076,11 @@ impl<'b> CodeGenerator<'b> {
         Ok(Vec::from(code))
     }
 
-    pub(crate) fn compile_fact(&mut self, fact: &Fact, var_data: VarData) -> Result<Code, CompilationError> {
+    pub(crate) fn compile_fact(
+        &mut self,
+        fact: &Fact,
+        var_data: VarData,
+    ) -> Result<Code, CompilationError> {
         let mut code = Vec::new();
         self.marker.var_data = var_data;
 
@@ -1031,10 +1088,7 @@ impl<'b> CodeGenerator<'b> {
             self.marker.reset_at_head(args);
 
             let iter = FactInstruction::iter(&fact.head);
-            let compiled_fact = self.compile_target::<FactInstruction, _>(
-                iter,
-                GenContext::Head,
-            );
+            let compiled_fact = self.compile_target::<FactInstruction, _>(iter, GenContext::Head);
 
             if self.marker.max_reg_allocated() > MAX_ARITY {
                 return Err(CompilationError::ExceededMaxArity);
@@ -1059,7 +1113,7 @@ impl<'b> CodeGenerator<'b> {
             &QueryTerm::Clause(_, ref ct, _, call_policy) => {
                 self.add_call(code, ct.to_instr(), call_policy);
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         };
     }
 
@@ -1072,8 +1126,7 @@ impl<'b> CodeGenerator<'b> {
             if let Some(args) = clause.args() {
                 for (instantiated_arg_index, arg) in args.iter().enumerate() {
                     match arg {
-                        Term::Var(..) | Term::AnonVar => {
-                        }
+                        Term::Var(..) | Term::AnonVar => {}
                         _ => {
                             if optimal_index != instantiated_arg_index {
                                 if left >= right {
@@ -1098,7 +1151,11 @@ impl<'b> CodeGenerator<'b> {
             }
 
             if left < right {
-                subseqs.push(ClauseSpan { left, right, instantiated_arg_index: optimal_index });
+                subseqs.push(ClauseSpan {
+                    left,
+                    right,
+                    instantiated_arg_index: optimal_index,
+                });
             }
 
             optimal_index = 0;
@@ -1129,11 +1186,8 @@ impl<'b> CodeGenerator<'b> {
         optimal_index: usize,
     ) -> Result<Code, CompilationError> {
         let mut code = VecDeque::new();
-        let mut code_offsets = CodeOffsets::new(
-            I::new(),
-            optimal_index + 1,
-            self.settings.non_counted_bt,
-        );
+        let mut code_offsets =
+            CodeOffsets::new(I::new(), optimal_index + 1, self.settings.non_counted_bt);
 
         let mut skip_stub_try_me_else = false;
         let clauses_len = clauses.len();
@@ -1178,7 +1232,9 @@ impl<'b> CodeGenerator<'b> {
                 skip_stub_try_me_else = !self.settings.is_dynamic();
             }
 
-            let arg = clause.args().and_then(|args| args.iter().nth(optimal_index));
+            let arg = clause
+                .args()
+                .and_then(|args| args.iter().nth(optimal_index));
 
             if let Some(arg) = arg {
                 let index = code.len();
@@ -1221,7 +1277,12 @@ impl<'b> CodeGenerator<'b> {
         let split_pred = Self::split_predicate(&clauses);
         let multi_seq = split_pred.len() > 1;
 
-        for ClauseSpan { left, right, instantiated_arg_index } in split_pred {
+        for ClauseSpan {
+            left,
+            right,
+            instantiated_arg_index,
+        } in split_pred
+        {
             let skel_lower_bound = self.skeleton.clauses.len();
             let code_segment = if self.settings.is_dynamic() {
                 self.compile_pred_subseq::<DynamicCodeIndices>(
@@ -1252,9 +1313,8 @@ impl<'b> CodeGenerator<'b> {
             if self.settings.is_extensible {
                 let segment_is_indexed = code_segment[0].to_indexing_line().is_some();
 
-                for clause_index_info in self.skeleton.clauses
-                                             .make_contiguous()[skel_lower_bound..]
-                                             .iter_mut()
+                for clause_index_info in
+                    self.skeleton.clauses.make_contiguous()[skel_lower_bound..].iter_mut()
                 {
                     clause_index_info.clause_start +=
                         clause_start_offset + 2 * (segment_is_indexed as usize);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -101,7 +101,7 @@ impl ForeignFunctionTable {
                 atom!("ptr") => &mut types::pointer,
                 atom!("f32") => &mut types::float,
                 atom!("f64") => &mut types::double,
-                struct_name => match self.structs.get_mut(struct_name.as_str()) {
+                struct_name => match self.structs.get_mut(&*struct_name.as_str()) {
                     Some(ref mut struct_type) => &mut struct_type.ffi_type,
                     None => unreachable!(),
                 },
@@ -437,11 +437,11 @@ impl ForeignFunctionTable {
                         let substruct = struct_type.atom_fields[i].as_str();
                         let struct_type = self
                             .structs
-                            .get(substruct)
+                            .get(&*substruct)
                             .ok_or(FFIError::StructNotFound)?;
                         field_ptr = field_ptr
                             .add(field_ptr.align_offset(struct_type.ffi_type.alignment as usize));
-                        let struct_val = self.read_struct(field_ptr, substruct, struct_type);
+                        let struct_val = self.read_struct(field_ptr, &*substruct, struct_type);
                         returns.push(struct_val?);
                         field_ptr = field_ptr.add(struct_type.ffi_type.size);
                     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -24,12 +24,12 @@ use crate::atom_table::Atom;
 use std::alloc::{alloc, Layout};
 use std::any::Any;
 use std::collections::HashMap;
-use std::error::Error;
-use std::ffi::{CString, c_void};
 use std::convert::TryFrom;
+use std::error::Error;
+use std::ffi::{c_void, CString};
 
-use libffi::low::{ffi_cif, types, CodePtr, ffi_abi_FFI_DEFAULT_ABI, prep_cif, ffi_type, type_tag};
-use libloading::{Symbol, Library};
+use libffi::low::{ffi_abi_FFI_DEFAULT_ABI, ffi_cif, ffi_type, prep_cif, type_tag, types, CodePtr};
+use libloading::{Library, Symbol};
 
 pub struct FunctionDefinition {
     pub name: String,
@@ -65,338 +65,393 @@ struct PointerArgs {
 
 impl ForeignFunctionTable {
     pub fn merge(&mut self, other: ForeignFunctionTable) {
-	self.table.extend(other.table);
+        self.table.extend(other.table);
     }
 
     pub fn define_struct(&mut self, name: &str, atom_fields: Vec<Atom>) {
-	let mut fields: Vec<_> = atom_fields.iter().map(|x| self.map_type_ffi(&x)).collect();
-	fields.push(std::ptr::null_mut::<ffi_type>());
-	let mut struct_type: ffi_type = Default::default();
-	struct_type.type_ = type_tag::STRUCT;
-	struct_type.elements = fields.as_mut_ptr();
-	self.structs.insert(name.to_string(), StructImpl { ffi_type: struct_type, fields, atom_fields});
+        let mut fields: Vec<_> = atom_fields.iter().map(|x| self.map_type_ffi(&x)).collect();
+        fields.push(std::ptr::null_mut::<ffi_type>());
+        let mut struct_type: ffi_type = Default::default();
+        struct_type.type_ = type_tag::STRUCT;
+        struct_type.elements = fields.as_mut_ptr();
+        self.structs.insert(
+            name.to_string(),
+            StructImpl {
+                ffi_type: struct_type,
+                fields,
+                atom_fields,
+            },
+        );
     }
 
     fn map_type_ffi(&mut self, source: &Atom) -> *mut ffi_type {
-	unsafe {
-	    match source {
-		atom!("sint64") => &mut types::sint64,
-		atom!("sint32") => &mut types::sint32,
-		atom!("sint16") => &mut types::sint16,
-		atom!("sint8") => &mut types::sint8,
-		atom!("uint64") => &mut types::uint64,
-		atom!("uint32") => &mut types::uint32,
-		atom!("uint16") => &mut types::uint16,
-		atom!("uint8") => &mut types::uint8,
-		atom!("bool") => &mut types::sint8,
-		atom!("void") => &mut types::void,
-		atom!("cstr") => &mut types::pointer,
-		atom!("ptr") => &mut types::pointer,
-		atom!("f32") => &mut types::float,
-		atom!("f64") => &mut types::double,
-		struct_name => {
-		    match self.structs.get_mut(struct_name.as_str()) {
-			Some(ref mut struct_type) => {
-			    &mut struct_type.ffi_type
-			},
-			None => unreachable!()
-		    }
-		}
-	    }
-	}
+        unsafe {
+            match source {
+                atom!("sint64") => &mut types::sint64,
+                atom!("sint32") => &mut types::sint32,
+                atom!("sint16") => &mut types::sint16,
+                atom!("sint8") => &mut types::sint8,
+                atom!("uint64") => &mut types::uint64,
+                atom!("uint32") => &mut types::uint32,
+                atom!("uint16") => &mut types::uint16,
+                atom!("uint8") => &mut types::uint8,
+                atom!("bool") => &mut types::sint8,
+                atom!("void") => &mut types::void,
+                atom!("cstr") => &mut types::pointer,
+                atom!("ptr") => &mut types::pointer,
+                atom!("f32") => &mut types::float,
+                atom!("f64") => &mut types::double,
+                struct_name => match self.structs.get_mut(struct_name.as_str()) {
+                    Some(ref mut struct_type) => &mut struct_type.ffi_type,
+                    None => unreachable!(),
+                },
+            }
+        }
     }
 
-    pub(crate) fn load_library(&mut self, library_name: &str, functions: &Vec<FunctionDefinition>) -> Result<(), Box<dyn Error>> {
-	let mut ff_table: ForeignFunctionTable = Default::default();
-	unsafe {
-	    let library = Library::new(library_name)?;
-	    for function in functions {
-		let symbol_name: CString = CString::new(function.name.clone())?;
-		let code_ptr: Symbol<*mut c_void> = library.get(&symbol_name.into_bytes_with_nul())?;
-		let mut args: Vec<_> = function.args.iter().map(|x| self.map_type_ffi(&x)).collect();
-		let mut cif: ffi_cif = Default::default();
-		prep_cif(
-		    &mut cif,
-		    ffi_abi_FFI_DEFAULT_ABI,
-		    args.len(),
-		    self.map_type_ffi(&function.return_value),
-		    args.as_mut_ptr()
-		).unwrap();
+    pub(crate) fn load_library(
+        &mut self,
+        library_name: &str,
+        functions: &Vec<FunctionDefinition>,
+    ) -> Result<(), Box<dyn Error>> {
+        let mut ff_table: ForeignFunctionTable = Default::default();
+        unsafe {
+            let library = Library::new(library_name)?;
+            for function in functions {
+                let symbol_name: CString = CString::new(function.name.clone())?;
+                let code_ptr: Symbol<*mut c_void> =
+                    library.get(&symbol_name.into_bytes_with_nul())?;
+                let mut args: Vec<_> = function
+                    .args
+                    .iter()
+                    .map(|x| self.map_type_ffi(&x))
+                    .collect();
+                let mut cif: ffi_cif = Default::default();
+                prep_cif(
+                    &mut cif,
+                    ffi_abi_FFI_DEFAULT_ABI,
+                    args.len(),
+                    self.map_type_ffi(&function.return_value),
+                    args.as_mut_ptr(),
+                )
+                .unwrap();
 
-		let return_struct_name = if (*self.map_type_ffi(&function.return_value)).type_ as u32 == libffi::raw::FFI_TYPE_STRUCT {
-		    Some(function.return_value.as_str().to_string())
-		} else {
-		    None
-		};
+                let return_struct_name = if (*self.map_type_ffi(&function.return_value)).type_
+                    as u32
+                    == libffi::raw::FFI_TYPE_STRUCT
+                {
+                    Some(function.return_value.as_str().to_string())
+                } else {
+                    None
+                };
 
-		ff_table.table.insert(function.name.clone(), FunctionImpl {
-		    cif,
-		    args,
-		    code_ptr: CodePtr(code_ptr.into_raw().into_raw() as *mut _),
-		    return_struct_name,
-		});
-	    }
-	    std::mem::forget(library);
-	}
-	self.merge(ff_table);
-	Ok(())
+                ff_table.table.insert(
+                    function.name.clone(),
+                    FunctionImpl {
+                        cif,
+                        args,
+                        code_ptr: CodePtr(code_ptr.into_raw().into_raw() as *mut _),
+                        return_struct_name,
+                    },
+                );
+            }
+            std::mem::forget(library);
+        }
+        self.merge(ff_table);
+        Ok(())
     }
 
-    fn build_pointer_args(args: &mut Vec<Value>, type_args: &Vec<*mut ffi_type>, structs_table: &mut HashMap<String, StructImpl>) -> Result<PointerArgs, FFIError> {
-	let mut pointers = Vec::with_capacity(args.len());
-	let mut _memory = Vec::new();
-	for i in 0..args.len() {
-	    let field_type = type_args[i];
-	    unsafe {
-		macro_rules! push_int {
-		    ($type:ty) => {
-			{
-			    let n: $type = <$type>::try_from(args[i].as_int()?).map_err(|_| FFIError::ValueDontFit)?;
-			    let mut box_value = Box::new(n) as Box<dyn Any>;
-			    pointers.push(&mut *box_value as *mut _ as *mut c_void);
-			    _memory.push(box_value);
-			}
-		    }
-		}
-		
-		match (*field_type).type_ as u32 {
-		    libffi::raw::FFI_TYPE_UINT8 => push_int!(u8),
-		    libffi::raw::FFI_TYPE_SINT8 => push_int!(i8),
-		    libffi::raw::FFI_TYPE_UINT16 => push_int!(u16),
-		    libffi::raw::FFI_TYPE_SINT16 => push_int!(i16),
-		    libffi::raw::FFI_TYPE_UINT32 => push_int!(u32),
-		    libffi::raw::FFI_TYPE_SINT32 => push_int!(i32),
-		    libffi::raw::FFI_TYPE_UINT64 => push_int!(u64),
-		    libffi::raw::FFI_TYPE_SINT64 => push_int!(i64),
-		    libffi::raw::FFI_TYPE_FLOAT => {
-			let n: f32 = args[i].as_float()? as f32;
-			let mut box_value = Box::new(n) as Box<dyn Any>;
-			pointers.push(&mut *box_value as *mut _ as *mut c_void);
-			_memory.push(box_value);
-		    },
-		    libffi::raw::FFI_TYPE_DOUBLE => {
-			let n: f64 = args[i].as_float()?;
-			let mut box_value = Box::new(n) as Box<dyn Any>;
-			pointers.push(&mut *box_value as *mut _ as *mut c_void);
-			_memory.push(box_value);
-		    },
-		    libffi::raw::FFI_TYPE_POINTER => {
-			let ptr: *mut c_void = args[i].as_ptr()?;
-			pointers.push(ptr);
-		    },
-		    libffi::raw::FFI_TYPE_STRUCT => {
-			let (mut ptr, _size, _align) = Self::build_struct(&mut args[i], structs_table)?;
-			pointers.push(&mut *ptr as *mut _ as *mut c_void);
-			_memory.push(ptr);
-		    },
-		    _ => return Err(FFIError::InvalidFFIType)
-		}
-	    }
-	}
-	Ok(PointerArgs {
-	    pointers,
-	    _memory
-	})
+    fn build_pointer_args(
+        args: &mut Vec<Value>,
+        type_args: &Vec<*mut ffi_type>,
+        structs_table: &mut HashMap<String, StructImpl>,
+    ) -> Result<PointerArgs, FFIError> {
+        let mut pointers = Vec::with_capacity(args.len());
+        let mut _memory = Vec::new();
+        for i in 0..args.len() {
+            let field_type = type_args[i];
+            unsafe {
+                macro_rules! push_int {
+                    ($type:ty) => {{
+                        let n: $type = <$type>::try_from(args[i].as_int()?)
+                            .map_err(|_| FFIError::ValueDontFit)?;
+                        let mut box_value = Box::new(n) as Box<dyn Any>;
+                        pointers.push(&mut *box_value as *mut _ as *mut c_void);
+                        _memory.push(box_value);
+                    }};
+                }
+
+                match (*field_type).type_ as u32 {
+                    libffi::raw::FFI_TYPE_UINT8 => push_int!(u8),
+                    libffi::raw::FFI_TYPE_SINT8 => push_int!(i8),
+                    libffi::raw::FFI_TYPE_UINT16 => push_int!(u16),
+                    libffi::raw::FFI_TYPE_SINT16 => push_int!(i16),
+                    libffi::raw::FFI_TYPE_UINT32 => push_int!(u32),
+                    libffi::raw::FFI_TYPE_SINT32 => push_int!(i32),
+                    libffi::raw::FFI_TYPE_UINT64 => push_int!(u64),
+                    libffi::raw::FFI_TYPE_SINT64 => push_int!(i64),
+                    libffi::raw::FFI_TYPE_FLOAT => {
+                        let n: f32 = args[i].as_float()? as f32;
+                        let mut box_value = Box::new(n) as Box<dyn Any>;
+                        pointers.push(&mut *box_value as *mut _ as *mut c_void);
+                        _memory.push(box_value);
+                    }
+                    libffi::raw::FFI_TYPE_DOUBLE => {
+                        let n: f64 = args[i].as_float()?;
+                        let mut box_value = Box::new(n) as Box<dyn Any>;
+                        pointers.push(&mut *box_value as *mut _ as *mut c_void);
+                        _memory.push(box_value);
+                    }
+                    libffi::raw::FFI_TYPE_POINTER => {
+                        let ptr: *mut c_void = args[i].as_ptr()?;
+                        pointers.push(ptr);
+                    }
+                    libffi::raw::FFI_TYPE_STRUCT => {
+                        let (mut ptr, _size, _align) =
+                            Self::build_struct(&mut args[i], structs_table)?;
+                        pointers.push(&mut *ptr as *mut _ as *mut c_void);
+                        _memory.push(ptr);
+                    }
+                    _ => return Err(FFIError::InvalidFFIType),
+                }
+            }
+        }
+        Ok(PointerArgs { pointers, _memory })
     }
 
-    fn build_struct(arg: &mut Value, structs_table: &mut HashMap<String, StructImpl>) -> Result<(Box<dyn Any>, usize, usize), FFIError> {
-	unsafe {
-        match arg {
-	    Value::Struct(ref name, ref mut struct_args) => {
-		if let Some(ref mut struct_type) = structs_table.clone().get_mut(name) {
-		    let layout = Layout::from_size_align(struct_type.ffi_type.size, struct_type.ffi_type.alignment.into()).unwrap();
-		    let align = struct_type.ffi_type.alignment as usize;
-		    let size = struct_type.ffi_type.size;
-		    let ptr = alloc(layout) as *mut c_void;
-		    let mut field_ptr = ptr;
+    fn build_struct(
+        arg: &mut Value,
+        structs_table: &mut HashMap<String, StructImpl>,
+    ) -> Result<(Box<dyn Any>, usize, usize), FFIError> {
+        unsafe {
+            match arg {
+                Value::Struct(ref name, ref mut struct_args) => {
+                    if let Some(ref mut struct_type) = structs_table.clone().get_mut(name) {
+                        let layout = Layout::from_size_align(
+                            struct_type.ffi_type.size,
+                            struct_type.ffi_type.alignment.into(),
+                        )
+                        .unwrap();
+                        let align = struct_type.ffi_type.alignment as usize;
+                        let size = struct_type.ffi_type.size;
+                        let ptr = alloc(layout) as *mut c_void;
+                        let mut field_ptr = ptr;
 
-		    for i in 0..(struct_type.fields.len()-1) {
-			macro_rules! try_write_int {
-			    ($type:ty) => {
-				{
-				    field_ptr = field_ptr.add(field_ptr.align_offset(std::mem::align_of::<$type>()));
-				    let n: $type = <$type>::try_from(struct_args[i].as_int()?).map_err(|_| FFIError::ValueDontFit)?;
-				    std::ptr::write(field_ptr as *mut $type, n);
-				    field_ptr = field_ptr.add(std::mem::size_of::<$type>());
-				}
-			    }
-			}
+                        for i in 0..(struct_type.fields.len() - 1) {
+                            macro_rules! try_write_int {
+                                ($type:ty) => {{
+                                    field_ptr = field_ptr
+                                        .add(field_ptr.align_offset(std::mem::align_of::<$type>()));
+                                    let n: $type = <$type>::try_from(struct_args[i].as_int()?)
+                                        .map_err(|_| FFIError::ValueDontFit)?;
+                                    std::ptr::write(field_ptr as *mut $type, n);
+                                    field_ptr = field_ptr.add(std::mem::size_of::<$type>());
+                                }};
+                            }
 
-			macro_rules! write {
-			    ($type:ty, $value:expr) => {
-				{
-				    let data: $type = $value;
-				    std::ptr::write(field_ptr as *mut $type, data);
-				    field_ptr = field_ptr.add(align);
-				}
-			    }
-			}
+                            macro_rules! write {
+                                ($type:ty, $value:expr) => {{
+                                    let data: $type = $value;
+                                    std::ptr::write(field_ptr as *mut $type, data);
+                                    field_ptr = field_ptr.add(align);
+                                }};
+                            }
 
-			let field = struct_type.fields[i];
-			match (*field).type_ as u32 {
-			    libffi::raw::FFI_TYPE_UINT8 => try_write_int!(u8),
-			    libffi::raw::FFI_TYPE_SINT8 => try_write_int!(i8),
-			    libffi::raw::FFI_TYPE_UINT16 => try_write_int!(u16),
-			    libffi::raw::FFI_TYPE_SINT16 => try_write_int!(i16),
-			    libffi::raw::FFI_TYPE_UINT32 => try_write_int!(u32),
-			    libffi::raw::FFI_TYPE_SINT32 => try_write_int!(i32),
-			    libffi::raw::FFI_TYPE_UINT64 => try_write_int!(u64),
-			    libffi::raw::FFI_TYPE_SINT64 => try_write_int!(i64),
-			    libffi::raw::FFI_TYPE_POINTER => write!(*mut c_void, struct_args[i].as_ptr()?),
-			    libffi::raw::FFI_TYPE_FLOAT => write!(f32, struct_args[i].as_float()? as f32),
-			    libffi::raw::FFI_TYPE_DOUBLE => write!(f64, struct_args[i].as_float()?),
-			    libffi::raw::FFI_TYPE_STRUCT => {
-				let (struct_ptr, struct_size, struct_align) = Self::build_struct(&mut struct_args[i], structs_table)?;
-				field_ptr = field_ptr.add(field_ptr.align_offset(struct_align));
-				
-				std::ptr::copy(& *struct_ptr as *const _ as *const c_void, field_ptr as *mut c_void, struct_size);
-				field_ptr = field_ptr.add(struct_size);
-			    },
-			    _ => {
-				unreachable!()
-			    }
-			}
-		    }
-		    return Ok((Box::from_raw(ptr), size, align));
-		} else {
-		    return Err(FFIError::InvalidStructName);
-		}
-	    }
-	    _ => return Err(FFIError::ValueCast)
-	}
-	}
+                            let field = struct_type.fields[i];
+                            match (*field).type_ as u32 {
+                                libffi::raw::FFI_TYPE_UINT8 => try_write_int!(u8),
+                                libffi::raw::FFI_TYPE_SINT8 => try_write_int!(i8),
+                                libffi::raw::FFI_TYPE_UINT16 => try_write_int!(u16),
+                                libffi::raw::FFI_TYPE_SINT16 => try_write_int!(i16),
+                                libffi::raw::FFI_TYPE_UINT32 => try_write_int!(u32),
+                                libffi::raw::FFI_TYPE_SINT32 => try_write_int!(i32),
+                                libffi::raw::FFI_TYPE_UINT64 => try_write_int!(u64),
+                                libffi::raw::FFI_TYPE_SINT64 => try_write_int!(i64),
+                                libffi::raw::FFI_TYPE_POINTER => {
+                                    write!(*mut c_void, struct_args[i].as_ptr()?)
+                                }
+                                libffi::raw::FFI_TYPE_FLOAT => {
+                                    write!(f32, struct_args[i].as_float()? as f32)
+                                }
+                                libffi::raw::FFI_TYPE_DOUBLE => {
+                                    write!(f64, struct_args[i].as_float()?)
+                                }
+                                libffi::raw::FFI_TYPE_STRUCT => {
+                                    let (struct_ptr, struct_size, struct_align) =
+                                        Self::build_struct(&mut struct_args[i], structs_table)?;
+                                    field_ptr = field_ptr.add(field_ptr.align_offset(struct_align));
+
+                                    std::ptr::copy(
+                                        &*struct_ptr as *const _ as *const c_void,
+                                        field_ptr as *mut c_void,
+                                        struct_size,
+                                    );
+                                    field_ptr = field_ptr.add(struct_size);
+                                }
+                                _ => {
+                                    unreachable!()
+                                }
+                            }
+                        }
+                        return Ok((Box::from_raw(ptr), size, align));
+                    } else {
+                        return Err(FFIError::InvalidStructName);
+                    }
+                }
+                _ => return Err(FFIError::ValueCast),
+            }
+        }
     }
 
     pub fn exec(&mut self, name: &str, mut args: Vec<Value>) -> Result<Value, FFIError> {
-	let function_impl = self.table.get_mut(name).ok_or(FFIError::FunctionNotFound)?;
-	let mut pointer_args = Self::build_pointer_args(&mut args, &function_impl.args, &mut self.structs)?;
-	
-	return unsafe {
-	    macro_rules! call_and_return {
-		($type:ty) => {
-		    {
-			let mut n: Box<u8> = Box::new(0);
-			libffi::raw::ffi_call(
-			    &mut function_impl.cif,
-			    Some(*function_impl.code_ptr.as_safe_fun()),
-			    &mut *n as *mut _ as *mut c_void,
-			    pointer_args.pointers.as_mut_ptr() as *mut *mut c_void
-			);
-			Ok(Value::Int(i64::from(*n)))
-		    }
-		}
-	    }
-	    
-	    match (*function_impl.cif.rtype).type_ as u32 {
-		libffi::raw::FFI_TYPE_VOID => call_and_return!(i32),
-		libffi::raw::FFI_TYPE_UINT8 => call_and_return!(u8),
-		libffi::raw::FFI_TYPE_SINT8 => call_and_return!(i8),
-		libffi::raw::FFI_TYPE_UINT16 => call_and_return!(u16),
-		libffi::raw::FFI_TYPE_SINT16 => call_and_return!(i16),
-		libffi::raw::FFI_TYPE_UINT32 => call_and_return!(u32),
-		libffi::raw::FFI_TYPE_SINT32 => call_and_return!(i32),
-		libffi::raw::FFI_TYPE_UINT64 => {
-		    let mut n: Box<u64> = Box::new(0);
-		    libffi::raw::ffi_call(
-			&mut function_impl.cif,
-			Some(*function_impl.code_ptr.as_safe_fun()),
-			&mut *n as *mut _ as *mut c_void,
-			pointer_args.pointers.as_mut_ptr() as *mut *mut c_void
-		    );
-		    Ok(Value::Int(i64::try_from(*n).map_err(|_| FFIError::ValueDontFit)?))
-		},
-		libffi::raw::FFI_TYPE_SINT64 => call_and_return!(i64),
-		libffi::raw::FFI_TYPE_POINTER => call_and_return!(*mut c_void),
-		libffi::raw::FFI_TYPE_FLOAT => {
-		    let mut n: Box<f32> = Box::new(0.0);
-		    libffi::raw::ffi_call(
-			&mut function_impl.cif,
-			Some(*function_impl.code_ptr.as_safe_fun()),
-			&mut *n as *mut _ as *mut c_void,
-			pointer_args.pointers.as_mut_ptr() as *mut *mut c_void
-		    );
-		    Ok(Value::Float((*n).into()))
-		},
-		libffi::raw::FFI_TYPE_DOUBLE => {
-		    let mut n: Box<f64> = Box::new(0.0);
-		    libffi::raw::ffi_call(
-			&mut function_impl.cif,
-			Some(*function_impl.code_ptr.as_safe_fun()),
-			&mut *n as *mut _ as *mut c_void,
-			pointer_args.pointers.as_mut_ptr() as *mut *mut c_void
-		    );
-		    Ok(Value::Float(*n))
-		},
-		libffi::raw::FFI_TYPE_STRUCT => {
-		    let name = &function_impl.return_struct_name.clone().ok_or(FFIError::StructNotFound)?;
-		    let struct_type = self.structs.get(name).ok_or(FFIError::StructNotFound)?;
-		    let layout = Layout::from_size_align(struct_type.ffi_type.size, struct_type.ffi_type.alignment.into()).unwrap();
-		    let ptr = alloc(layout) as *mut c_void;
+        let function_impl = self.table.get_mut(name).ok_or(FFIError::FunctionNotFound)?;
+        let mut pointer_args =
+            Self::build_pointer_args(&mut args, &function_impl.args, &mut self.structs)?;
 
-		    libffi::raw::ffi_call(
-			&mut function_impl.cif,
-			Some(*function_impl.code_ptr.as_safe_fun()),
-			&mut *ptr as *mut _ as *mut c_void,
-			pointer_args.pointers.as_mut_ptr() as *mut *mut c_void
-		    );
-		    let struct_val = self.read_struct(ptr, name, struct_type);
-		    drop(Box::from_raw(ptr));
-		    struct_val
-		}
-	    _ => unreachable!()
-	    }
-	};
+        return unsafe {
+            macro_rules! call_and_return {
+                ($type:ty) => {{
+                    let mut n: Box<u8> = Box::new(0);
+                    libffi::raw::ffi_call(
+                        &mut function_impl.cif,
+                        Some(*function_impl.code_ptr.as_safe_fun()),
+                        &mut *n as *mut _ as *mut c_void,
+                        pointer_args.pointers.as_mut_ptr() as *mut *mut c_void,
+                    );
+                    Ok(Value::Int(i64::from(*n)))
+                }};
+            }
+
+            match (*function_impl.cif.rtype).type_ as u32 {
+                libffi::raw::FFI_TYPE_VOID => call_and_return!(i32),
+                libffi::raw::FFI_TYPE_UINT8 => call_and_return!(u8),
+                libffi::raw::FFI_TYPE_SINT8 => call_and_return!(i8),
+                libffi::raw::FFI_TYPE_UINT16 => call_and_return!(u16),
+                libffi::raw::FFI_TYPE_SINT16 => call_and_return!(i16),
+                libffi::raw::FFI_TYPE_UINT32 => call_and_return!(u32),
+                libffi::raw::FFI_TYPE_SINT32 => call_and_return!(i32),
+                libffi::raw::FFI_TYPE_UINT64 => {
+                    let mut n: Box<u64> = Box::new(0);
+                    libffi::raw::ffi_call(
+                        &mut function_impl.cif,
+                        Some(*function_impl.code_ptr.as_safe_fun()),
+                        &mut *n as *mut _ as *mut c_void,
+                        pointer_args.pointers.as_mut_ptr() as *mut *mut c_void,
+                    );
+                    Ok(Value::Int(
+                        i64::try_from(*n).map_err(|_| FFIError::ValueDontFit)?,
+                    ))
+                }
+                libffi::raw::FFI_TYPE_SINT64 => call_and_return!(i64),
+                libffi::raw::FFI_TYPE_POINTER => call_and_return!(*mut c_void),
+                libffi::raw::FFI_TYPE_FLOAT => {
+                    let mut n: Box<f32> = Box::new(0.0);
+                    libffi::raw::ffi_call(
+                        &mut function_impl.cif,
+                        Some(*function_impl.code_ptr.as_safe_fun()),
+                        &mut *n as *mut _ as *mut c_void,
+                        pointer_args.pointers.as_mut_ptr() as *mut *mut c_void,
+                    );
+                    Ok(Value::Float((*n).into()))
+                }
+                libffi::raw::FFI_TYPE_DOUBLE => {
+                    let mut n: Box<f64> = Box::new(0.0);
+                    libffi::raw::ffi_call(
+                        &mut function_impl.cif,
+                        Some(*function_impl.code_ptr.as_safe_fun()),
+                        &mut *n as *mut _ as *mut c_void,
+                        pointer_args.pointers.as_mut_ptr() as *mut *mut c_void,
+                    );
+                    Ok(Value::Float(*n))
+                }
+                libffi::raw::FFI_TYPE_STRUCT => {
+                    let name = &function_impl
+                        .return_struct_name
+                        .clone()
+                        .ok_or(FFIError::StructNotFound)?;
+                    let struct_type = self.structs.get(name).ok_or(FFIError::StructNotFound)?;
+                    let layout = Layout::from_size_align(
+                        struct_type.ffi_type.size,
+                        struct_type.ffi_type.alignment.into(),
+                    )
+                    .unwrap();
+                    let ptr = alloc(layout) as *mut c_void;
+
+                    libffi::raw::ffi_call(
+                        &mut function_impl.cif,
+                        Some(*function_impl.code_ptr.as_safe_fun()),
+                        &mut *ptr as *mut _ as *mut c_void,
+                        pointer_args.pointers.as_mut_ptr() as *mut *mut c_void,
+                    );
+                    let struct_val = self.read_struct(ptr, name, struct_type);
+                    drop(Box::from_raw(ptr));
+                    struct_val
+                }
+                _ => unreachable!(),
+            }
+        };
     }
 
-    fn read_struct(&self, ptr: *mut c_void, name: &str, struct_type: &StructImpl) -> Result<Value, FFIError> {
-	unsafe {
-	    let mut returns = Vec::new();
-	    let mut field_ptr = ptr;
+    fn read_struct(
+        &self,
+        ptr: *mut c_void,
+        name: &str,
+        struct_type: &StructImpl,
+    ) -> Result<Value, FFIError> {
+        unsafe {
+            let mut returns = Vec::new();
+            let mut field_ptr = ptr;
 
-	    for i in 0..(struct_type.fields.len()-1) {
-		let field = struct_type.fields[i];
+            for i in 0..(struct_type.fields.len() - 1) {
+                let field = struct_type.fields[i];
 
-		macro_rules! read_and_push_int {
-		    ($type:ty) => {
-			{
-			    field_ptr = field_ptr.add(field_ptr.align_offset(std::mem::align_of::<$type>()));
-			    let n = std::ptr::read(field_ptr as *mut $type);
-			    returns.push(Value::Int(i64::from(n)));
-			    field_ptr = field_ptr.add(std::mem::size_of::<$type>());
-			}
-		    }
-		}
+                macro_rules! read_and_push_int {
+                    ($type:ty) => {{
+                        field_ptr =
+                            field_ptr.add(field_ptr.align_offset(std::mem::align_of::<$type>()));
+                        let n = std::ptr::read(field_ptr as *mut $type);
+                        returns.push(Value::Int(i64::from(n)));
+                        field_ptr = field_ptr.add(std::mem::size_of::<$type>());
+                    }};
+                }
 
-		match (*field).type_ as u32 {
-		    libffi::raw::FFI_TYPE_UINT8 => read_and_push_int!(u8),
-		    libffi::raw::FFI_TYPE_SINT8 => read_and_push_int!(i8),
-		    libffi::raw::FFI_TYPE_UINT16 => read_and_push_int!(u16),
-		    libffi::raw::FFI_TYPE_SINT16 => read_and_push_int!(i16),
-		    libffi::raw::FFI_TYPE_UINT32 => read_and_push_int!(u32),
-		    libffi::raw::FFI_TYPE_SINT32 => read_and_push_int!(i32),
-		    libffi::raw::FFI_TYPE_UINT64 => {
-			field_ptr = field_ptr.add(field_ptr.align_offset(std::mem::align_of::<u64>()));
-			let n = std::ptr::read(field_ptr as *mut u64);
-			returns.push(Value::Int(i64::try_from(n).map_err(|_| FFIError::ValueDontFit)?));
-			field_ptr = field_ptr.add(std::mem::size_of::<u64>());
-		    },
-		    libffi::raw::FFI_TYPE_SINT64 => read_and_push_int!(i64),
-		    libffi::raw::FFI_TYPE_POINTER => read_and_push_int!(i64),
-		    libffi::raw::FFI_TYPE_STRUCT => {
-			let substruct = struct_type.atom_fields[i].as_str();
-			let struct_type = self.structs.get(substruct).ok_or(FFIError::StructNotFound)?;
-			field_ptr = field_ptr.add(field_ptr.align_offset(struct_type.ffi_type.alignment as usize));
-			let struct_val = self.read_struct(field_ptr, substruct, struct_type);
-			returns.push(struct_val?);
-			field_ptr = field_ptr.add(struct_type.ffi_type.size);
-		    },
-		    _ => {
-			unreachable!()
-		    }
-		}
-	    }
-	    Ok(Value::Struct(name.into(), returns))
-	}
+                match (*field).type_ as u32 {
+                    libffi::raw::FFI_TYPE_UINT8 => read_and_push_int!(u8),
+                    libffi::raw::FFI_TYPE_SINT8 => read_and_push_int!(i8),
+                    libffi::raw::FFI_TYPE_UINT16 => read_and_push_int!(u16),
+                    libffi::raw::FFI_TYPE_SINT16 => read_and_push_int!(i16),
+                    libffi::raw::FFI_TYPE_UINT32 => read_and_push_int!(u32),
+                    libffi::raw::FFI_TYPE_SINT32 => read_and_push_int!(i32),
+                    libffi::raw::FFI_TYPE_UINT64 => {
+                        field_ptr =
+                            field_ptr.add(field_ptr.align_offset(std::mem::align_of::<u64>()));
+                        let n = std::ptr::read(field_ptr as *mut u64);
+                        returns.push(Value::Int(
+                            i64::try_from(n).map_err(|_| FFIError::ValueDontFit)?,
+                        ));
+                        field_ptr = field_ptr.add(std::mem::size_of::<u64>());
+                    }
+                    libffi::raw::FFI_TYPE_SINT64 => read_and_push_int!(i64),
+                    libffi::raw::FFI_TYPE_POINTER => read_and_push_int!(i64),
+                    libffi::raw::FFI_TYPE_STRUCT => {
+                        let substruct = struct_type.atom_fields[i].as_str();
+                        let struct_type = self
+                            .structs
+                            .get(substruct)
+                            .ok_or(FFIError::StructNotFound)?;
+                        field_ptr = field_ptr
+                            .add(field_ptr.align_offset(struct_type.ffi_type.alignment as usize));
+                        let struct_val = self.read_struct(field_ptr, substruct, struct_type);
+                        returns.push(struct_val?);
+                        field_ptr = field_ptr.add(struct_type.ffi_type.size);
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                }
+            }
+            Ok(Value::Struct(name.into(), returns))
+        }
     }
 }
 
@@ -410,26 +465,26 @@ pub enum Value {
 
 impl Value {
     fn as_int(&self) -> Result<i64, FFIError> {
-	match self {
-	    Value::Int(n) => Ok(*n),
-	    _ => Err(FFIError::ValueCast),
-	}
+        match self {
+            Value::Int(n) => Ok(*n),
+            _ => Err(FFIError::ValueCast),
+        }
     }
 
     fn as_float(&self) -> Result<f64, FFIError> {
-	match self {
-	    Value::Float(n) => Ok(*n),
-	    Value::Int(n) => Ok(*n as f64),
-	    _ => Err(FFIError::ValueCast),
-	}
+        match self {
+            Value::Float(n) => Ok(*n),
+            Value::Int(n) => Ok(*n as f64),
+            _ => Err(FFIError::ValueCast),
+        }
     }
 
     fn as_ptr(&mut self) -> Result<*mut c_void, FFIError> {
-	match self {
-	    Value::CString(ref mut cstr) => Ok(&mut *cstr as *mut _ as *mut c_void),
-	    Value::Int(n) => Ok(*n as *mut c_void),
-	    _ => Err(FFIError::ValueCast)
-	}
+        match self {
+            Value::CString(ref mut cstr) => Ok(&mut *cstr as *mut _ as *mut c_void),
+            Value::Int(n) => Ok(*n as *mut c_void),
+            _ => Err(FFIError::ValueCast),
+        }
     }
 }
 

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -16,8 +16,6 @@ use fxhash::FxBuildHasher;
 use indexmap::{IndexMap, IndexSet};
 use ordered_float::OrderedFloat;
 
-use tokio::sync::RwLock;
-
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::convert::TryFrom;
@@ -483,7 +481,7 @@ pub enum AtomOrString {
 
 impl AtomOrString {
     #[inline]
-    pub fn as_atom(&self, atom_tbl: &RwLock<AtomTable>) -> Atom {
+    pub fn as_atom(&self, atom_tbl: &AtomTable) -> Atom {
         match self {
             &AtomOrString::Atom(atom) => atom,
             AtomOrString::String(string) => AtomTable::build_with(atom_tbl, &string),

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -290,7 +290,7 @@ impl ClauseInfo for Term {
 
     fn arity(&self) -> usize {
         match self {
-            Term::Clause(_, name, terms) => match name.as_str() {
+            Term::Clause(_, name, terms) => match &*name.as_str() {
                 ":-" => match terms.len() {
                     1 => 0,
                     2 => terms[0].arity(),
@@ -489,11 +489,11 @@ impl AtomOrString {
     }
 
     #[inline]
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> AtomString<'_> {
         match self {
-            AtomOrString::Atom(atom) if atom == &atom!("[]") => "",
+            AtomOrString::Atom(atom) if atom == &atom!("[]") => AtomString::Static(""),
             AtomOrString::Atom(atom) => atom.as_str(),
-            AtomOrString::String(string) => string.as_str(),
+            AtomOrString::String(string) => AtomString::Static(string.as_str()),
         }
     }
 

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -16,6 +16,8 @@ use fxhash::FxBuildHasher;
 use indexmap::{IndexMap, IndexSet};
 use ordered_float::OrderedFloat;
 
+use tokio::sync::RwLock;
+
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::convert::TryFrom;
@@ -481,10 +483,10 @@ pub enum AtomOrString {
 
 impl AtomOrString {
     #[inline]
-    pub fn as_atom(&self, atom_tbl: &mut AtomTable) -> Atom {
+    pub fn as_atom(&self, atom_tbl: &RwLock<AtomTable>) -> Atom {
         match self {
             &AtomOrString::Atom(atom) => atom,
-            AtomOrString::String(string) => atom_tbl.build_with(&string),
+            AtomOrString::String(string) => AtomTable::build_with(atom_tbl, &string),
         }
     }
 

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -7,8 +7,8 @@ use crate::machine::loader::PredicateQueue;
 use crate::machine::machine_errors::*;
 use crate::machine::machine_indices::*;
 use crate::parser::ast::*;
-use crate::parser::parser::CompositeOpDesc;
 use crate::parser::dashu::{Integer, Rational};
+use crate::parser::parser::CompositeOpDesc;
 use crate::types::*;
 
 use fxhash::FxBuildHasher;
@@ -58,7 +58,7 @@ impl AppendOrPrepend {
 #[derive(Debug, Clone, Copy)]
 pub enum VarComparison {
     Indistinct,
-    Distinct
+    Distinct,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -153,11 +153,14 @@ impl DerefMut for ChunkedTermVec {
 impl ChunkedTermVec {
     #[inline]
     pub fn new() -> Self {
-        Self { chunk_vec: VecDeque::new() }
+        Self {
+            chunk_vec: VecDeque::new(),
+        }
     }
 
     pub fn reserve_branch(&mut self, capacity: usize) {
-        self.chunk_vec.push_back(ChunkedTerms::Branch(Vec::with_capacity(capacity)));
+        self.chunk_vec
+            .push_back(ChunkedTerms::Branch(Vec::with_capacity(capacity)));
     }
 
     pub fn push_branch_arm(&mut self, branch: VecDeque<ChunkedTerms>) {
@@ -173,19 +176,22 @@ impl ChunkedTermVec {
 
     #[inline]
     pub fn add_chunk(&mut self) {
-        self.chunk_vec.push_back(ChunkedTerms::Chunk(VecDeque::from(vec![])));
+        self.chunk_vec
+            .push_back(ChunkedTerms::Chunk(VecDeque::from(vec![])));
     }
 
     pub fn push_chunk_term(&mut self, term: QueryTerm) {
         match self.chunk_vec.back_mut() {
             Some(ChunkedTerms::Branch(_)) => {
-                self.chunk_vec.push_back(ChunkedTerms::Chunk(VecDeque::from(vec![term])));
+                self.chunk_vec
+                    .push_back(ChunkedTerms::Chunk(VecDeque::from(vec![term])));
             }
             Some(ChunkedTerms::Chunk(chunk)) => {
                 chunk.push_back(term);
             }
             None => {
-                self.chunk_vec.push_back(ChunkedTerms::Chunk(VecDeque::from(vec![term])));
+                self.chunk_vec
+                    .push_back(ChunkedTerms::Chunk(VecDeque::from(vec![term])));
             }
         }
     }
@@ -196,7 +202,7 @@ pub enum QueryTerm {
     // register, clause type, subterms, clause call policy.
     Clause(Cell<RegType>, ClauseType, Vec<Term>, CallPolicy),
     Fail,
-    LocalCut(usize), // var_num
+    LocalCut(usize),  // var_num
     GlobalCut(usize), // var_num
     GetCutPoint { var_num: usize, prev_b: bool },
     GetLevel(usize), // var_num
@@ -266,11 +272,10 @@ impl ClauseInfo for Term {
     fn name(&self) -> Option<Atom> {
         match self {
             Term::Clause(_, name, terms) => {
-
                 match name {
                     atom!(":-") => {
                         match terms.len() {
-                            1 => None,            // a declaration.
+                            1 => None, // a declaration.
                             2 => terms[0].name(),
                             _ => Some(*name),
                         }
@@ -410,7 +415,6 @@ pub(crate) fn fixity(spec: u32) -> Fixity {
     }
 }
 
-
 impl OpDecl {
     #[inline]
     pub(crate) fn new(op_desc: OpDesc, name: Atom) -> Self {
@@ -479,12 +483,8 @@ impl AtomOrString {
     #[inline]
     pub fn as_atom(&self, atom_tbl: &mut AtomTable) -> Atom {
         match self {
-            &AtomOrString::Atom(atom) => {
-                atom
-            }
-            AtomOrString::String(string) => {
-                atom_tbl.build_with(&string)
-            }
+            &AtomOrString::Atom(atom) => atom,
+            AtomOrString::String(string) => atom_tbl.build_with(&string),
         }
     }
 
@@ -500,12 +500,8 @@ impl AtomOrString {
     #[inline]
     pub fn to_string(self) -> String {
         match self {
-            AtomOrString::Atom(atom) => {
-                atom.as_str().to_owned()
-            }
-            AtomOrString::String(string) => {
-                string
-            }
+            AtomOrString::Atom(atom) => atom.as_str().to_owned(),
+            AtomOrString::String(string) => string,
         }
     }
 }
@@ -561,9 +557,7 @@ pub(crate) fn fetch_op_spec(name: Atom, arity: usize, op_dir: &OpDir) -> Option<
                 }
             })
         }
-        0 => {
-            fetch_atom_op_spec(name, None, op_dir)
-        }
+        0 => fetch_atom_op_spec(name, None, op_dir),
         _ => None,
     }
 }
@@ -595,10 +589,7 @@ pub struct Module {
 
 // Module's and related types are defined in forms.
 impl Module {
-    pub(crate) fn new(
-        module_decl: ModuleDecl,
-        listing_src: ListingSource,
-    ) -> Self {
+    pub(crate) fn new(module_decl: ModuleDecl, listing_src: ListingSource) -> Self {
         Module {
             module_decl,
             code_dir: CodeDir::with_hasher(FxBuildHasher::default()),
@@ -620,7 +611,7 @@ impl Module {
             meta_predicates: MetaPredicateDir::with_hasher(FxBuildHasher::default()),
             extensible_predicates: ExtensiblePredicates::with_hasher(FxBuildHasher::default()),
             local_extensible_predicates: LocalExtensiblePredicates::with_hasher(
-                FxBuildHasher::default()
+                FxBuildHasher::default(),
             ),
             listing_src: ListingSource::DynamicallyGenerated,
         }
@@ -923,8 +914,10 @@ impl PredicateInfo {
 
     #[inline]
     pub(crate) fn must_retract_local_clauses(&self, is_cross_module_clause: bool) -> bool {
-        self.is_extensible && self.has_clauses && !self.is_discontiguous &&
-            !(self.is_multifile && is_cross_module_clause)
+        self.is_extensible
+            && self.has_clauses
+            && !self.is_discontiguous
+            && !(self.is_multifile && is_cross_module_clause)
     }
 }
 
@@ -1013,19 +1006,17 @@ impl PredicateSkeleton {
         &mut self,
         clause_clause_loc: usize,
     ) -> Option<usize> {
-        let search_result = self.core.clause_clause_locs
-            .make_contiguous()[0..self.core.clause_assert_margin]
+        let search_result = self.core.clause_clause_locs.make_contiguous()
+            [0..self.core.clause_assert_margin]
             .binary_search_by(|loc| clause_clause_loc.cmp(&loc));
 
         match search_result {
             Ok(loc) => Some(loc),
-            Err(_) => {
-                self.core.clause_clause_locs
-                    .make_contiguous()[self.core.clause_assert_margin..]
-                    .binary_search_by(|loc| loc.cmp(&clause_clause_loc))
-                    .map(|loc| loc + self.core.clause_assert_margin)
-                    .ok()
-            }
+            Err(_) => self.core.clause_clause_locs.make_contiguous()
+                [self.core.clause_assert_margin..]
+                .binary_search_by(|loc| loc.cmp(&clause_clause_loc))
+                .map(|loc| loc + self.core.clause_assert_margin)
+                .ok(),
         }
     }
 }

--- a/src/heap_iter.rs
+++ b/src/heap_iter.rs
@@ -711,7 +711,7 @@ mod tests {
         let pstr_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "abc ",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
@@ -736,7 +736,7 @@ mod tests {
         let pstr_second_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "def",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
 
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
@@ -1779,7 +1779,7 @@ mod tests {
         let pstr_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "abc ",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
@@ -1807,7 +1807,7 @@ mod tests {
         let pstr_second_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "def",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 
@@ -2378,7 +2378,7 @@ mod tests {
         let pstr_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "abc ",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
@@ -2405,7 +2405,7 @@ mod tests {
         let pstr_second_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "def",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 
@@ -2841,7 +2841,7 @@ mod tests {
         let pstr_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "abc ",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
@@ -2865,7 +2865,7 @@ mod tests {
         let pstr_second_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "def",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
 
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];

--- a/src/heap_iter.rs
+++ b/src/heap_iter.rs
@@ -708,11 +708,8 @@ mod tests {
 
         // first a 'dangling' partial string, later modified to be a two-part complete string,
         // then a three-part cyclic string involving an uncompacted list of chars.
-        let pstr_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "abc ",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "abc ", &wam.machine_st.atom_tbl);
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
         {
@@ -733,11 +730,8 @@ mod tests {
         wam.machine_st.heap.pop();
         wam.machine_st.heap.push(pstr_loc_as_cell!(2));
 
-        let pstr_second_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "def",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_second_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "def", &wam.machine_st.atom_tbl);
 
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 
@@ -1776,11 +1770,8 @@ mod tests {
         // two-part complete string, then a three-part cyclic string
         // involving an uncompacted list of chars.
 
-        let pstr_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "abc ",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "abc ", &wam.machine_st.atom_tbl);
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
         {
@@ -1804,11 +1795,8 @@ mod tests {
         wam.machine_st.heap.pop();
         wam.machine_st.heap.push(heap_loc_as_cell!(2));
 
-        let pstr_second_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "def",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_second_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "def", &wam.machine_st.atom_tbl);
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 
         {
@@ -2375,11 +2363,8 @@ mod tests {
         // two-part complete string, then a three-part cyclic string
         // involving an uncompacted list of chars.
 
-        let pstr_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "abc ",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "abc ", &wam.machine_st.atom_tbl);
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
         {
@@ -2402,11 +2387,8 @@ mod tests {
         wam.machine_st.heap.pop();
         wam.machine_st.heap.push(pstr_loc_as_cell!(2));
 
-        let pstr_second_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "def",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_second_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "def", &wam.machine_st.atom_tbl);
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 
         {
@@ -2838,11 +2820,8 @@ mod tests {
         // two-part complete string, then a three-part cyclic string
         // involving an uncompacted list of chars.
 
-        let pstr_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "abc ",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "abc ", &wam.machine_st.atom_tbl);
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
         {
@@ -2862,11 +2841,8 @@ mod tests {
         wam.machine_st.heap.pop();
         wam.machine_st.heap.push(pstr_loc_as_cell!(2));
 
-        let pstr_second_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "def",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_second_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "def", &wam.machine_st.atom_tbl);
 
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -1588,7 +1588,7 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
                 print_struct(self, name, arity);
             }
             (HeapCellValueTag::Char, c) => {
-                let name = self.atom_tbl.blocking_write().build_with(&String::from(c));
+                let name = AtomTable::build_with(&self.atom_tbl, &String::from(c));
                 print_struct(self, name, 0);
             }
             (HeapCellValueTag::Str, s) => {
@@ -1950,11 +1950,7 @@ mod tests {
 
         wam.machine_st.heap.clear();
 
-        put_partial_string(
-            &mut wam.machine_st.heap,
-            "abc",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        put_partial_string(&mut wam.machine_st.heap, "abc", &wam.machine_st.atom_tbl);
 
         {
             let printer = HCPrinter::new(

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -24,8 +24,6 @@ use ordered_float::OrderedFloat;
 
 use indexmap::IndexMap;
 
-use tokio::sync::RwLock;
-
 use std::cell::Cell;
 use std::convert::TryFrom;
 use std::iter::once;
@@ -483,7 +481,7 @@ pub fn fmt_float(mut fl: f64) -> String {
 pub struct HCPrinter<'a, Outputter> {
     outputter: Outputter,
     iter: StackfulPreOrderHeapIter<'a>,
-    atom_tbl: Arc<RwLock<AtomTable>>,
+    atom_tbl: Arc<AtomTable>,
     op_dir: &'a OpDir,
     state_stack: Vec<TokenOrRedirect>,
     toplevel_spec: Option<DirectedOp>,
@@ -552,7 +550,7 @@ pub(crate) fn numbervar(offset: &Integer, addr: HeapCellValue) -> Option<String>
 impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
     pub fn new(
         heap: &'a mut Heap,
-        atom_tbl: Arc<RwLock<AtomTable>>,
+        atom_tbl: Arc<AtomTable>,
         stack: &'a mut Stack,
         op_dir: &'a OpDir,
         output: Outputter,

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,13 +1,13 @@
-use std::sync::{Arc, Mutex, Condvar};
-use std::future::Future;
-use std::pin::Pin;
-use http_body_util::Full;
 use bytes::Bytes;
+use http_body_util::Full;
 use hyper::service::Service;
 use hyper::{body::Incoming as IncomingBody, Request, Response};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Condvar, Mutex};
 
 pub struct HttpListener {
-    pub incoming: std::sync::mpsc::Receiver<HttpRequest>
+    pub incoming: std::sync::mpsc::Receiver<HttpRequest>,
 }
 
 #[derive(Debug)]
@@ -28,27 +28,28 @@ impl Service<Request<IncomingBody>> for HttpService {
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn call(&mut self, req: Request<IncomingBody>) -> Self::Future {
-	// new connection!
-	// we send the Request info to Prolog
-	let response = Arc::new((Mutex::new(false), Mutex::new(None), Condvar::new()));
-	let http_request = HttpRequest { request: req, response: Arc::clone(&response) };
-	self.tx.send(http_request).unwrap();
+        // new connection!
+        // we send the Request info to Prolog
+        let response = Arc::new((Mutex::new(false), Mutex::new(None), Condvar::new()));
+        let http_request = HttpRequest {
+            request: req,
+            response: Arc::clone(&response),
+        };
+        self.tx.send(http_request).unwrap();
 
-	// we wait for the Response info from Prolog
-	{
-	    let (ready, _response, cvar) = &*response;
-	    let mut ready = ready.lock().unwrap();
-	    while !*ready {
-		ready = cvar.wait(ready).unwrap();
-	    }
-	}
-	{
-	    let (_, response, _) = &*response;
-	    let response = response.lock().unwrap().take();
-	    let res = response.expect("Data race error in HTTP Server");
-	    Box::pin(async move {
-		Ok(res)
-	    })
-	}
+        // we wait for the Response info from Prolog
+        {
+            let (ready, _response, cvar) = &*response;
+            let mut ready = ready.lock().unwrap();
+            while !*ready {
+                ready = cvar.wait(ready).unwrap();
+            }
+        }
+        {
+            let (_, response, _) = &*response;
+            let response = response.lock().unwrap().take();
+            let res = response.expect("Data race error in HTTP Server");
+            Box::pin(async move { Ok(res) })
+        }
     }
 }

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -150,17 +150,20 @@ impl<'a> IndexingCodeMergingPtr<'a> {
         let third_level_index = if self.append_or_prepend.is_append() {
             vec![
                 IndexedChoiceInstruction::Try(external),
-                IndexedChoiceInstruction::Trust(index)
-            ].into()
+                IndexedChoiceInstruction::Trust(index),
+            ]
+            .into()
         } else {
             vec![
                 IndexedChoiceInstruction::Try(index),
-                IndexedChoiceInstruction::Trust(external)
-            ].into()
+                IndexedChoiceInstruction::Trust(external),
+            ]
+            .into()
         };
 
         let indexing_code_len = self.indexing_code.len();
-        self.indexing_code.push(IndexingLine::IndexedChoice(third_level_index));
+        self.indexing_code
+            .push(IndexingLine::IndexedChoice(third_level_index));
 
         match &mut self.indexing_code[self.offset] {
             IndexingLine::Indexing(IndexingInstruction::SwitchOnConstant(ref mut constants)) => {
@@ -188,7 +191,8 @@ impl<'a> IndexingCodeMergingPtr<'a> {
         };
 
         let indexing_code_len = self.indexing_code.len();
-        self.indexing_code.push(IndexingLine::DynamicIndexedChoice(third_level_index));
+        self.indexing_code
+            .push(IndexingLine::DynamicIndexedChoice(third_level_index));
 
         match &mut self.indexing_code[self.offset] {
             IndexingLine::Indexing(IndexingInstruction::SwitchOnConstant(ref mut constants)) => {
@@ -275,10 +279,8 @@ impl<'a> IndexingCodeMergingPtr<'a> {
                             );
                         }
                         None | Some(IndexingCodePtr::Fail) => {
-                            constants.insert(
-                                overlapping_constant,
-                                IndexingCodePtr::External(index),
-                            );
+                            constants
+                                .insert(overlapping_constant, IndexingCodePtr::External(index));
                         }
                         Some(IndexingCodePtr::DynamicExternal(o)) => {
                             self.add_dynamic_indexed_choice_for_constant(
@@ -345,16 +347,10 @@ impl<'a> IndexingCodeMergingPtr<'a> {
                 IndexingLine::Indexing(IndexingInstruction::SwitchOnConstant(constants)) => {
                     match constants.get(&constant).cloned() {
                         None | Some(IndexingCodePtr::Fail) if self.is_dynamic => {
-                            constants.insert(
-                                constant,
-                                IndexingCodePtr::DynamicExternal(index),
-                            );
+                            constants.insert(constant, IndexingCodePtr::DynamicExternal(index));
                         }
                         None | Some(IndexingCodePtr::Fail) => {
-                            constants.insert(
-                                constant,
-                                IndexingCodePtr::External(index),
-                            );
+                            constants.insert(constant, IndexingCodePtr::External(index));
                         }
                         Some(IndexingCodePtr::DynamicExternal(o)) => {
                             self.add_dynamic_indexed_choice_for_constant(o, constant, index);
@@ -432,17 +428,20 @@ impl<'a> IndexingCodeMergingPtr<'a> {
         let third_level_index = if self.append_or_prepend.is_append() {
             vec![
                 IndexedChoiceInstruction::Try(external),
-                IndexedChoiceInstruction::Trust(index)
-            ].into()
+                IndexedChoiceInstruction::Trust(index),
+            ]
+            .into()
         } else {
             vec![
                 IndexedChoiceInstruction::Try(index),
-                IndexedChoiceInstruction::Trust(external)
-            ].into()
+                IndexedChoiceInstruction::Trust(external),
+            ]
+            .into()
         };
 
         let indexing_code_len = self.indexing_code.len();
-        self.indexing_code.push(IndexingLine::IndexedChoice(third_level_index));
+        self.indexing_code
+            .push(IndexingLine::IndexedChoice(third_level_index));
 
         match &mut self.indexing_code[self.offset] {
             IndexingLine::Indexing(IndexingInstruction::SwitchOnStructure(ref mut structures)) => {
@@ -470,7 +469,8 @@ impl<'a> IndexingCodeMergingPtr<'a> {
         };
 
         let indexing_code_len = self.indexing_code.len();
-        self.indexing_code.push(IndexingLine::DynamicIndexedChoice(third_level_index));
+        self.indexing_code
+            .push(IndexingLine::DynamicIndexedChoice(third_level_index));
 
         match &mut self.indexing_code[self.offset] {
             IndexingLine::Indexing(IndexingInstruction::SwitchOnStructure(ref mut structures)) => {
@@ -584,13 +584,15 @@ impl<'a> IndexingCodeMergingPtr<'a> {
                         let third_level_index = if self.append_or_prepend.is_append() {
                             vec![
                                 IndexedChoiceInstruction::Try(o),
-                                IndexedChoiceInstruction::Trust(index)
-                            ].into()
+                                IndexedChoiceInstruction::Trust(index),
+                            ]
+                            .into()
                         } else {
                             vec![
                                 IndexedChoiceInstruction::Try(index),
-                                IndexedChoiceInstruction::Trust(o)
-                            ].into()
+                                IndexedChoiceInstruction::Trust(o),
+                            ]
+                            .into()
                         };
 
                         self.indexing_code
@@ -613,7 +615,7 @@ pub(crate) fn merge_clause_index(
     target_indexing_code: &mut Vec<IndexingLine>,
     skeleton: &mut [ClauseIndexInfo], // the clause to be merged is the last element in the skeleton.
     retracted_clauses: &Option<Vec<ClauseIndexInfo>>,
-    new_clause_loc: usize,            // the absolute location of the new clause in the code vector.
+    new_clause_loc: usize, // the absolute location of the new clause in the code vector.
     append_or_prepend: AppendOrPrepend,
 ) {
     let opt_arg_index_key = match append_or_prepend {
@@ -636,11 +638,7 @@ pub(crate) fn merge_clause_index(
             for overlapping_constant in overlapping_constants {
                 merging_ptr.offset = 0;
 
-                merging_ptr.index_overlapping_constant(
-                    *constant,
-                    *overlapping_constant,
-                    offset,
-                );
+                merging_ptr.index_overlapping_constant(*constant, *overlapping_constant, offset);
             }
         }
         OptArgIndexKey::Structure(_, index_loc, name, arity) => {
@@ -1060,31 +1058,27 @@ fn cap_choice_seq(prelude: &mut [IndexedChoiceInstruction]) {
 
 #[inline]
 fn cap_choice_seq_with_trust(prelude: &mut [IndexedChoiceInstruction]) {
-    prelude.last_mut().map(|instr| {
-        match instr {
-            IndexedChoiceInstruction::Retry(i) => {
-                *instr = IndexedChoiceInstruction::Trust(*i);
-            }
-            IndexedChoiceInstruction::DefaultRetry(i) => {
-                *instr = IndexedChoiceInstruction::DefaultTrust(*i);
-            }
-            _ => {}
+    prelude.last_mut().map(|instr| match instr {
+        IndexedChoiceInstruction::Retry(i) => {
+            *instr = IndexedChoiceInstruction::Trust(*i);
         }
+        IndexedChoiceInstruction::DefaultRetry(i) => {
+            *instr = IndexedChoiceInstruction::DefaultTrust(*i);
+        }
+        _ => {}
     });
 }
 
 #[inline]
 fn uncap_choice_seq_with_trust(prelude: &mut [IndexedChoiceInstruction]) {
-    prelude.last_mut().map(|instr| {
-        match instr {
-            IndexedChoiceInstruction::Trust(i) => {
-                *instr = IndexedChoiceInstruction::Retry(*i);
-            }
-            IndexedChoiceInstruction::DefaultTrust(i) => {
-                *instr = IndexedChoiceInstruction::DefaultRetry(*i);
-            }
-            _ => {}
+    prelude.last_mut().map(|instr| match instr {
+        IndexedChoiceInstruction::Trust(i) => {
+            *instr = IndexedChoiceInstruction::Retry(*i);
         }
+        IndexedChoiceInstruction::DefaultTrust(i) => {
+            *instr = IndexedChoiceInstruction::DefaultRetry(*i);
+        }
+        _ => {}
     });
 }
 
@@ -1129,9 +1123,11 @@ pub(crate) fn constant_key_alternatives(
         */
         Literal::Integer(ref n) => {
             if let Some(n) = n.to_isize() {
-                Fixnum::build_with_checked(n as i64).map(|n| {
-                    constants.push(Literal::Fixnum(n));
-                }).unwrap();
+                Fixnum::build_with_checked(n as i64)
+                    .map(|n| {
+                        constants.push(Literal::Fixnum(n));
+                    })
+                    .unwrap();
             }
         }
         _ => {}
@@ -1159,11 +1155,19 @@ pub(crate) trait Indexer {
 
     fn new() -> Self;
 
-    fn constants(&mut self) -> &mut IndexMap<Literal, VecDeque<Self::ThirdLevelIndex>, FxBuildHasher>;
+    fn constants(
+        &mut self,
+    ) -> &mut IndexMap<Literal, VecDeque<Self::ThirdLevelIndex>, FxBuildHasher>;
     fn lists(&mut self) -> &mut VecDeque<Self::ThirdLevelIndex>;
-    fn structures(&mut self) -> &mut IndexMap<(Atom, usize), VecDeque<Self::ThirdLevelIndex>, FxBuildHasher>;
+    fn structures(
+        &mut self,
+    ) -> &mut IndexMap<(Atom, usize), VecDeque<Self::ThirdLevelIndex>, FxBuildHasher>;
 
-    fn compute_index(is_initial_index: bool, index: usize, non_counted_bt: bool) -> Self::ThirdLevelIndex;
+    fn compute_index(
+        is_initial_index: bool,
+        index: usize,
+        non_counted_bt: bool,
+    ) -> Self::ThirdLevelIndex;
 
     fn second_level_index<IndexKey: Eq + Hash>(
         indices: IndexMap<IndexKey, VecDeque<Self::ThirdLevelIndex>, FxBuildHasher>,
@@ -1199,7 +1203,9 @@ impl Indexer for StaticCodeIndices {
     }
 
     #[inline]
-    fn constants(&mut self) -> &mut IndexMap<Literal, VecDeque<IndexedChoiceInstruction>, FxBuildHasher> {
+    fn constants(
+        &mut self,
+    ) -> &mut IndexMap<Literal, VecDeque<IndexedChoiceInstruction>, FxBuildHasher> {
         &mut self.constants
     }
 
@@ -1209,11 +1215,17 @@ impl Indexer for StaticCodeIndices {
     }
 
     #[inline]
-    fn structures(&mut self) -> &mut IndexMap<(Atom, usize), VecDeque<IndexedChoiceInstruction>, FxBuildHasher> {
+    fn structures(
+        &mut self,
+    ) -> &mut IndexMap<(Atom, usize), VecDeque<IndexedChoiceInstruction>, FxBuildHasher> {
         &mut self.structures
     }
 
-    fn compute_index(is_initial_index: bool, index: usize, non_counted_bt: bool) -> IndexedChoiceInstruction {
+    fn compute_index(
+        is_initial_index: bool,
+        index: usize,
+        non_counted_bt: bool,
+    ) -> IndexedChoiceInstruction {
         if is_initial_index {
             IndexedChoiceInstruction::Try(index + 1)
         } else if non_counted_bt {
@@ -1245,7 +1257,9 @@ impl Indexer for StaticCodeIndices {
     }
 
     fn switch_on<IndexKey: Eq + Hash>(
-        mut instr_fn: impl FnMut(IndexMap<IndexKey, IndexingCodePtr, FxBuildHasher>) -> IndexingInstruction,
+        mut instr_fn: impl FnMut(
+            IndexMap<IndexKey, IndexingCodePtr, FxBuildHasher>,
+        ) -> IndexingInstruction,
         index: &mut IndexMap<IndexKey, VecDeque<IndexedChoiceInstruction>, FxBuildHasher>,
         prelude: &mut VecDeque<IndexingLine>,
     ) -> IndexingCodePtr {
@@ -1345,7 +1359,9 @@ impl Indexer for DynamicCodeIndices {
         for (key, code) in indices.into_iter() {
             if code.len() > 1 {
                 index_locs.insert(key, IndexingCodePtr::Internal(prelude.len() + 1));
-                prelude.push_back(IndexingLine::DynamicIndexedChoice(code.into_iter().collect()));
+                prelude.push_back(IndexingLine::DynamicIndexedChoice(
+                    code.into_iter().collect(),
+                ));
             } else {
                 code.front().map(|i| {
                     index_locs.insert(key, IndexingCodePtr::DynamicExternal(*i));
@@ -1357,7 +1373,9 @@ impl Indexer for DynamicCodeIndices {
     }
 
     fn switch_on<IndexKey: Eq + Hash>(
-        mut instr_fn: impl FnMut(IndexMap<IndexKey, IndexingCodePtr, FxBuildHasher>) -> IndexingInstruction,
+        mut instr_fn: impl FnMut(
+            IndexMap<IndexKey, IndexingCodePtr, FxBuildHasher>,
+        ) -> IndexingInstruction,
         index: &mut IndexMap<IndexKey, VecDeque<usize>, FxBuildHasher>,
         prelude: &mut VecDeque<IndexingLine>,
     ) -> IndexingCodePtr {
@@ -1384,7 +1402,9 @@ impl Indexer for DynamicCodeIndices {
     ) -> IndexingCodePtr {
         if lists.len() > 1 {
             let lists = mem::replace(lists, VecDeque::new());
-            prelude.push_back(IndexingLine::DynamicIndexedChoice(lists.into_iter().collect()));
+            prelude.push_back(IndexingLine::DynamicIndexedChoice(
+                lists.into_iter().collect(),
+            ));
             IndexingCodePtr::Internal(1)
         } else {
             lists
@@ -1439,10 +1459,18 @@ impl<I: Indexer> CodeOffsets<I> {
         index: usize,
     ) -> Vec<Literal> {
         let overlapping_constants = constant_key_alternatives(constant, atom_tbl);
-        let code = self.indices.constants().entry(constant).or_insert(VecDeque::new());
+        let code = self
+            .indices
+            .constants()
+            .entry(constant)
+            .or_insert(VecDeque::new());
 
         let is_initial_index = code.is_empty();
-        code.push_back(I::compute_index(is_initial_index, index, self.non_counted_bt));
+        code.push_back(I::compute_index(
+            is_initial_index,
+            index,
+            self.non_counted_bt,
+        ));
 
         for constant in &overlapping_constants {
             let code = self
@@ -1470,7 +1498,11 @@ impl<I: Indexer> CodeOffsets<I> {
         let code_len = code.len();
         let is_initial_index = code.is_empty();
 
-        code.push_back(I::compute_index(is_initial_index, index, self.non_counted_bt));
+        code.push_back(I::compute_index(
+            is_initial_index,
+            index,
+            self.non_counted_bt,
+        ));
         code_len
     }
 

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -6,7 +6,6 @@ use crate::instructions::*;
 
 use fxhash::FxBuildHasher;
 use indexmap::IndexMap;
-use tokio::sync::RwLock;
 
 use std::collections::VecDeque;
 use std::hash::Hash;
@@ -1094,7 +1093,7 @@ fn uncap_choice_seq_with_try(prelude: &mut [IndexedChoiceInstruction]) {
 
 pub(crate) fn constant_key_alternatives(
     constant: Literal,
-    atom_tbl: &RwLock<AtomTable>,
+    atom_tbl: &AtomTable,
     // arena: &mut Arena,
 ) -> Vec<Literal> {
     let mut constants = vec![];
@@ -1455,7 +1454,7 @@ impl<I: Indexer> CodeOffsets<I> {
 
     fn index_constant(
         &mut self,
-        atom_tbl: &RwLock<AtomTable>,
+        atom_tbl: &AtomTable,
         constant: Literal,
         index: usize,
     ) -> Vec<Literal> {
@@ -1512,7 +1511,7 @@ impl<I: Indexer> CodeOffsets<I> {
         optimal_arg: &Term,
         index: usize,
         clause_index_info: &mut ClauseIndexInfo,
-        atom_tbl: &RwLock<AtomTable>,
+        atom_tbl: &AtomTable,
     ) {
         match optimal_arg {
             &Term::Clause(_, atom!("."), ref terms) if terms.len() == 2 => {

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -6,6 +6,7 @@ use crate::instructions::*;
 
 use fxhash::FxBuildHasher;
 use indexmap::IndexMap;
+use tokio::sync::RwLock;
 
 use std::collections::VecDeque;
 use std::hash::Hash;
@@ -1093,7 +1094,7 @@ fn uncap_choice_seq_with_try(prelude: &mut [IndexedChoiceInstruction]) {
 
 pub(crate) fn constant_key_alternatives(
     constant: Literal,
-    atom_tbl: &mut AtomTable,
+    atom_tbl: &RwLock<AtomTable>,
     // arena: &mut Arena,
 ) -> Vec<Literal> {
     let mut constants = vec![];
@@ -1105,7 +1106,7 @@ pub(crate) fn constant_key_alternatives(
             }
         }
         Literal::Char(c) => {
-            let atom = atom_tbl.build_with(&c.to_string());
+            let atom = AtomTable::build_with(&atom_tbl, &c.to_string());
             constants.push(Literal::Atom(atom));
         }
         /*
@@ -1454,7 +1455,7 @@ impl<I: Indexer> CodeOffsets<I> {
 
     fn index_constant(
         &mut self,
-        atom_tbl: &mut AtomTable,
+        atom_tbl: &RwLock<AtomTable>,
         constant: Literal,
         index: usize,
     ) -> Vec<Literal> {
@@ -1511,7 +1512,7 @@ impl<I: Indexer> CodeOffsets<I> {
         optimal_arg: &Term,
         index: usize,
         clause_index_info: &mut ClauseIndexInfo,
-        atom_tbl: &mut AtomTable,
+        atom_tbl: &RwLock<AtomTable>,
     ) {
         match optimal_arg {
             &Term::Clause(_, atom!("."), ref terms) if terms.len() == 2 => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,13 @@ pub mod codegen;
 mod debray_allocator;
 #[cfg(feature = "ffi")]
 mod ffi;
-mod variable_records;
 mod forms;
 mod heap_iter;
 pub mod heap_print;
 #[cfg(feature = "http")]
 mod http;
 mod indexing;
+mod variable_records;
 #[macro_use]
 pub mod instructions {
     include!(concat!(env!("OUT_DIR"), "/instructions.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,3 +38,5 @@ mod targets;
 pub mod types;
 
 use instructions::instr;
+
+mod rcu;

--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -50,9 +50,7 @@ macro_rules! drop_iter_on_err {
     };
 }
 
-fn zero_divisor_eval_error(
-    stub_gen: impl Fn() -> FunctorStub + 'static,
-) -> MachineStubGen {
+fn zero_divisor_eval_error(stub_gen: impl Fn() -> FunctorStub + 'static) -> MachineStubGen {
     Box::new(move |machine_st| {
         let eval_error = machine_st.evaluation_error(EvalError::ZeroDivisor);
         let stub = stub_gen();
@@ -61,9 +59,7 @@ fn zero_divisor_eval_error(
     })
 }
 
-fn undefined_eval_error(
-    stub_gen: impl Fn() -> FunctorStub + 'static,
-) -> MachineStubGen {
+fn undefined_eval_error(stub_gen: impl Fn() -> FunctorStub + 'static) -> MachineStubGen {
     Box::new(move |machine_st| {
         let eval_error = machine_st.evaluation_error(EvalError::Undefined);
         let stub = stub_gen();
@@ -169,9 +165,7 @@ pub(crate) fn add(lhs: Number, rhs: Number, arena: &mut Arena) -> Result<Number,
             Ok(Number::Float(add_f(float_i_to_f(&n1)?, n2)?))
         }
         (Number::Integer(n1), Number::Rational(n2))
-        | (Number::Rational(n2), Number::Integer(n1)) => {
-            Ok(Number::arena_from(&*n1 + &*n2, arena))
-        }
+        | (Number::Rational(n2), Number::Integer(n1)) => Ok(Number::arena_from(&*n1 + &*n2, arena)),
         (Number::Rational(n1), Number::Float(OrderedFloat(n2)))
         | (Number::Float(OrderedFloat(n2)), Number::Rational(n1)) => {
             Ok(Number::Float(add_f(float_r_to_f(&n1)?, n2)?))
@@ -179,9 +173,7 @@ pub(crate) fn add(lhs: Number, rhs: Number, arena: &mut Arena) -> Result<Number,
         (Number::Float(OrderedFloat(f1)), Number::Float(OrderedFloat(f2))) => {
             Ok(Number::Float(add_f(f1, f2)?))
         }
-        (Number::Rational(r1), Number::Rational(r2)) => {
-            Ok(Number::arena_from(&*r1 + &*r2, arena))
-        }
+        (Number::Rational(r1), Number::Rational(r2)) => Ok(Number::arena_from(&*r1 + &*r2, arena)),
     }
 }
 
@@ -197,12 +189,12 @@ pub(crate) fn neg(n: Number, arena: &mut Arena) -> Number {
         Number::Integer(n) => {
             let n_clone: Integer = (*n).clone();
             Number::arena_from(-Integer::from(n_clone), arena)
-        },
+        }
         Number::Float(OrderedFloat(f)) => Number::Float(OrderedFloat(-f)),
         Number::Rational(r) => {
             let r_clone: Rational = (*r).clone();
             Number::arena_from(-Rational::from(r_clone), arena)
-        },
+        }
     }
 }
 
@@ -219,12 +211,12 @@ pub(crate) fn abs(n: Number, arena: &mut Arena) -> Number {
         Number::Integer(n) => {
             let n_clone: Integer = (*n).clone();
             Number::arena_from(Integer::from(n_clone.abs()), arena)
-        },
+        }
         Number::Float(f) => Number::Float(f.abs()),
         Number::Rational(r) => {
             let r_clone: Rational = (*r).clone();
             Number::arena_from(Rational::from(r_clone.abs()), arena)
-        },
+        }
     }
 }
 
@@ -368,7 +360,11 @@ pub(crate) fn int_pow(n1: Number, n2: Number, arena: &mut Arena) -> Result<Numbe
         (Number::Integer(n1), Number::Fixnum(n2)) => {
             let n2_i = n2.get_num();
 
-            if !(&*n1 == &Integer::from(1) || &*n1 == &Integer::from(0) || &*n1 == &Integer::from(-1)) && n2_i < 0 {
+            if !(&*n1 == &Integer::from(1)
+                || &*n1 == &Integer::from(0)
+                || &*n1 == &Integer::from(-1))
+                && n2_i < 0
+            {
                 let n = Number::Integer(n1);
                 Err(numerical_type_error(ValidType::Float, n, stub_gen))
             } else {
@@ -377,7 +373,11 @@ pub(crate) fn int_pow(n1: Number, n2: Number, arena: &mut Arena) -> Result<Numbe
             }
         }
         (Number::Integer(n1), Number::Integer(n2)) => {
-            if !(&*n1 == &Integer::from(1) || &*n1 == &Integer::from(0) || &*n1 == &Integer::from(-1)) && &*n2 < &Integer::from(0) {
+            if !(&*n1 == &Integer::from(1)
+                || &*n1 == &Integer::from(0)
+                || &*n1 == &Integer::from(-1))
+                && &*n2 < &Integer::from(0)
+            {
                 let n = Number::Integer(n1);
                 Err(numerical_type_error(ValidType::Float, n, stub_gen))
             } else {
@@ -552,7 +552,7 @@ pub fn rational_from_number(
         Number::Integer(n) => {
             let n_clone: Integer = (*n).clone();
             Ok(arena_alloc!(Rational::from(n_clone), arena))
-        },
+        }
     }
 }
 
@@ -659,7 +659,7 @@ pub(crate) fn shr(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
 
             if let Ok(n2) = usize::try_from(n2_i) {
                 return Ok(Number::arena_from(n1 >> n2, arena));
-	        } else {
+            } else {
                 return Ok(Number::arena_from(n1 >> usize::max_value(), arena));
             }
         }
@@ -668,22 +668,22 @@ pub(crate) fn shr(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
 
             match n2.to_usize() {
                 Some(n2) => Ok(Number::arena_from(n1 >> n2, arena)),
-                _ => {
-			        Ok(Number::arena_from(n1 >> usize::max_value(), arena))
-		        },
+                _ => Ok(Number::arena_from(n1 >> usize::max_value(), arena)),
             }
         }
         (Number::Integer(n1), Number::Fixnum(n2)) => match usize::try_from(n2.get_num()) {
             Ok(n2) => Ok(Number::arena_from(Integer::from(&*n1 >> n2), arena)),
-            _ => {
-		        Ok(Number::arena_from(Integer::from(&*n1 >> usize::max_value()),arena))
-	        },
+            _ => Ok(Number::arena_from(
+                Integer::from(&*n1 >> usize::max_value()),
+                arena,
+            )),
         },
         (Number::Integer(n1), Number::Integer(n2)) => match n2.to_usize() {
             Some(n2) => Ok(Number::arena_from(Integer::from(&*n1 >> n2), arena)),
-            _ => {
-		        Ok(Number::arena_from(Integer::from(&*n1 >> usize::max_value()), arena))
-            },
+            _ => Ok(Number::arena_from(
+                Integer::from(&*n1 >> usize::max_value()),
+                arena,
+            )),
         },
         (Number::Integer(_), n2) => Err(numerical_type_error(ValidType::Integer, n2, stub_gen)),
         (Number::Fixnum(_), n2) => Err(numerical_type_error(ValidType::Integer, n2, stub_gen)),
@@ -710,7 +710,7 @@ pub(crate) fn shl(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
 
             if let Ok(n2) = usize::try_from(n2_i) {
                 return Ok(Number::arena_from(n1 << n2, arena));
-	        } else {
+            } else {
                 return Ok(Number::arena_from(n1 << usize::max_value(), arena));
             }
         }
@@ -719,22 +719,25 @@ pub(crate) fn shl(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
 
             match n2.to_u32() {
                 Some(n2) => Ok(Number::arena_from(n1.to_u64().unwrap() << n2, arena)),
-                _ => {
-			        Ok(Number::arena_from(n1 << usize::max_value(), arena))
-		        }
+                _ => Ok(Number::arena_from(n1 << usize::max_value(), arena)),
             }
         }
         (Number::Integer(n1), Number::Fixnum(n2)) => match usize::try_from(n2.get_num()) {
             Ok(n2) => Ok(Number::arena_from(Integer::from(&*n1 << n2), arena)),
-            _ => {
-		        Ok(Number::arena_from(Integer::from(&*n1 << usize::max_value()),arena))
-		    }
+            _ => Ok(Number::arena_from(
+                Integer::from(&*n1 << usize::max_value()),
+                arena,
+            )),
         },
         (Number::Integer(n1), Number::Integer(n2)) => match n2.to_u32() {
-            Some(n2) => Ok(Number::arena_from(Integer::from(n1.to_u64().unwrap() << n2), arena)),
-            _ => {
-		        Ok(Number::arena_from(Integer::from(&*n1 << usize::max_value()),arena))
-	        }
+            Some(n2) => Ok(Number::arena_from(
+                Integer::from(n1.to_u64().unwrap() << n2),
+                arena,
+            )),
+            _ => Ok(Number::arena_from(
+                Integer::from(&*n1 << usize::max_value()),
+                arena,
+            )),
         },
         (Number::Integer(_), n2) => Err(numerical_type_error(ValidType::Integer, n2, stub_gen)),
         (Number::Fixnum(_), n2) => Err(numerical_type_error(ValidType::Integer, n2, stub_gen)),
@@ -949,10 +952,7 @@ pub(crate) fn gcd(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
                 Ok(Number::arena_from(result, arena))
             } else {
                 let value: IBig = Integer::from(n1_i).gcd(&Integer::from(n2_i)).into();
-                Ok(Number::arena_from(
-                    value,
-                    arena,
-                ))
+                Ok(Number::arena_from(value, arena))
             }
         }
         (Number::Fixnum(n1), Number::Integer(n2)) | (Number::Integer(n2), Number::Fixnum(n1)) => {
@@ -962,7 +962,10 @@ pub(crate) fn gcd(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
         }
         (Number::Integer(n1), Number::Integer(n2)) => {
             let n1_clone: Integer = (*n1).clone();
-            Ok(Number::arena_from(Integer::from(n1_clone.gcd(&Integer::from(n2.to_isize().unwrap()))) as IBig, arena))
+            Ok(Number::arena_from(
+                Integer::from(n1_clone.gcd(&Integer::from(n2.to_isize().unwrap()))) as IBig,
+                arena,
+            ))
         }
         (Number::Float(f), _) | (_, Number::Float(f)) => {
             let n = Number::Float(f);
@@ -1050,12 +1053,14 @@ pub(crate) fn atanh(n1: Number) -> Result<f64, MachineStubGen> {
 
     let f1 = try_numeric_result!(result_f(&n1), stub_gen)?;
 
-    try_numeric_result!(if f1 == 1.0 || f1 == -1.0 {
-        Err(EvalError::Undefined)
-    } else {
-        result_f(&Number::Float(OrderedFloat(f1.atanh())))
-    },
-    stub_gen)
+    try_numeric_result!(
+        if f1 == 1.0 || f1 == -1.0 {
+            Err(EvalError::Undefined)
+        } else {
+            result_f(&Number::Float(OrderedFloat(f1.atanh())))
+        },
+        stub_gen
+    )
 }
 
 #[inline]
@@ -1106,7 +1111,6 @@ pub(crate) fn sqrt(n1: Number) -> Result<f64, MachineStubGen> {
 pub(crate) fn floor(n1: Number, arena: &mut Arena) -> Number {
     rnd_i(&n1, arena)
 }
-
 
 #[inline]
 pub(crate) fn ceiling(n1: Number, arena: &mut Arena) -> Number {
@@ -1160,16 +1164,17 @@ impl MachineState {
     pub fn get_number(&mut self, at: &ArithmeticTerm) -> Result<Number, MachineStub> {
         match at {
             &ArithmeticTerm::Reg(r) => {
-		        let value = self.store(self.deref(self[r]));
+                let value = self.store(self.deref(self[r]));
 
                 match Number::try_from(value) {
                     Ok(n) => Ok(n),
                     Err(_) => self.arith_eval_by_metacall(value),
                 }
             }
-            &ArithmeticTerm::Interm(i) => {
-                Ok(mem::replace(&mut self.interms[i - 1], Number::Fixnum(Fixnum::build_with(0))))
-            }
+            &ArithmeticTerm::Interm(i) => Ok(mem::replace(
+                &mut self.interms[i - 1],
+                Number::Fixnum(Fixnum::build_with(0)),
+            )),
             &ArithmeticTerm::Number(n) => Ok(n),
         }
     }
@@ -1183,11 +1188,14 @@ impl MachineState {
 
         match rational_from_number(n, caller, &mut self.arena) {
             Ok(r) => Ok(r),
-            Err(e_gen) => Err(e_gen(self))
+            Err(e_gen) => Err(e_gen(self)),
         }
     }
 
-    pub(crate) fn arith_eval_by_metacall(&mut self, value: HeapCellValue) -> Result<Number, MachineStub> {
+    pub(crate) fn arith_eval_by_metacall(
+        &mut self,
+        value: HeapCellValue,
+    ) -> Result<Number, MachineStub> {
         let stub_gen = || functor_stub(atom!("is"), 2);
         let mut iter = stackful_post_order_iter(&mut self.heap, &mut self.stack, value);
 
@@ -1493,26 +1501,11 @@ mod tests {
         let mut wam = MachineState::new();
         let mut op_dir = default_op_dir();
 
-        op_dir.insert(
-            (atom!("+"), Fixity::In),
-            OpDesc::build_with(500, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("-"), Fixity::In),
-            OpDesc::build_with(500, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("-"), Fixity::Pre),
-            OpDesc::build_with(200, FY as u8),
-        );
-        op_dir.insert(
-            (atom!("*"), Fixity::In),
-            OpDesc::build_with(400, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("/"), Fixity::In),
-            OpDesc::build_with(400, YFX as u8),
-        );
+        op_dir.insert((atom!("+"), Fixity::In), OpDesc::build_with(500, YFX as u8));
+        op_dir.insert((atom!("-"), Fixity::In), OpDesc::build_with(500, YFX as u8));
+        op_dir.insert((atom!("-"), Fixity::Pre), OpDesc::build_with(200, FY as u8));
+        op_dir.insert((atom!("*"), Fixity::In), OpDesc::build_with(400, YFX as u8));
+        op_dir.insert((atom!("/"), Fixity::In), OpDesc::build_with(400, YFX as u8));
 
         let term_write_result =
             parse_and_write_parsed_term_to_heap(&mut wam, "3 + 4 - 1 + 2.", &op_dir).unwrap();

--- a/src/machine/attributed_variables.rs
+++ b/src/machine/attributed_variables.rs
@@ -118,12 +118,9 @@ impl MachineState {
             and_frame[i] = self.registers[i];
         }
 
-        and_frame[arity + 1] =
-            fixnum_as_cell!(Fixnum::build_with(self.b0 as i64));
-        and_frame[arity + 2] =
-            fixnum_as_cell!(Fixnum::build_with(self.num_of_args as i64));
-        and_frame[arity + 3] =
-            fixnum_as_cell!(Fixnum::build_with(self.attr_var_init.cp as i64));
+        and_frame[arity + 1] = fixnum_as_cell!(Fixnum::build_with(self.b0 as i64));
+        and_frame[arity + 2] = fixnum_as_cell!(Fixnum::build_with(self.num_of_args as i64));
+        and_frame[arity + 3] = fixnum_as_cell!(Fixnum::build_with(self.attr_var_init.cp as i64));
 
         self.verify_attributes();
 

--- a/src/machine/code_walker.rs
+++ b/src/machine/code_walker.rs
@@ -8,7 +8,9 @@ fn capture_offset(line: &Instruction, index: usize, stack: &mut Vec<usize>) -> b
         &Instruction::TryMeElse(offset) if offset > 0 => {
             stack.push(index + offset);
         }
-        &Instruction::DefaultRetryMeElse(offset) | &Instruction::RetryMeElse(offset) if offset > 0 => {
+        &Instruction::DefaultRetryMeElse(offset) | &Instruction::RetryMeElse(offset)
+            if offset > 0 =>
+        {
             stack.push(index + offset);
         }
         &Instruction::DynamicElse(_, _, NextOrFail::Next(offset)) if offset > 0 => {

--- a/src/machine/compile.rs
+++ b/src/machine/compile.rs
@@ -1240,6 +1240,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                     return Some(
                         LS::machine_st(&mut self.payload)
                             .atom_tbl
+                            .blocking_write()
                             .build_with(path_str),
                     );
                 }
@@ -1259,7 +1260,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
         let clause = self.try_term_to_tl(term, &mut preprocessor)?;
         // let queue = preprocessor.parse_queue(self)?;
 
-        let mut cg = CodeGenerator::new(&mut LS::machine_st(&mut self.payload).atom_tbl, settings);
+        let mut cg = CodeGenerator::new(&LS::machine_st(&mut self.payload).atom_tbl, settings);
 
         let clause_code = cg.compile_predicate(vec![clause])?;
 
@@ -1289,7 +1290,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             clauses.push(self.try_term_to_tl(term, &mut preprocessor)?);
         }
 
-        let mut cg = CodeGenerator::new(&mut LS::machine_st(&mut self.payload).atom_tbl, settings);
+        let mut cg = CodeGenerator::new(&LS::machine_st(&mut self.payload).atom_tbl, settings);
 
         let mut code = cg.compile_predicate(clauses)?;
 

--- a/src/machine/compile.rs
+++ b/src/machine/compile.rs
@@ -28,17 +28,15 @@ pub(super) fn bootstrapping_compile(
 ) -> Result<(), SessionError> {
     let (wam_prelude, machine_st) = wam.prelude_view_and_machine_st();
 
-    let term_stream = BootstrappingTermStream::from_char_reader(
-        stream,
-        machine_st,
-        listing_src,
-    );
+    let term_stream = BootstrappingTermStream::from_char_reader(stream, machine_st, listing_src);
 
-    let payload = BootstrappingLoadState(
-        LoadStatePayload::new(wam_prelude.code.len(), term_stream)
-    );
+    let payload =
+        BootstrappingLoadState(LoadStatePayload::new(wam_prelude.code.len(), term_stream));
 
-    let loader: Loader<'_, BootstrappingLoadState> = Loader { payload, wam_prelude };
+    let loader: Loader<'_, BootstrappingLoadState> = Loader {
+        payload,
+        wam_prelude,
+    };
 
     loader.load()?;
     Ok(())
@@ -98,8 +96,8 @@ fn derelictize_try_me_else(
             retraction_info.push_record(RetractionRecord::ReplacedDynamicElseOffset(index, *o));
             Some(mem::replace(o, 0))
         }
-        Instruction::DynamicElse(_, _, NextOrFail::Fail(_)) |
-        Instruction::DynamicInternalElse(_, _, NextOrFail::Fail(_)) => None,
+        Instruction::DynamicElse(_, _, NextOrFail::Fail(_))
+        | Instruction::DynamicInternalElse(_, _, NextOrFail::Fail(_)) => None,
         Instruction::TryMeElse(0) => None,
         Instruction::TryMeElse(ref mut o) => {
             retraction_info.push_record(RetractionRecord::ModifiedTryMeElse(index, *o));
@@ -154,8 +152,8 @@ fn merge_indices(
 fn find_outer_choice_instr(code: &Code, mut index: usize) -> usize {
     loop {
         match &code[index] {
-            Instruction::DynamicElse(_, _, NextOrFail::Next(i)) |
-            Instruction::DynamicInternalElse(_, _, NextOrFail::Next(i))
+            Instruction::DynamicElse(_, _, NextOrFail::Next(i))
+            | Instruction::DynamicInternalElse(_, _, NextOrFail::Next(i))
                 if *i > 0 =>
             {
                 index += i;
@@ -170,42 +168,37 @@ fn find_outer_choice_instr(code: &Code, mut index: usize) -> usize {
 fn find_inner_choice_instr(code: &Code, mut index: usize, index_loc: usize) -> usize {
     loop {
         match &code[index] {
-            Instruction::TryMeElse(o) |
-            Instruction::RetryMeElse(o) => {
+            Instruction::TryMeElse(o) | Instruction::RetryMeElse(o) => {
                 if *o > 0 {
                     return index;
                 } else {
                     index = index_loc;
                 }
             }
-            &Instruction::DynamicElse(_, _, next_or_fail) => {
-                match next_or_fail {
-                    NextOrFail::Next(i) => {
-                        if i == 0 {
-                            index = index_loc;
-                        } else {
-                            return index;
-                        }
-                    }
-                    NextOrFail::Fail(_) => {
+            &Instruction::DynamicElse(_, _, next_or_fail) => match next_or_fail {
+                NextOrFail::Next(i) => {
+                    if i == 0 {
                         index = index_loc;
-                    }
-                }
-            }
-            &Instruction::DynamicInternalElse(_, _, next_or_fail) => {
-                match next_or_fail {
-                    NextOrFail::Next(i) => {
-                        if i == 0 {
-                            index = index_loc;
-                        } else {
-                            return index;
-                        }
-                    }
-                    NextOrFail::Fail(_) => {
+                    } else {
                         return index;
                     }
                 }
-            }
+                NextOrFail::Fail(_) => {
+                    index = index_loc;
+                }
+            },
+            &Instruction::DynamicInternalElse(_, _, next_or_fail) => match next_or_fail {
+                NextOrFail::Next(i) => {
+                    if i == 0 {
+                        index = index_loc;
+                    } else {
+                        return index;
+                    }
+                }
+                NextOrFail::Fail(_) => {
+                    return index;
+                }
+            },
             Instruction::TrustMe(_) => {
                 return index;
             }
@@ -215,11 +208,7 @@ fn find_inner_choice_instr(code: &Code, mut index: usize, index_loc: usize) -> u
                         index += v;
                     }
                     IndexingCodePtr::DynamicExternal(v) => match &code[index + v] {
-                        &Instruction::DynamicInternalElse(
-                            _,
-                            _,
-                            NextOrFail::Next(0),
-                        ) => {
+                        &Instruction::DynamicInternalElse(_, _, NextOrFail::Next(0)) => {
                             return index + v;
                         }
                         _ => {
@@ -309,8 +298,7 @@ fn merge_indexed_subsequences(
                         code[inner_try_me_else_loc] = Instruction::TrustMe(o);
                     }
                     _ => {
-                        code[inner_try_me_else_loc] =
-                            Instruction::RetryMeElse(o);
+                        code[inner_try_me_else_loc] = Instruction::RetryMeElse(o);
                     }
                 },
             }
@@ -376,7 +364,9 @@ fn delete_from_skeleton(
     }
 
     if skeleton.core.is_dynamic {
-        skeleton.core.add_retracted_dynamic_clause_info(clause_index_info);
+        skeleton
+            .core
+            .add_retracted_dynamic_clause_info(clause_index_info);
 
         retraction_info.push_record(RetractionRecord::RemovedDynamicSkeletonClause(
             compilation_target,
@@ -409,8 +399,8 @@ fn blunt_leading_choice_instr(
                 code[instr_loc] = Instruction::TryMeElse(*o);
                 return instr_loc;
             }
-            Instruction::DynamicElse(_, _, NextOrFail::Next(_)) |
-            Instruction::DynamicInternalElse(_, _, NextOrFail::Next(_)) => {
+            Instruction::DynamicElse(_, _, NextOrFail::Next(_))
+            | Instruction::DynamicInternalElse(_, _, NextOrFail::Next(_)) => {
                 return instr_loc;
             }
             &mut Instruction::DynamicElse(b, d, NextOrFail::Fail(o)) => {
@@ -422,26 +412,19 @@ fn blunt_leading_choice_instr(
                 code[instr_loc] = Instruction::DynamicElse(b, d, NextOrFail::Next(0));
                 return instr_loc;
             }
-            &mut Instruction::DynamicInternalElse(
-                b,
-                d,
-                NextOrFail::Fail(o),
-            ) => {
+            &mut Instruction::DynamicInternalElse(b, d, NextOrFail::Fail(o)) => {
                 retraction_info.push_record(RetractionRecord::AppendedNextOrFail(
                     instr_loc,
                     NextOrFail::Fail(o),
                 ));
 
-                code[instr_loc] = Instruction::DynamicInternalElse(
-                    b,
-                    d,
-                    NextOrFail::Next(0),
-                );
+                code[instr_loc] = Instruction::DynamicInternalElse(b, d, NextOrFail::Next(0));
 
                 return instr_loc;
             }
             Instruction::TrustMe(o) => {
-                retraction_info.push_record(RetractionRecord::AppendedTrustMe(instr_loc, *o, false));
+                retraction_info
+                    .push_record(RetractionRecord::AppendedTrustMe(instr_loc, *o, false));
 
                 code[instr_loc] = Instruction::TryMeElse(0);
                 return instr_loc + 1;
@@ -481,9 +464,9 @@ fn set_switch_var_offset_to_choice_instr(
     };
 
     match &code[index_loc + v] {
-        Instruction::TryMeElse(_) |
-        Instruction::DynamicElse(..) |
-        Instruction::DynamicInternalElse(..) => {}
+        Instruction::TryMeElse(_)
+        | Instruction::DynamicElse(..)
+        | Instruction::DynamicInternalElse(..) => {}
         _ => {
             set_switch_var_offset(code, index_loc, offset, retraction_info);
         }
@@ -523,9 +506,8 @@ fn internalize_choice_instr_at(
     retraction_info: &mut RetractionInfo,
 ) {
     match &mut code[instr_loc] {
-        Instruction::DynamicElse(_, _, NextOrFail::Fail(_)) |
-        Instruction::DynamicInternalElse(_, _, NextOrFail::Fail(_)) => {
-        }
+        Instruction::DynamicElse(_, _, NextOrFail::Fail(_))
+        | Instruction::DynamicInternalElse(_, _, NextOrFail::Fail(_)) => {}
         Instruction::DynamicElse(_, _, ref mut o @ NextOrFail::Next(0)) => {
             retraction_info.push_record(RetractionRecord::ReplacedDynamicElseOffset(instr_loc, 0));
             *o = NextOrFail::Fail(0);
@@ -554,18 +536,10 @@ fn internalize_choice_instr_at(
 
             match &mut code[instr_loc + o] {
                 Instruction::RevJmpBy(p) if *p == 0 => {
-                    code[instr_loc] = Instruction::DynamicInternalElse(
-                        b,
-                        d,
-                        NextOrFail::Fail(o),
-                    );
+                    code[instr_loc] = Instruction::DynamicInternalElse(b, d, NextOrFail::Fail(o));
                 }
                 _ => {
-                    code[instr_loc] = Instruction::DynamicInternalElse(
-                        b,
-                        d,
-                        NextOrFail::Next(o),
-                    );
+                    code[instr_loc] = Instruction::DynamicInternalElse(b, d, NextOrFail::Next(o));
                 }
             }
         }
@@ -609,23 +583,20 @@ fn thread_choice_instr_at_to(
                 *o = target_loc - instr_loc;
                 return;
             }
-            Instruction::DynamicElse(_, _, NextOrFail::Next(ref mut o)) |
-            Instruction::DynamicInternalElse(
-                _,
-                _,
-                NextOrFail::Next(ref mut o),
-            ) if target_loc >= instr_loc => {
+            Instruction::DynamicElse(_, _, NextOrFail::Next(ref mut o))
+            | Instruction::DynamicInternalElse(_, _, NextOrFail::Next(ref mut o))
+                if target_loc >= instr_loc =>
+            {
                 retraction_info
                     .push_record(RetractionRecord::ReplacedDynamicElseOffset(instr_loc, *o));
                 *o = target_loc - instr_loc;
                 return;
             }
-            Instruction::DynamicElse(_, _, NextOrFail::Next(o)) |
-            Instruction::DynamicInternalElse(_, _, NextOrFail::Next(o)) => {
+            Instruction::DynamicElse(_, _, NextOrFail::Next(o))
+            | Instruction::DynamicInternalElse(_, _, NextOrFail::Next(o)) => {
                 instr_loc += *o;
             }
-            Instruction::TryMeElse(o)
-            | Instruction::RetryMeElse(o) => {
+            Instruction::TryMeElse(o) | Instruction::RetryMeElse(o) => {
                 instr_loc += *o;
             }
             Instruction::RevJmpBy(ref mut o) if instr_loc >= target_loc => {
@@ -642,7 +613,8 @@ fn thread_choice_instr_at_to(
             {
                 retraction_info.push_record(RetractionRecord::AppendedNextOrFail(instr_loc, *fail));
 
-                code[instr_loc] = instr!("dynamic_else",
+                code[instr_loc] = instr!(
+                    "dynamic_else",
                     birth,
                     death,
                     NextOrFail::Next(target_loc - instr_loc)
@@ -653,14 +625,13 @@ fn thread_choice_instr_at_to(
             Instruction::DynamicElse(_, _, NextOrFail::Fail(o)) if *o > 0 => {
                 instr_loc += *o;
             }
-            &mut Instruction::DynamicInternalElse(
-                birth,
-                death,
-                ref mut fail,
-            ) if target_loc >= instr_loc => {
+            &mut Instruction::DynamicInternalElse(birth, death, ref mut fail)
+                if target_loc >= instr_loc =>
+            {
                 retraction_info.push_record(RetractionRecord::AppendedNextOrFail(instr_loc, *fail));
 
-                code[instr_loc] = instr!("dynamic_internal_else",
+                code[instr_loc] = instr!(
+                    "dynamic_internal_else",
                     birth,
                     death,
                     NextOrFail::Next(target_loc - instr_loc)
@@ -668,9 +639,7 @@ fn thread_choice_instr_at_to(
 
                 return;
             }
-            Instruction::DynamicInternalElse(_, _, NextOrFail::Fail(o))
-                if *o > 0 =>
-            {
+            Instruction::DynamicInternalElse(_, _, NextOrFail::Fail(o)) if *o > 0 => {
                 instr_loc += *o;
             }
             Instruction::TrustMe(ref mut o) if target_loc >= instr_loc => {
@@ -711,33 +680,31 @@ fn remove_non_leading_clause(
 
             None
         }
-        Instruction::TrustMe(_) => {
-            match &mut code[preceding_choice_instr_loc] {
-                Instruction::RetryMeElse(o) => {
-                    retraction_info.push_record(RetractionRecord::ModifiedRetryMeElse(
-                        preceding_choice_instr_loc,
-                        *o,
-                    ));
+        Instruction::TrustMe(_) => match &mut code[preceding_choice_instr_loc] {
+            Instruction::RetryMeElse(o) => {
+                retraction_info.push_record(RetractionRecord::ModifiedRetryMeElse(
+                    preceding_choice_instr_loc,
+                    *o,
+                ));
 
-                    code[preceding_choice_instr_loc] = Instruction::TrustMe(0);
+                code[preceding_choice_instr_loc] = Instruction::TrustMe(0);
 
-                    None
-                }
-                Instruction::TryMeElse(ref mut o) => {
-                    retraction_info.push_record(RetractionRecord::ModifiedTryMeElse(
-                        preceding_choice_instr_loc,
-                        *o,
-                    ));
-
-                    *o = 0;
-
-                    Some(IndexPtr::index(preceding_choice_instr_loc + 1))
-                }
-                _ => {
-                    unreachable!();
-                }
+                None
             }
-        }
+            Instruction::TryMeElse(ref mut o) => {
+                retraction_info.push_record(RetractionRecord::ModifiedTryMeElse(
+                    preceding_choice_instr_loc,
+                    *o,
+                ));
+
+                *o = 0;
+
+                Some(IndexPtr::index(preceding_choice_instr_loc + 1))
+            }
+            _ => {
+                unreachable!();
+            }
+        },
         _ => {
             unreachable!();
         }
@@ -988,11 +955,7 @@ fn prepend_compiled_clause(
                     Instruction::TryMeElse(ref mut o) if *o == 0 => {
                         *o = prepend_queue_len - 2;
                     }
-                    Instruction::DynamicInternalElse(
-                        _,
-                        _,
-                        ref mut o @ NextOrFail::Next(0),
-                    ) => {
+                    Instruction::DynamicInternalElse(_, _, ref mut o @ NextOrFail::Next(0)) => {
                         *o = NextOrFail::Fail(prepend_queue_len - 2);
                     }
                     _ => {
@@ -1258,7 +1221,11 @@ fn print_overwrite_warning(
         _ => {}
     }
 
-    println!("Warning: overwriting {}/{} because the clauses are discontiguous", key.0.as_str(), key.1);
+    println!(
+        "Warning: overwriting {}/{} because the clauses are discontiguous",
+        key.0.as_str(),
+        key.1
+    );
 }
 
 impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
@@ -1270,9 +1237,11 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
             if let Some(path_str) = load_context.path.to_str() {
                 if !path_str.is_empty() {
-                    return Some(LS::machine_st(&mut self.payload).atom_tbl.build_with(
-                        path_str
-                    ));
+                    return Some(
+                        LS::machine_st(&mut self.payload)
+                            .atom_tbl
+                            .build_with(path_str),
+                    );
                 }
             }
         }
@@ -1290,10 +1259,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
         let clause = self.try_term_to_tl(term, &mut preprocessor)?;
         // let queue = preprocessor.parse_queue(self)?;
 
-        let mut cg = CodeGenerator::new(
-            &mut LS::machine_st(&mut self.payload).atom_tbl,
-            settings,
-        );
+        let mut cg = CodeGenerator::new(&mut LS::machine_st(&mut self.payload).atom_tbl, settings);
 
         let clause_code = cg.compile_predicate(vec![clause])?;
 
@@ -1323,10 +1289,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             clauses.push(self.try_term_to_tl(term, &mut preprocessor)?);
         }
 
-        let mut cg = CodeGenerator::new(
-            &mut LS::machine_st(&mut self.payload).atom_tbl,
-            settings,
-        );
+        let mut cg = CodeGenerator::new(&mut LS::machine_st(&mut self.payload).atom_tbl, settings);
 
         let mut code = cg.compile_predicate(clauses)?;
 
@@ -1361,26 +1324,23 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         .clause_clause_locs
                         .extend(&clause_clause_locs.make_contiguous()[0..]);
 
-                    self.payload.retraction_info
-                        .push_record(RetractionRecord::SkeletonClauseTruncateBack(
+                    self.payload.retraction_info.push_record(
+                        RetractionRecord::SkeletonClauseTruncateBack(
                             predicates.compilation_target,
                             key,
                             skeleton_clause_len,
-                        ));
+                        ),
+                    );
                 }
                 None => {
                     cg.skeleton
-                      .core
-                      .clause_clause_locs
-                      .extend(&clause_clause_locs.make_contiguous()[0..]);
+                        .core
+                        .clause_clause_locs
+                        .extend(&clause_clause_locs.make_contiguous()[0..]);
 
                     let skeleton = cg.skeleton;
 
-                    self.add_extensible_predicate(
-                        key,
-                        skeleton,
-                        predicates.compilation_target,
-                    );
+                    self.add_extensible_predicate(key, skeleton, predicates.compilation_target);
                 }
             };
 
@@ -1450,11 +1410,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 let mut skeleton = LocalPredicateSkeleton::new();
                 skeleton.clause_clause_locs = clause_clause_locs;
 
-                self.add_local_extensible_predicate(
-                    *compilation_target,
-                    *key,
-                    skeleton,
-                );
+                self.add_local_extensible_predicate(*compilation_target, *key, skeleton);
             }
         }
     }
@@ -1490,11 +1446,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 let mut skeleton = LocalPredicateSkeleton::new();
                 skeleton.clause_clause_locs.push_front(code_len);
 
-                self.add_local_extensible_predicate(
-                    *compilation_target,
-                    *key,
-                    skeleton,
-                );
+                self.add_local_extensible_predicate(*compilation_target, *key, skeleton);
             }
         }
     }
@@ -1530,11 +1482,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 let mut skeleton = LocalPredicateSkeleton::new();
                 skeleton.clause_clause_locs.push_back(code_len);
 
-                self.add_local_extensible_predicate(
-                    *compilation_target,
-                    *key,
-                    skeleton,
-                );
+                self.add_local_extensible_predicate(*compilation_target, *key, skeleton);
             }
         }
     }
@@ -1606,7 +1554,8 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
                 skeleton.core.clause_clause_locs.push_back(code_len);
 
-                self.payload.retraction_info
+                self.payload
+                    .retraction_info
                     .push_record(RetractionRecord::SkeletonClausePopBack(
                         compilation_target,
                         key,
@@ -1624,8 +1573,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
                 self.push_back_to_local_predicate_skeleton(&compilation_target, &key, code_len);
 
-                let code_index =
-                    self.get_or_insert_code_index(key, compilation_target);
+                let code_index = self.get_or_insert_code_index(key, compilation_target);
 
                 if let Some(new_code_ptr) = result {
                     set_code_index(
@@ -1646,7 +1594,8 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 skeleton.core.clause_clause_locs.push_front(code_len);
                 skeleton.core.clause_assert_margin += 1;
 
-                self.payload.retraction_info
+                self.payload
+                    .retraction_info
                     .push_record(RetractionRecord::SkeletonClausePopFront(
                         compilation_target,
                         key,
@@ -1666,8 +1615,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
                 self.push_front_to_local_predicate_skeleton(&compilation_target, &key, code_len);
 
-                let code_index =
-                    self.get_or_insert_code_index(key, compilation_target);
+                let code_index = self.get_or_insert_code_index(key, compilation_target);
 
                 set_code_index(
                     &mut self.payload.retraction_info,
@@ -1698,19 +1646,17 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             .opt_arg_index_key
             .switch_on_term_loc()
         {
-            Some(index_loc) => {
-                find_inner_choice_instr(
-                    &self.wam_prelude.code,
-                    skeleton.clauses[target_pos].clause_start,
-                    index_loc,
-                )
-            }
+            Some(index_loc) => find_inner_choice_instr(
+                &self.wam_prelude.code,
+                skeleton.clauses[target_pos].clause_start,
+                index_loc,
+            ),
             None => skeleton.clauses[target_pos].clause_start,
         };
 
         match &mut self.wam_prelude.code[clause_loc] {
-            Instruction::DynamicElse(_, ref mut d, _) |
-            Instruction::DynamicInternalElse(_, ref mut d, _) => {
+            Instruction::DynamicElse(_, ref mut d, _)
+            | Instruction::DynamicInternalElse(_, ref mut d, _) => {
                 *d = Death::Finite(LS::machine_st(&mut self.payload).global_clock);
             }
             _ => unreachable!(),
@@ -1797,11 +1743,11 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             skeleton.clauses[target_pos + 1].clause_start =
                                 skeleton.clauses[target_pos].clause_start;
 
-                            let update_code_index = target_pos == 0 &&
-                                skeleton.clauses[target_pos + 1]
-                                  .opt_arg_index_key
-                                  .switch_on_term_loc()
-                                  .is_none();
+                            let update_code_index = target_pos == 0
+                                && skeleton.clauses[target_pos + 1]
+                                    .opt_arg_index_key
+                                    .switch_on_term_loc()
+                                    .is_none();
 
                             let index_ptr_opt = if update_code_index {
                                 Some(IndexPtr::index(clause_loc))
@@ -1964,7 +1910,8 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                                 index_loc,
                             );
 
-                            let lower_bound_clause_start = skeleton.clauses[lower_bound].clause_start;
+                            let lower_bound_clause_start =
+                                skeleton.clauses[lower_bound].clause_start;
                             let preceding_choice_instr_loc;
 
                             match &mut code[clause_start] {
@@ -2093,13 +2040,8 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
         clause_clauses: ClauseIter,
         append_or_prepend: AppendOrPrepend,
     ) -> Result<(), SessionError> {
-        let clause_predicates = clause_clauses.map(|(head, body)| {
-            Term::Clause(
-                Cell::default(),
-                atom!("$clause"),
-                vec![head, body],
-            )
-        });
+        let clause_predicates = clause_clauses
+            .map(|(head, body)| Term::Clause(Cell::default(), atom!("$clause"), vec![head, body]));
 
         let clause_clause_compilation_target = match compilation_target {
             CompilationTarget::User => CompilationTarget::Module(atom!("builtins")),
@@ -2132,21 +2074,21 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                     .cloned()
                     .collect()
             }
-            Some(skeleton) => {
-                skeleton.core.clause_clause_locs.make_contiguous()[0..num_clause_predicates]
-                    .iter()
-                    .cloned()
-                    .collect()
-            }
+            Some(skeleton) => skeleton.core.clause_clause_locs.make_contiguous()
+                [0..num_clause_predicates]
+                .iter()
+                .cloned()
+                .collect(),
             None => {
                 unreachable!()
             }
         };
 
-        match self.wam_prelude.indices.get_predicate_skeleton_mut(
-            &clause_clause_compilation_target,
-            &(atom!("$clause"), 2),
-        ) {
+        match self
+            .wam_prelude
+            .indices
+            .get_predicate_skeleton_mut(&clause_clause_compilation_target, &(atom!("$clause"), 2))
+        {
             Some(skeleton) if append_or_prepend.is_append() => {
                 for _ in 0..num_clause_predicates {
                     skeleton.core.clause_clause_locs.pop_back();
@@ -2270,25 +2212,25 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         println!(
                             "Warning: overwriting multifile predicate {}:{}/{} because \
                                   it was not locally declared multifile.",
-                            self.payload.predicates.compilation_target, key.0.as_str(), key.1
+                            self.payload.predicates.compilation_target,
+                            key.0.as_str(),
+                            key.1
                         );
                     }
 
-                    if let Some(skeleton) = self
-                        .wam_prelude
-                        .indices
-                        .remove_predicate_skeleton(&self.payload.predicates.compilation_target, &key)
-                    {
+                    if let Some(skeleton) = self.wam_prelude.indices.remove_predicate_skeleton(
+                        &self.payload.predicates.compilation_target,
+                        &key,
+                    ) {
                         let compilation_target = self.payload.predicates.compilation_target;
 
                         if predicate_info.is_dynamic {
-                            let clause_clause_compilation_target =
-                                match compilation_target {
-                                    CompilationTarget::User => {
-                                        CompilationTarget::Module(atom!("builtins"))
-                                    }
-                                    module => module,
-                                };
+                            let clause_clause_compilation_target = match compilation_target {
+                                CompilationTarget::User => {
+                                    CompilationTarget::Module(atom!("builtins"))
+                                }
+                                module => module,
+                            };
 
                             self.retract_local_clauses_by_locs(
                                 clause_clause_compilation_target,
@@ -2301,11 +2243,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         }
 
                         self.payload.retraction_info.push_record(
-                            RetractionRecord::RemovedSkeleton(
-                                compilation_target,
-                                key,
-                                skeleton,
-                            ),
+                            RetractionRecord::RemovedSkeleton(compilation_target, key, skeleton),
                         );
                     }
                 }
@@ -2328,9 +2266,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 match self.wam_prelude.indices.modules.get_mut(&filename) {
                     Some(ref mut module) => {
                         let index_ptr = code_index.get();
-                        let code_index = module.code_dir.entry(key)
-                            .or_insert(code_index)
-                            .clone();
+                        let code_index = module.code_dir.entry(key).or_insert(code_index).clone();
 
                         set_code_index(
                             &mut self.payload.retraction_info,
@@ -2349,8 +2285,10 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             LS::machine_st(&mut self.payload).global_clock += 1;
 
             let clause_clauses_len = self.payload.clause_clauses.len();
-            let clauses_vec: Vec<_> = self.payload
-                .clause_clauses.drain(0..std::cmp::min(predicates_len, clause_clauses_len))
+            let clauses_vec: Vec<_> = self
+                .payload
+                .clause_clauses
+                .drain(0..std::cmp::min(predicates_len, clause_clauses_len))
                 .collect();
 
             let compilation_target = self.payload.predicates.compilation_target;
@@ -2374,10 +2312,7 @@ impl Machine {
         module_name: HeapCellValue,
         key: PredicateKey,
     ) -> CodeIndex {
-        let mut loader: Loader<'_, InlineLoadState<'_>> = Loader::new(
-            self,
-            InlineTermStream {},
-        );
+        let mut loader: Loader<'_, InlineLoadState<'_>> = Loader::new(self, InlineTermStream {});
 
         let module_name = if module_name.get_tag() == HeapCellValueTag::Atom {
             cell_as_atom!(module_name)
@@ -2394,10 +2329,8 @@ impl Machine {
         vars: &[Term],
     ) -> Result<(), SessionError> {
         let mut compile = || {
-            let mut loader: Loader<'_, InlineLoadState<'_>> = Loader::new(
-                self,
-                InlineTermStream {},
-            );
+            let mut loader: Loader<'_, InlineLoadState<'_>> =
+                Loader::new(self, InlineTermStream {});
 
             let term = loader.read_term_from_heap(term_loc)?;
             let clause = build_rule_body(vars, term);

--- a/src/machine/compile.rs
+++ b/src/machine/compile.rs
@@ -1237,12 +1237,10 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
             if let Some(path_str) = load_context.path.to_str() {
                 if !path_str.is_empty() {
-                    return Some(
-                        LS::machine_st(&mut self.payload)
-                            .atom_tbl
-                            .blocking_write()
-                            .build_with(path_str),
-                    );
+                    return Some(AtomTable::build_with(
+                        &LS::machine_st(&mut self.payload).atom_tbl,
+                        path_str,
+                    ));
                 }
             }
         }

--- a/src/machine/copier.rs
+++ b/src/machine/copier.rs
@@ -409,7 +409,7 @@ mod tests {
         let pstr_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "abc ",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
@@ -419,7 +419,7 @@ mod tests {
         let pstr_second_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "def",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 

--- a/src/machine/copier.rs
+++ b/src/machine/copier.rs
@@ -406,21 +406,15 @@ mod tests {
 
         wam.machine_st.heap.clear();
 
-        let pstr_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "abc ",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "abc ", &wam.machine_st.atom_tbl);
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
         wam.machine_st.heap.pop();
         wam.machine_st.heap.push(pstr_loc_as_cell!(2));
 
-        let pstr_second_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "def",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_second_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "def", &wam.machine_st.atom_tbl);
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 
         wam.machine_st.heap.pop();

--- a/src/machine/copier.rs
+++ b/src/machine/copier.rs
@@ -91,12 +91,16 @@ impl<T: CopierTarget> CopyTermState<T> {
             self.target.push(hcv);
         }
 
-        let cdr = self.target.store(self.target.deref(heap_loc_as_cell!(addr + 1)));
+        let cdr = self
+            .target
+            .store(self.target.deref(heap_loc_as_cell!(addr + 1)));
 
         if !cdr.is_var() {
             self.trail_list_cell(addr + 1, threshold);
         } else {
-            let car = self.target.store(self.target.deref(heap_loc_as_cell!(addr)));
+            let car = self
+                .target
+                .store(self.target.deref(heap_loc_as_cell!(addr)));
 
             if !car.is_var() {
                 self.trail_list_cell(addr, threshold);
@@ -188,10 +192,10 @@ impl<T: CopierTarget> CopyTermState<T> {
         while let HeapCellValueTag::Lis = list_addr.get_tag() {
             let threshold = self.target.threshold();
             let heap_loc = list_addr.get_value() as usize;
-            let str_loc  = self.target[heap_loc].get_value() as usize;
+            let str_loc = self.target[heap_loc].get_value() as usize;
 
-            self.target.push(heap_loc_as_cell!(threshold+2));
-            self.target.push(heap_loc_as_cell!(threshold+1));
+            self.target.push(heap_loc_as_cell!(threshold + 2));
+            self.target.push(heap_loc_as_cell!(threshold + 1));
 
             read_heap_cell!(self.target[str_loc],
                 (HeapCellValueTag::Atom) => {
@@ -377,8 +381,9 @@ mod tests {
         let a_atom = atom!("a");
         let b_atom = atom!("b");
 
-        wam.machine_st.heap
-           .extend(functor!(f_atom, [atom(a_atom), atom(b_atom)]));
+        wam.machine_st
+            .heap
+            .extend(functor!(f_atom, [atom(a_atom), atom(b_atom)]));
 
         assert_eq!(wam.machine_st.heap[0], atom_as_cell!(f_atom, 2));
         assert_eq!(wam.machine_st.heap[1], atom_as_cell!(a_atom));
@@ -401,20 +406,32 @@ mod tests {
 
         wam.machine_st.heap.clear();
 
-        let pstr_var_cell = put_partial_string(&mut wam.machine_st.heap, "abc ", &mut wam.machine_st.atom_tbl);
+        let pstr_var_cell = put_partial_string(
+            &mut wam.machine_st.heap,
+            "abc ",
+            &mut wam.machine_st.atom_tbl,
+        );
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
         wam.machine_st.heap.pop();
         wam.machine_st.heap.push(pstr_loc_as_cell!(2));
 
-        let pstr_second_var_cell = put_partial_string(&mut wam.machine_st.heap, "def", &mut wam.machine_st.atom_tbl);
+        let pstr_second_var_cell = put_partial_string(
+            &mut wam.machine_st.heap,
+            "def",
+            &mut wam.machine_st.atom_tbl,
+        );
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 
         wam.machine_st.heap.pop();
-        wam.machine_st.heap.push(pstr_loc_as_cell!(wam.machine_st.heap.len() + 1));
+        wam.machine_st
+            .heap
+            .push(pstr_loc_as_cell!(wam.machine_st.heap.len() + 1));
 
         wam.machine_st.heap.push(pstr_offset_as_cell!(0));
-        wam.machine_st.heap.push(fixnum_as_cell!(Fixnum::build_with(0i64)));
+        wam.machine_st
+            .heap
+            .push(fixnum_as_cell!(Fixnum::build_with(0i64)));
 
         {
             let wam = TermCopyingMockWAM { wam: &mut wam };
@@ -428,14 +445,20 @@ mod tests {
         assert_eq!(wam.machine_st.heap[2], pstr_second_cell);
         assert_eq!(wam.machine_st.heap[3], pstr_loc_as_cell!(4));
         assert_eq!(wam.machine_st.heap[4], pstr_offset_as_cell!(0));
-        assert_eq!(wam.machine_st.heap[5], fixnum_as_cell!(Fixnum::build_with(0i64)));
+        assert_eq!(
+            wam.machine_st.heap[5],
+            fixnum_as_cell!(Fixnum::build_with(0i64))
+        );
 
         assert_eq!(wam.machine_st.heap[7], pstr_cell);
         assert_eq!(wam.machine_st.heap[8], pstr_loc_as_cell!(9));
         assert_eq!(wam.machine_st.heap[9], pstr_second_cell);
         assert_eq!(wam.machine_st.heap[10], pstr_loc_as_cell!(11));
         assert_eq!(wam.machine_st.heap[11], pstr_offset_as_cell!(7));
-        assert_eq!(wam.machine_st.heap[12], fixnum_as_cell!(Fixnum::build_with(0i64)));
+        assert_eq!(
+            wam.machine_st.heap[12],
+            fixnum_as_cell!(Fixnum::build_with(0i64))
+        );
 
         wam.machine_st.heap.clear();
 

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -3000,7 +3000,7 @@ impl Machine {
                              HeapCellValueTag::StackVar |
                              HeapCellValueTag::Var) => {
                                 let target_cell = self.machine_st.push_str_to_heap(
-                                    string.as_str(),
+                                    &string.as_str(),
                                     has_tail,
                                 );
 

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -1,10 +1,10 @@
 use crate::arena::*;
 use crate::atom_table::*;
 use crate::instructions::*;
-use crate::machine::*;
 use crate::machine::arithmetic_ops::*;
 use crate::machine::machine_errors::*;
 use crate::machine::machine_state::*;
+use crate::machine::*;
 use crate::types::*;
 
 use crate::try_numeric_result;
@@ -59,17 +59,16 @@ impl MachineState {
         let a2 = self.registers[2];
         let a3 = self.registers[3];
 
-        let check_atom = |machine_st: &mut MachineState, name: Atom, arity: usize| -> Result<(), MachineStub> {
-            match name {
-                atom!(">") | atom!("<") | atom!("=") if arity == 0 => {
-                    Ok(())
+        let check_atom =
+            |machine_st: &mut MachineState, name: Atom, arity: usize| -> Result<(), MachineStub> {
+                match name {
+                    atom!(">") | atom!("<") | atom!("=") if arity == 0 => Ok(()),
+                    _ => {
+                        let err = machine_st.domain_error(DomainErrorType::Order, a1);
+                        Err(machine_st.error_form(err, stub_gen()))
+                    }
                 }
-                _ => {
-                    let err = machine_st.domain_error(DomainErrorType::Order, a1);
-                    Err(machine_st.error_form(err, stub_gen()))
-                }
-            }
-        };
+            };
 
         read_heap_cell!(a1,
             (HeapCellValueTag::Atom, (name, arity)) => {
@@ -127,13 +126,9 @@ impl MachineState {
             compare_term_test!(self, *v1, *v2).unwrap_or(Ordering::Less)
         });
 
-        list.dedup_by(|v1, v2| {
-            compare_term_test!(self, *v1, *v2) == Some(Ordering::Equal)
-        });
+        list.dedup_by(|v1, v2| compare_term_test!(self, *v1, *v2) == Some(Ordering::Equal));
 
-        let heap_addr = heap_loc_as_cell!(
-            iter_to_heap_list(&mut self.heap, list.into_iter())
-        );
+        let heap_addr = heap_loc_as_cell!(iter_to_heap_list(&mut self.heap, list.into_iter()));
 
         let target_addr = self.registers[2];
 
@@ -159,9 +154,7 @@ impl MachineState {
         });
 
         let key_pairs = key_pairs.into_iter().map(|kp| kp.1);
-        let heap_addr = heap_loc_as_cell!(
-            iter_to_heap_list(&mut self.heap, key_pairs)
-        );
+        let heap_addr = heap_loc_as_cell!(iter_to_heap_list(&mut self.heap, key_pairs));
 
         let target_addr = self.registers[2];
 
@@ -312,11 +305,7 @@ impl Machine {
     pub(super) fn find_living_dynamic_else(&self, mut p: usize) -> Option<(usize, usize)> {
         loop {
             match &self.code[p] {
-                &Instruction::DynamicElse(
-                    birth,
-                    death,
-                    NextOrFail::Next(i),
-                ) => {
+                &Instruction::DynamicElse(birth, death, NextOrFail::Next(i)) => {
                     if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death {
                         return Some((p, i));
                     } else if i > 0 {
@@ -325,22 +314,14 @@ impl Machine {
                         return None;
                     }
                 }
-                &Instruction::DynamicElse(
-                    birth,
-                    death,
-                    NextOrFail::Fail(_),
-                ) => {
+                &Instruction::DynamicElse(birth, death, NextOrFail::Fail(_)) => {
                     if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death {
                         return Some((p, 0));
                     } else {
                         return None;
                     }
                 }
-                &Instruction::DynamicInternalElse(
-                    birth,
-                    death,
-                    NextOrFail::Next(i),
-                ) => {
+                &Instruction::DynamicInternalElse(birth, death, NextOrFail::Next(i)) => {
                     if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death {
                         return Some((p, i));
                     } else if i > 0 {
@@ -349,11 +330,7 @@ impl Machine {
                         return None;
                     }
                 }
-                &Instruction::DynamicInternalElse(
-                    birth,
-                    death,
-                    NextOrFail::Fail(_),
-                ) => {
+                &Instruction::DynamicInternalElse(birth, death, NextOrFail::Fail(_)) => {
                     if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death {
                         return Some((p, 0));
                     } else {
@@ -370,7 +347,11 @@ impl Machine {
         }
     }
 
-    pub(super) fn find_living_dynamic(&self, oi: u32, mut ii: u32) -> Option<(usize, u32, u32, bool)> {
+    pub(super) fn find_living_dynamic(
+        &self,
+        oi: u32,
+        mut ii: u32,
+    ) -> Option<(usize, u32, u32, bool)> {
         let p = self.machine_st.p;
 
         let indexed_choice_instrs = match &self.code[p] {
@@ -386,12 +367,9 @@ impl Machine {
         loop {
             match &indexed_choice_instrs.get(ii as usize) {
                 Some(&offset) => match &self.code[p + offset - 1] {
-                    &Instruction::DynamicInternalElse(
-                        birth,
-                        death,
-                        next_or_fail,
-                    ) => {
-                        if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death {
+                    &Instruction::DynamicInternalElse(birth, death, next_or_fail) => {
+                        if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death
+                        {
                             return Some((offset, oi, ii, next_or_fail.is_next()));
                         } else {
                             ii += 1;
@@ -418,7 +396,9 @@ impl Machine {
 
             match &machine.code[p - 1] {
                 &Instruction::DynamicInternalElse(birth, death, _) => {
-                    if birth < machine.machine_st.cc && Death::Finite(machine.machine_st.cc) <= death {
+                    if birth < machine.machine_st.cc
+                        && Death::Finite(machine.machine_st.cc) <= death
+                    {
                         return true;
                     } else {
                         return false;
@@ -434,9 +414,9 @@ impl Machine {
 
         let mut index = 0;
         let addr = match &indexing_lines[0] {
-            &IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(arg, ..)) => {
-                self.machine_st.store(self.machine_st.deref(self.machine_st.registers[arg]))
-            }
+            &IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(arg, ..)) => self
+                .machine_st
+                .store(self.machine_st.deref(self.machine_st.registers[arg])),
             _ => {
                 unreachable!()
             }
@@ -445,7 +425,9 @@ impl Machine {
         loop {
             match &indexing_lines[index] {
                 &IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(_, v, c, l, s)) => {
-                    let offset = self.machine_st.select_switch_on_term_index(addr, v, c, l, s);
+                    let offset = self
+                        .machine_st
+                        .select_switch_on_term_index(addr, v, c, l, s);
 
                     match offset {
                         IndexingCodePtr::Fail => {
@@ -560,4846 +542,4955 @@ impl Machine {
     #[inline(always)]
     pub(super) fn dispatch_loop(&mut self) -> std::process::ExitCode {
         'outer: loop {
-        for _ in 0 .. INSTRUCTIONS_PER_INTERRUPT_POLL {
-            match &self.code[self.machine_st.p] {
-                &Instruction::BreakFromDispatchLoop => {
-                    break 'outer;
-                }
-                &Instruction::InstallVerifyAttr => {
-                    self.machine_st.p = self.machine_st.attr_var_init.p;
+            for _ in 0..INSTRUCTIONS_PER_INTERRUPT_POLL {
+                match &self.code[self.machine_st.p] {
+                    &Instruction::BreakFromDispatchLoop => {
+                        break 'outer;
+                    }
+                    &Instruction::InstallVerifyAttr => {
+                        self.machine_st.p = self.machine_st.attr_var_init.p;
 
-                    if self.code[self.machine_st.p].is_execute() {
-                        self.machine_st.p = self.machine_st.attr_var_init.cp;
-                    } else {
+                        if self.code[self.machine_st.p].is_execute() {
+                            self.machine_st.p = self.machine_st.attr_var_init.cp;
+                        } else {
+                            self.machine_st.p += 1;
+                            self.machine_st.cp = self.machine_st.attr_var_init.cp;
+                        }
+
+                        let mut p = self.machine_st.p;
+
+                        while self.code[p].is_head_instr() {
+                            p += 1;
+                        }
+
+                        let instr =
+                            std::mem::replace(&mut self.code[p], Instruction::VerifyAttrInterrupt);
+
+                        self.code[VERIFY_ATTR_INTERRUPT_LOC] = instr;
+                        self.machine_st.attr_var_init.cp = p;
+                    }
+                    &Instruction::VerifyAttrInterrupt => {
+                        let (_, arity) = self.code[VERIFY_ATTR_INTERRUPT_LOC].to_name_and_arity();
+                        let arity = std::cmp::max(arity, self.machine_st.num_of_args);
+                        self.run_verify_attr_interrupt(arity);
+                    }
+                    &Instruction::Add(ref a1, ref a2, t) => {
+                        let stub_gen = || functor_stub(atom!("is"), 2);
+
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            try_numeric_result!(add(n1, n2, &mut self.machine_st.arena), stub_gen)
+                        );
+
                         self.machine_st.p += 1;
-                        self.machine_st.cp = self.machine_st.attr_var_init.cp;
                     }
+                    &Instruction::Sub(ref a1, ref a2, t) => {
+                        let stub_gen = || functor_stub(atom!("is"), 2);
 
-                    let mut p = self.machine_st.p;
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
 
-                    while self.code[p].is_head_instr() {
-                        p += 1;
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            try_numeric_result!(sub(n1, n2, &mut self.machine_st.arena), stub_gen)
+                        );
+
+                        self.machine_st.p += 1;
                     }
+                    &Instruction::Mul(ref a1, ref a2, t) => {
+                        let stub_gen = || functor_stub(atom!("is"), 2);
 
-                    let instr = std::mem::replace(
-                        &mut self.code[p],
-                        Instruction::VerifyAttrInterrupt,
-                    );
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
 
-                    self.code[VERIFY_ATTR_INTERRUPT_LOC] = instr;
-                    self.machine_st.attr_var_init.cp = p;
-                }
-                &Instruction::VerifyAttrInterrupt => {
-                    let (_, arity) = self.code[VERIFY_ATTR_INTERRUPT_LOC].to_name_and_arity();
-                    let arity = std::cmp::max(arity, self.machine_st.num_of_args);
-                    self.run_verify_attr_interrupt(arity);
-                }
-                &Instruction::Add(ref a1, ref a2, t) => {
-                    let stub_gen = || functor_stub(atom!("is"), 2);
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            try_numeric_result!(mul(n1, n2, &mut self.machine_st.arena), stub_gen)
+                        );
 
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        try_numeric_result!(add(n1, n2, &mut self.machine_st.arena), stub_gen)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Sub(ref a1, ref a2, t) => {
-                    let stub_gen = || functor_stub(atom!("is"), 2);
-
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        try_numeric_result!(sub(n1, n2, &mut self.machine_st.arena), stub_gen)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Mul(ref a1, ref a2, t) => {
-                    let stub_gen = || functor_stub(atom!("is"), 2);
-
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        try_numeric_result!(mul(n1, n2, &mut self.machine_st.arena), stub_gen)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Max(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        max(n1, n2)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Min(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        min(n1, n2)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::IntPow(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        int_pow(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Gcd(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        gcd(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Pow(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        pow(n1, n2, atom!("**"))
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::RDiv(ref a1, ref a2, t) => {
-                    let stub_gen = || functor_stub(atom!("(rdiv)"), 2);
-
-                    let r1 = try_or_throw!(self.machine_st, self.machine_st.get_rational(a1, stub_gen));
-                    let r2 = try_or_throw!(self.machine_st, self.machine_st.get_rational(a2, stub_gen));
-
-                    self.machine_st.interms[t - 1] = Number::Rational(arena_alloc!(
-                        try_or_throw_gen!(&mut self.machine_st, rdiv(r1, r2)),
-                        &mut self.machine_st.arena
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::IntFloorDiv(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        int_floor_div(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::IDiv(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        idiv(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Abs(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = abs(n1, &mut self.machine_st.arena);
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Sign(ref a1, t) => {
-                    let n = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = n.sign();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Neg(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = neg(n1, &mut self.machine_st.arena);
-                    self.machine_st.p += 1;
-                }
-                &Instruction::BitwiseComplement(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        bitwise_complement(n1, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Div(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        div(n1, n2)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Shr(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        shr(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Shl(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        shl(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Xor(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        xor(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::And(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        and(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Or(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        or(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Mod(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        modulus(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Rem(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = try_or_throw_gen!(
-                        &mut self.machine_st,
-                        remainder(n1, n2, &mut self.machine_st.arena)
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Cos(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, cos(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Sin(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, sin(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Tan(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, tan(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Sqrt(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, sqrt(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Log(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, log(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Exp(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, exp(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ACos(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, acos(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ASin(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, asin(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ATan(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, atan(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ATan2(ref a1, ref a2, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, atan2(n1, n2))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ACosh(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, acosh(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ASinh(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, asinh(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ATanh(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, atanh(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Cosh(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, cosh(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Sinh(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, sinh(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Tanh(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, tanh(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Log10(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, log10(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Float(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, float(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Truncate(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = truncate(n1, &mut self.machine_st.arena);
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Round(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] =
-                        try_or_throw_gen!(&mut self.machine_st, round(n1, &mut self.machine_st.arena));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Ceiling(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = ceiling(n1, &mut self.machine_st.arena);
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Floor(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = floor(n1, &mut self.machine_st.arena);
-                    self.machine_st.p += 1;
-                }
-                &Instruction::FloatFractionalPart(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, float_fractional_part(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::FloatIntegerPart(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
-                        try_or_throw_gen!(&mut self.machine_st, float_integer_part(n1))
-                    ));
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Plus(ref a1, t) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
-
-                    self.machine_st.interms[t - 1] = n1;
-                    self.machine_st.p += 1;
-                }
-                &Instruction::DynamicElse(..) => {
-                    if let FirstOrNext::First = self.machine_st.dynamic_mode {
-                        self.machine_st.cc = self.machine_st.global_clock;
+                        self.machine_st.p += 1;
                     }
+                    &Instruction::Max(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
 
-                    let p = self.machine_st.p;
+                        self.machine_st.interms[t - 1] =
+                            try_or_throw_gen!(&mut self.machine_st, max(n1, n2));
 
-                    match self.find_living_dynamic_else(p) {
-                        Some((p, next_i)) => {
-                            self.machine_st.p = p;
-                            self.machine_st.oip = 0;
-                            self.machine_st.iip = 0;
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Min(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
 
-                            match self.machine_st.dynamic_mode {
-                                FirstOrNext::First if next_i == 0 => {
-                                    self.machine_st.p += 1;
-                                }
-                                FirstOrNext::First => {
-                                    self.machine_st.cc = self.machine_st.global_clock;
+                        self.machine_st.interms[t - 1] =
+                            try_or_throw_gen!(&mut self.machine_st, min(n1, n2));
 
-                                    match self.find_living_dynamic_else(p + next_i) {
-                                        Some(_) => {
-                                            self.machine_st.registers[self.machine_st.num_of_args + 1] =
-                                                fixnum_as_cell!(Fixnum::build_with(self.machine_st.cc as i64));
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::IntPow(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
 
-                                            self.machine_st.num_of_args += 1;
-                                            self.try_me_else(next_i);
-                                            self.machine_st.num_of_args -= 1;
-                                        }
-                                        None => {
-                                            self.machine_st.p += 1;
-                                        }
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            int_pow(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Gcd(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            gcd(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Pow(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] =
+                            try_or_throw_gen!(&mut self.machine_st, pow(n1, n2, atom!("**")));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::RDiv(ref a1, ref a2, t) => {
+                        let stub_gen = || functor_stub(atom!("(rdiv)"), 2);
+
+                        let r1 = try_or_throw!(
+                            self.machine_st,
+                            self.machine_st.get_rational(a1, stub_gen)
+                        );
+                        let r2 = try_or_throw!(
+                            self.machine_st,
+                            self.machine_st.get_rational(a2, stub_gen)
+                        );
+
+                        self.machine_st.interms[t - 1] = Number::Rational(arena_alloc!(
+                            try_or_throw_gen!(&mut self.machine_st, rdiv(r1, r2)),
+                            &mut self.machine_st.arena
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::IntFloorDiv(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            int_floor_div(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::IDiv(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            idiv(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Abs(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = abs(n1, &mut self.machine_st.arena);
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Sign(ref a1, t) => {
+                        let n = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = n.sign();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Neg(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = neg(n1, &mut self.machine_st.arena);
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::BitwiseComplement(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            bitwise_complement(n1, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Div(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] =
+                            try_or_throw_gen!(&mut self.machine_st, div(n1, n2));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Shr(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            shr(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Shl(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            shl(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Xor(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            xor(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::And(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            and(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Or(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            or(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Mod(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            modulus(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Rem(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            remainder(n1, n2, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Cos(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, cos(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Sin(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, sin(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Tan(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, tan(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Sqrt(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, sqrt(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Log(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, log(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Exp(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, exp(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ACos(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, acos(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ASin(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, asin(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ATan(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, atan(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ATan2(ref a1, ref a2, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(a2));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, atan2(n1, n2)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ACosh(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, acosh(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ASinh(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, asinh(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ATanh(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, atanh(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Cosh(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, cosh(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Sinh(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, sinh(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Tanh(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, tanh(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Log10(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, log10(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Float(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, float(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Truncate(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = truncate(n1, &mut self.machine_st.arena);
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Round(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = try_or_throw_gen!(
+                            &mut self.machine_st,
+                            round(n1, &mut self.machine_st.arena)
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Ceiling(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = ceiling(n1, &mut self.machine_st.arena);
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Floor(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = floor(n1, &mut self.machine_st.arena);
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::FloatFractionalPart(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, float_fractional_part(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::FloatIntegerPart(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = Number::Float(OrderedFloat(
+                            try_or_throw_gen!(&mut self.machine_st, float_integer_part(n1)),
+                        ));
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Plus(ref a1, t) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(a1));
+
+                        self.machine_st.interms[t - 1] = n1;
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::DynamicElse(..) => {
+                        if let FirstOrNext::First = self.machine_st.dynamic_mode {
+                            self.machine_st.cc = self.machine_st.global_clock;
+                        }
+
+                        let p = self.machine_st.p;
+
+                        match self.find_living_dynamic_else(p) {
+                            Some((p, next_i)) => {
+                                self.machine_st.p = p;
+                                self.machine_st.oip = 0;
+                                self.machine_st.iip = 0;
+
+                                match self.machine_st.dynamic_mode {
+                                    FirstOrNext::First if next_i == 0 => {
+                                        self.machine_st.p += 1;
                                     }
-                                }
-                                FirstOrNext::Next => {
-                                    let n = self.machine_st
-                                        .stack
-                                        .index_or_frame(self.machine_st.b)
-                                        .prelude
-                                        .num_cells;
+                                    FirstOrNext::First => {
+                                        self.machine_st.cc = self.machine_st.global_clock;
 
-                                    self.machine_st.cc = cell_as_fixnum!(
-                                        self.machine_st.stack[stack_loc!(OrFrame, self.machine_st.b, n-1)]
-                                    ).get_num() as usize;
-
-                                    if next_i > 0 {
                                         match self.find_living_dynamic_else(p + next_i) {
                                             Some(_) => {
-                                                self.retry_me_else(next_i);
+                                                self.machine_st.registers
+                                                    [self.machine_st.num_of_args + 1] = fixnum_as_cell!(
+                                                    Fixnum::build_with(self.machine_st.cc as i64)
+                                                );
+
+                                                self.machine_st.num_of_args += 1;
+                                                self.try_me_else(next_i);
+                                                self.machine_st.num_of_args -= 1;
                                             }
                                             None => {
-                                                self.trust_me();
+                                                self.machine_st.p += 1;
                                             }
                                         }
-                                    } else {
-                                        self.trust_me();
                                     }
-
-                                    try_or_throw!(
-                                        self.machine_st,
-                                        (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                                    );
-                                }
-                            }
-                        }
-                        None => {
-                            self.machine_st.fail = true;
-                        }
-                    }
-
-                    self.machine_st.dynamic_mode = FirstOrNext::Next;
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::DynamicInternalElse(..) => {
-                    let p = self.machine_st.p;
-
-                    match self.find_living_dynamic_else(p) {
-                        Some((p, next_i)) => {
-                            self.machine_st.p = p;
-                            self.machine_st.oip = 0;
-                            self.machine_st.iip = 0;
-
-                            match self.machine_st.dynamic_mode {
-                                FirstOrNext::First if next_i == 0 => {
-                                    self.machine_st.p += 1;
-                                }
-                                FirstOrNext::First => {
-                                    match self.find_living_dynamic_else(p + next_i) {
-                                        Some(_) => {
-                                            self.machine_st.registers[self.machine_st.num_of_args + 1] =
-                                                fixnum_as_cell!(Fixnum::build_with(self.machine_st.cc as i64));
-
-                                            self.machine_st.num_of_args += 1;
-                                            self.try_me_else(next_i);
-                                            self.machine_st.num_of_args -= 1;
-                                        }
-                                        None => {
-                                            self.machine_st.p += 1;
-                                        }
-                                    }
-                                }
-                                FirstOrNext::Next => {
-                                    let n = self.machine_st
-                                        .stack
-                                        .index_or_frame(self.machine_st.b)
-                                        .prelude
-                                        .num_cells;
-
-                                    self.machine_st.cc = cell_as_fixnum!(
-                                        self.machine_st.stack[stack_loc!(OrFrame, self.machine_st.b, n-1)]
-                                    ).get_num() as usize;
-
-                                    if next_i > 0 {
-                                        match self.find_living_dynamic_else(p + next_i) {
-                                            Some(_) => {
-                                                self.retry_me_else(next_i);
-                                            }
-                                            None => {
-                                                self.trust_me();
-                                            }
-                                        }
-                                    } else {
-                                        self.trust_me();
-                                    }
-
-                                    try_or_throw!(
-                                        self.machine_st,
-                                        (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                                    );
-                                }
-                            }
-                        }
-                        None => {
-                            self.machine_st.fail = true;
-                        }
-                    }
-
-                    self.machine_st.dynamic_mode = FirstOrNext::Next;
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::TryMeElse(offset) => {
-                    self.try_me_else(offset);
-                }
-                &Instruction::DefaultRetryMeElse(offset) => {
-                    self.retry_me_else(offset);
-                }
-                &Instruction::DefaultTrustMe(_) => {
-                    self.trust_me();
-                }
-                &Instruction::RetryMeElse(offset) => {
-                    self.retry_me_else(offset);
-
-                    try_or_throw!(
-                        self.machine_st,
-                        (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                    );
-                }
-                &Instruction::TrustMe(_) => {
-                    self.trust_me();
-
-                    try_or_throw!(
-                        self.machine_st,
-                        (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                    );
-                }
-                &Instruction::NeckCut => {
-                    self.machine_st.neck_cut();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::GetLevel(r) => {
-                    let b0 = self.machine_st.b0;
-
-                    self.machine_st[r] = fixnum_as_cell!(Fixnum::as_cutpoint(b0 as i64));
-                    self.machine_st.p += 1;
-                }
-                &Instruction::GetPrevLevel(r) => {
-                    let prev_b = self.machine_st.stack.index_or_frame(self.machine_st.b).prelude.b;
-
-                    self.machine_st[r] = fixnum_as_cell!(Fixnum::as_cutpoint(prev_b as i64));
-                    self.machine_st.p += 1;
-                }
-                &Instruction::GetCutPoint(r) => {
-                    self.machine_st[r] = fixnum_as_cell!(Fixnum::as_cutpoint(self.machine_st.b as i64));
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Cut(r) => {
-                    let value = self.machine_st[r];
-                    self.machine_st.cut_body(value);
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                        continue;
-                    }
-
-                    if (self.machine_st.run_cleaners_fn)(self) {
-                       continue;
-                    }
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::Allocate(num_cells) => {
-                    self.machine_st.allocate(num_cells);
-                }
-                &Instruction::DefaultCallAcyclicTerm => {
-                    let addr = self.machine_st.registers[1];
-
-                    if self.machine_st.is_cyclic_term(addr) {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::DefaultExecuteAcyclicTerm => {
-                    let addr = self.machine_st.registers[1];
-
-                    if self.machine_st.is_cyclic_term(addr) {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::DefaultCallArg => {
-                    try_or_throw!(self.machine_st, self.machine_st.try_arg());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::DefaultExecuteArg => {
-                    try_or_throw!(self.machine_st, self.machine_st.try_arg());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::DefaultCallCompare => {
-                    try_or_throw!(self.machine_st, self.machine_st.compare());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::DefaultExecuteCompare => {
-                    try_or_throw!(self.machine_st, self.machine_st.compare());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::DefaultCallTermGreaterThan => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Greater) = compare_term_test!(self.machine_st, a1, a2) {
-                        self.machine_st.p += 1;
-                    } else {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::DefaultExecuteTermGreaterThan => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Greater) = compare_term_test!(self.machine_st, a1, a2) {
-                        self.machine_st.p = self.machine_st.cp;
-                    } else {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::DefaultCallTermLessThan => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Less) = compare_term_test!(self.machine_st, a1, a2) {
-                        self.machine_st.p += 1;
-                    } else {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::DefaultExecuteTermLessThan => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Less) = compare_term_test!(self.machine_st, a1, a2) {
-                        self.machine_st.p = self.machine_st.cp;
-                    } else {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::DefaultCallTermGreaterThanOrEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    match compare_term_test!(self.machine_st, a1, a2) {
-                        Some(Ordering::Greater | Ordering::Equal) => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultExecuteTermGreaterThanOrEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    match compare_term_test!(self.machine_st, a1, a2) {
-                        Some(Ordering::Greater | Ordering::Equal) => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultCallTermLessThanOrEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    match compare_term_test!(self.machine_st, a1, a2) {
-                        Some(Ordering::Less | Ordering::Equal) => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultExecuteTermLessThanOrEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    match compare_term_test!(self.machine_st, a1, a2) {
-                        Some(Ordering::Less | Ordering::Equal) => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultCallCopyTerm => {
-                    self.machine_st.copy_term(AttrVarPolicy::DeepCopy);
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::DefaultExecuteCopyTerm => {
-                    self.machine_st.copy_term(AttrVarPolicy::DeepCopy);
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::DefaultCallTermEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if self.machine_st.eq_test(a1, a2) {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::DefaultExecuteTermEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if self.machine_st.eq_test(a1, a2) {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::DefaultCallGround => {
-                    if self.machine_st.ground_test() {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::DefaultExecuteGround => {
-                    if self.machine_st.ground_test() {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::DefaultCallFunctor => {
-                    try_or_throw!(self.machine_st, self.machine_st.try_functor());
-
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::DefaultExecuteFunctor => {
-                    try_or_throw!(self.machine_st, self.machine_st.try_functor());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::DefaultCallTermNotEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Equal) = compare_term_test!(self.machine_st, a1, a2) {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::DefaultExecuteTermNotEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Equal) = compare_term_test!(self.machine_st, a1, a2) {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::DefaultCallSort => {
-                    try_or_throw!(self.machine_st, self.machine_st.sort());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::DefaultExecuteSort => {
-                    try_or_throw!(self.machine_st, self.machine_st.sort());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::DefaultCallKeySort => {
-                    try_or_throw!(self.machine_st, self.machine_st.keysort(VarComparison::Distinct));
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::DefaultExecuteKeySort => {
-                    try_or_throw!(self.machine_st, self.machine_st.keysort(VarComparison::Distinct));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::DefaultCallIs(r, at) => {
-                    try_or_throw!(self.machine_st, self.machine_st.is(r, at));
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::DefaultExecuteIs(r, at) => {
-                    try_or_throw!(self.machine_st, self.machine_st.is(r, at));
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                Instruction::DefaultCallGetNumber(at) => {
-                    try_or_throw!(self.machine_st, self.machine_st.get_number(at));
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                Instruction::DefaultExecuteGetNumber(at) => {
-                    try_or_throw!(self.machine_st, self.machine_st.get_number(at));
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallAcyclicTerm => {
-                    let addr = self.machine_st.registers[1];
-
-                    if self.machine_st.is_cyclic_term(addr) {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteAcyclicTerm => {
-                    let addr = self.machine_st.registers[1];
-
-                    if self.machine_st.is_cyclic_term(addr) {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallArg => {
-                    try_or_throw!(self.machine_st, self.machine_st.try_arg());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteArg => {
-                    try_or_throw!(self.machine_st, self.machine_st.try_arg());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallCompare => {
-                    try_or_throw!(self.machine_st, self.machine_st.compare());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteCompare => {
-                    try_or_throw!(self.machine_st, self.machine_st.compare());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallTermGreaterThan => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Greater) = compare_term_test!(self.machine_st, a1, a2) {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    } else {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::ExecuteTermGreaterThan => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Greater) = compare_term_test!(self.machine_st, a1, a2) {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    } else {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::CallTermLessThan => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Less) = compare_term_test!(self.machine_st, a1, a2) {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    } else {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::ExecuteTermLessThan => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Less) = compare_term_test!(self.machine_st, a1, a2) {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    } else {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::CallTermGreaterThanOrEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    match compare_term_test!(self.machine_st, a1, a2) {
-                        Some(Ordering::Greater | Ordering::Equal) => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteTermGreaterThanOrEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    match compare_term_test!(self.machine_st, a1, a2) {
-                        Some(Ordering::Greater | Ordering::Equal) => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallTermLessThanOrEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    match compare_term_test!(self.machine_st, a1, a2) {
-                        Some(Ordering::Less | Ordering::Equal) => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteTermLessThanOrEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    match compare_term_test!(self.machine_st, a1, a2) {
-                        Some(Ordering::Less | Ordering::Equal) => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallCopyTerm => {
-                    self.machine_st.copy_term(AttrVarPolicy::DeepCopy);
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteCopyTerm => {
-                    self.machine_st.copy_term(AttrVarPolicy::DeepCopy);
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallTermEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if self.machine_st.eq_test(a1, a2) {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteTermEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if self.machine_st.eq_test(a1, a2) {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallGround => {
-                    if self.machine_st.ground_test() {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteGround => {
-                    if self.machine_st.ground_test() {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallFunctor => {
-                    try_or_throw!(self.machine_st, self.machine_st.try_functor());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteFunctor => {
-                    try_or_throw!(self.machine_st, self.machine_st.try_functor());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallTermNotEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Equal) = compare_term_test!(self.machine_st, a1, a2) {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteTermNotEqual => {
-                    let a1 = self.machine_st.registers[1];
-                    let a2 = self.machine_st.registers[2];
-
-                    if let Some(Ordering::Equal) = compare_term_test!(self.machine_st, a1, a2) {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallSort => {
-                    try_or_throw!(self.machine_st, self.machine_st.sort());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteSort => {
-                    try_or_throw!(self.machine_st, self.machine_st.sort());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallKeySort => {
-                    try_or_throw!(self.machine_st, self.machine_st.keysort(VarComparison::Distinct));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteKeySort => {
-                    try_or_throw!(self.machine_st, self.machine_st.keysort(VarComparison::Distinct));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallKeySortWithConstantVarOrdering => {
-                    try_or_throw!(self.machine_st, self.machine_st.keysort(VarComparison::Indistinct));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteKeySortWithConstantVarOrdering => {
-                    try_or_throw!(self.machine_st, self.machine_st.keysort(VarComparison::Indistinct));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallIs(r, at) => {
-                    try_or_throw!(self.machine_st, self.machine_st.is(r, at));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteIs(r, at) => {
-                    try_or_throw!(self.machine_st, self.machine_st.is(r, at));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                Instruction::CallGetNumber(at) => {
-                    try_or_throw!(self.machine_st, self.machine_st.get_number(at));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p += 1;
-                    }
-                }
-                Instruction::ExecuteGetNumber(at) => {
-                    try_or_throw!(self.machine_st, self.machine_st.get_number(at));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallN(arity) => {
-                    let pred = self.machine_st.registers[1];
-
-                    for i in 2..arity + 1 {
-                        self.machine_st.registers[i - 1] = self.machine_st.registers[i];
-                    }
-
-                    self.machine_st.registers[arity] = pred;
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.call_n(atom!("user"), arity)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-                    }
-                }
-                &Instruction::ExecuteN(arity) => {
-                    let pred = self.machine_st.registers[1];
-
-                    for i in 2..arity + 1 {
-                        self.machine_st.registers[i - 1] = self.machine_st.registers[i];
-                    }
-
-                    self.machine_st.registers[arity] = pred;
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.execute_n(atom!("user"), arity)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-                    }
-                }
-                &Instruction::DefaultCallN(arity) => {
-                    let pred = self.machine_st.registers[1];
-
-                    for i in 2..arity + 1 {
-                        self.machine_st.registers[i - 1] = self.machine_st.registers[i];
-                    }
-
-                    self.machine_st.registers[arity] = pred;
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.call_n(atom!("user"), arity)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::DefaultExecuteN(arity) => {
-                    let pred = self.machine_st.registers[1];
-
-                    for i in 2..arity + 1 {
-                        self.machine_st.registers[i - 1] = self.machine_st.registers[i];
-                    }
-
-                    self.machine_st.registers[arity] = pred;
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.execute_n(atom!("user"), arity)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::CallNumberLessThanOrEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Less | Ordering::Equal => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteNumberLessThanOrEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Less | Ordering::Equal => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallNumberEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Equal => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteNumberEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Equal => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallNumberNotEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Equal => {
-                            self.machine_st.backtrack();
-                        }
-                        _ => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p += 1;
-                        }
-                    }
-                }
-                &Instruction::ExecuteNumberNotEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Equal => {
-                            self.machine_st.backtrack();
-                        }
-                        _ => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                    }
-                }
-                &Instruction::CallNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Greater | Ordering::Equal => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Greater | Ordering::Equal => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallNumberGreaterThan(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Greater => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteNumberGreaterThan(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Greater => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallNumberLessThan(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Less => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteNumberLessThan(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Less => {
-                            try_or_throw!(
-                                self.machine_st,
-                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                            );
-
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultCallNumberLessThanOrEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Less | Ordering::Equal => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultExecuteNumberLessThanOrEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Less | Ordering::Equal => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultCallNumberNotEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Equal => {
-                            self.machine_st.backtrack();
-                        }
-                        _ => {
-                            self.machine_st.p += 1;
-                        }
-                    }
-                }
-                &Instruction::DefaultExecuteNumberNotEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Equal => {
-                            self.machine_st.backtrack();
-                        }
-                        _ => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                    }
-                }
-                &Instruction::DefaultCallNumberEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Equal => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultExecuteNumberEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Equal => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultCallNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Greater | Ordering::Equal => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultExecuteNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Greater | Ordering::Equal => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultCallNumberGreaterThan(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Greater => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultExecuteNumberGreaterThan(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Greater => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultCallNumberLessThan(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Less => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::DefaultExecuteNumberLessThan(ref at_1, ref at_2) => {
-                    let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
-                    let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
-
-                    match n1.cmp(&n2) {
-                        Ordering::Less => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                //
-                &Instruction::CallIsAtom(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    read_heap_cell!(d,
-                        (HeapCellValueTag::Atom, (_name, arity)) => {
-                            if arity == 0 {
-                                self.machine_st.p += 1;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        (HeapCellValueTag::Str, s) => {
-                            let arity = cell_as_atom_cell!(self.machine_st.heap[s])
-                                .get_arity();
-
-                            if arity == 0 {
-                                self.machine_st.p += 1;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        (HeapCellValueTag::Char) => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    );
-                }
-                &Instruction::ExecuteIsAtom(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    read_heap_cell!(d,
-                        (HeapCellValueTag::Atom, (_name, arity)) => {
-                            if arity == 0 {
-                                self.machine_st.p = self.machine_st.cp;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        (HeapCellValueTag::Str, s) => {
-                            let arity = cell_as_atom_cell!(self.machine_st.heap[s])
-                                .get_arity();
-
-                            if arity == 0 {
-                                self.machine_st.p = self.machine_st.cp;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        (HeapCellValueTag::Char) => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    );
-                }
-                &Instruction::CallIsAtomic(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    read_heap_cell!(d,
-                        (HeapCellValueTag::Char | HeapCellValueTag::Fixnum | HeapCellValueTag::F64 |
-                         HeapCellValueTag::Cons) => {
-                            self.machine_st.p += 1;
-                        }
-                        (HeapCellValueTag::Atom, (_name, arity)) => {
-                            if arity == 0 {
-                                self.machine_st.p += 1;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        (HeapCellValueTag::Str, s) => {
-                            let arity = cell_as_atom_cell!(self.machine_st.heap[s])
-                                .get_arity();
-
-                            if arity == 0 {
-                                self.machine_st.p += 1;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    );
-                }
-                &Instruction::ExecuteIsAtomic(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    read_heap_cell!(d,
-                        (HeapCellValueTag::Char | HeapCellValueTag::Fixnum | HeapCellValueTag::F64 |
-                         HeapCellValueTag::Cons) => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        (HeapCellValueTag::Atom, (_name, arity)) => {
-                            if arity == 0 {
-                                self.machine_st.p = self.machine_st.cp;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        (HeapCellValueTag::Str, s) => {
-                            let arity = cell_as_atom_cell!(self.machine_st.heap[s])
-                                .get_arity();
-
-                            if arity == 0 {
-                                self.machine_st.p = self.machine_st.cp;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    );
-                }
-                &Instruction::CallIsCompound(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    read_heap_cell!(d,
-                        (HeapCellValueTag::Lis |
-                         HeapCellValueTag::PStrLoc |
-                         HeapCellValueTag::CStr) => {
-                            self.machine_st.p += 1;
-                        }
-                        (HeapCellValueTag::Str, s) => {
-                            let arity = cell_as_atom_cell!(self.machine_st.heap[s])
-                                .get_arity();
-
-                            if arity > 0 {
-                                self.machine_st.p += 1;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        (HeapCellValueTag::Atom, (_name, arity)) => {
-                            if arity > 0 {
-                                self.machine_st.p += 1;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    );
-                }
-                &Instruction::ExecuteIsCompound(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    read_heap_cell!(d,
-                        (HeapCellValueTag::Lis |
-                         HeapCellValueTag::PStrLoc |
-                         HeapCellValueTag::CStr) => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        (HeapCellValueTag::Str, s) => {
-                            let arity = cell_as_atom_cell!(self.machine_st.heap[s])
-                                .get_arity();
-
-                            if arity > 0 {
-                                self.machine_st.p = self.machine_st.cp;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        (HeapCellValueTag::Atom, (_name, arity)) => {
-                            if arity > 0 {
-                                self.machine_st.p = self.machine_st.cp;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    );
-                }
-                &Instruction::CallIsInteger(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match Number::try_from(d) {
-                        Ok(Number::Fixnum(_) | Number::Integer(_)) => {
-                            self.machine_st.p += 1;
-                        }
-                        Ok(Number::Rational(n)) => {
-                            if n.denominator().is_one() {
-                                self.machine_st.p += 1;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteIsInteger(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match Number::try_from(d) {
-                        Ok(Number::Fixnum(_) | Number::Integer(_)) => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        Ok(Number::Rational(n)) => {
-                            if n.denominator().is_one() {
-                                self.machine_st.p = self.machine_st.cp;
-                            } else {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallIsNumber(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match Number::try_from(d) {
-                        Ok(_) => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteIsNumber(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match Number::try_from(d) {
-                        Ok(_) => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallIsRational(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    read_heap_cell!(d,
-                        (HeapCellValueTag::Cons, ptr) => {
-                            match_untyped_arena_ptr!(ptr,
-                                 (ArenaHeaderTag::Rational | ArenaHeaderTag::Integer, _r) => {
-                                     self.machine_st.p += 1;
-                                 }
-                                 _ => {
-                                     self.machine_st.backtrack();
-                                 }
-                            );
-                        }
-                        (HeapCellValueTag::Fixnum) => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    );
-                }
-                &Instruction::ExecuteIsRational(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    read_heap_cell!(d,
-                        (HeapCellValueTag::Cons, ptr) => {
-                            match_untyped_arena_ptr!(ptr,
-                                 (ArenaHeaderTag::Rational | ArenaHeaderTag::Integer, _r) => {
-                                     self.machine_st.p = self.machine_st.cp;
-                                 }
-                                 _ => {
-                                     self.machine_st.backtrack();
-                                 }
-                            );
-                        }
-                        (HeapCellValueTag::Fixnum) => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    );
-                }
-                &Instruction::CallIsFloat(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match Number::try_from(d) {
-                        Ok(Number::Float(_)) => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteIsFloat(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match Number::try_from(d) {
-                        Ok(Number::Float(_)) => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallIsNonVar(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match d.get_tag() {
-                        HeapCellValueTag::AttrVar |
-                        HeapCellValueTag::Var |
-                        HeapCellValueTag::StackVar => {
-                            self.machine_st.backtrack();
-                        }
-                        _ => {
-                            self.machine_st.p += 1;
-                        }
-                    }
-                }
-                &Instruction::ExecuteIsNonVar(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match d.get_tag() {
-                        HeapCellValueTag::AttrVar |
-                        HeapCellValueTag::Var |
-                        HeapCellValueTag::StackVar => {
-                            self.machine_st.backtrack();
-                        }
-                        _ => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                    }
-                }
-                &Instruction::CallIsVar(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match d.get_tag() {
-                        HeapCellValueTag::AttrVar |
-                        HeapCellValueTag::Var |
-                        HeapCellValueTag::StackVar => {
-                            self.machine_st.p += 1;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::ExecuteIsVar(r) => {
-                    let d = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
-
-                    match d.get_tag() {
-                        HeapCellValueTag::AttrVar |
-                        HeapCellValueTag::Var |
-                        HeapCellValueTag::StackVar => {
-                            self.machine_st.p = self.machine_st.cp;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                        }
-                    }
-                }
-                &Instruction::CallNamed(arity, name, ref idx) => {
-                    let idx = idx.get();
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.try_call(name, arity, idx)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-                    }
-                }
-                &Instruction::ExecuteNamed(arity, name, ref idx) => {
-                    let idx = idx.get();
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.try_execute(name, arity, idx)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        try_or_throw!(
-                            self.machine_st,
-                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                        );
-                    }
-                }
-                &Instruction::DefaultCallNamed(arity, name, ref idx) => {
-                    let idx = idx.get();
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.try_call(name, arity, idx)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::DefaultExecuteNamed(arity, name, ref idx) => {
-                    let idx = idx.get();
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.try_execute(name, arity, idx)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::Deallocate => {
-                    self.machine_st.deallocate()
-                }
-                &Instruction::JmpByCall(offset) => {
-                    self.machine_st.p += offset;
-                }
-                &Instruction::RevJmpBy(offset) => {
-                    self.machine_st.p -= offset;
-                }
-                &Instruction::Proceed => {
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::GetConstant(_, c, reg) => {
-                    let value = self.machine_st.deref(self.machine_st[reg]);
-                    self.machine_st.write_literal_to_var(value, c);
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::GetList(_, reg) => {
-                    let deref_v = self.machine_st.deref(self.machine_st[reg]);
-                    let store_v = self.machine_st.store(deref_v);
-
-                    read_heap_cell!(store_v,
-                        (HeapCellValueTag::PStrLoc, h) => {
-                            let (h, n) = pstr_loc_and_offset(&self.machine_st.heap, h);
-
-                            self.machine_st.s = HeapPtr::PStrChar(h, n.get_num() as usize);
-                            self.machine_st.s_offset = 0;
-                            self.machine_st.mode = MachineMode::Read;
-                        }
-                        (HeapCellValueTag::CStr) => {
-                            let h = self.machine_st.heap.len();
-                            self.machine_st.heap.push(store_v);
-
-                            self.machine_st.s = HeapPtr::PStrChar(h, 0);
-                            self.machine_st.s_offset = 0;
-                            self.machine_st.mode = MachineMode::Read;
-                        }
-                        (HeapCellValueTag::Str, s) => {
-                            let (name, arity) = cell_as_atom_cell!(self.machine_st.heap[s])
-                                .get_name_and_arity();
-
-                            if name == atom!(".") && arity == 2 {
-                                self.machine_st.s = HeapPtr::HeapCell(s+1);
-                                self.machine_st.s_offset = 0;
-                                self.machine_st.mode = MachineMode::Read;
-                            } else {
-                                self.machine_st.backtrack();
-                                continue;
-                            }
-                        }
-                        (HeapCellValueTag::Lis, l) => {
-                            self.machine_st.s = HeapPtr::HeapCell(l);
-                            self.machine_st.s_offset = 0;
-                            self.machine_st.mode = MachineMode::Read;
-                        }
-                        (HeapCellValueTag::AttrVar | HeapCellValueTag::Var | HeapCellValueTag::StackVar) => {
-                            let h = self.machine_st.heap.len();
-
-                            self.machine_st.heap.push(list_loc_as_cell!(h+1));
-                            self.machine_st.bind(store_v.as_var().unwrap(), heap_loc_as_cell!(h));
-
-                            self.machine_st.mode = MachineMode::Write;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                            continue;
-                        }
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::GetPartialString(_, string, reg, has_tail) => {
-                    let deref_v = self.machine_st.deref(self.machine_st[reg]);
-                    let store_v = self.machine_st.store(deref_v);
-
-                    read_heap_cell!(store_v,
-                        (HeapCellValueTag::Str |
-                         HeapCellValueTag::Lis |
-                         HeapCellValueTag::PStrLoc |
-                         HeapCellValueTag::CStr) => {
-                            self.machine_st.match_partial_string(store_v, string, has_tail);
-                        }
-                        (HeapCellValueTag::AttrVar |
-                         HeapCellValueTag::StackVar |
-                         HeapCellValueTag::Var) => {
-                            let target_cell = self.machine_st.push_str_to_heap(
-                                string.as_str(),
-                                has_tail,
-                            );
-
-                            self.machine_st.bind(
-                                store_v.as_var().unwrap(),
-                                target_cell,
-                            );
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                            continue;
-                        }
-                    );
-
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::GetStructure(_lvl, name, arity, reg) => {
-                    let deref_v = self.machine_st.deref(self.machine_st[reg]);
-                    let store_v = self.machine_st.store(deref_v);
-
-                    read_heap_cell!(store_v,
-                        (HeapCellValueTag::Str, a) => {
-                            read_heap_cell!(self.machine_st.heap[a],
-                                (HeapCellValueTag::Atom, (result_name, result_arity)) => {
-                                    if arity == result_arity && name == result_name {
-                                        self.machine_st.s = HeapPtr::HeapCell(a + 1);
-                                        self.machine_st.s_offset = 0;
-                                        self.machine_st.mode = MachineMode::Read;
-                                    } else {
-                                        self.machine_st.backtrack();
-                                        continue;
-                                    }
-                                }
-                                _ => {
-                                    unreachable!();
-                                }
-                            );
-                        }
-                        (HeapCellValueTag::AttrVar | HeapCellValueTag::Var | HeapCellValueTag::StackVar) => {
-                            let h = self.machine_st.heap.len();
-
-                            self.machine_st.heap.push(str_loc_as_cell!(h+1));
-                            self.machine_st.heap.push(atom_as_cell!(name, arity));
-
-                            self.machine_st.bind(store_v.as_var().unwrap(), heap_loc_as_cell!(h));
-                            self.machine_st.mode = MachineMode::Write;
-                        }
-                        _ => {
-                            self.machine_st.backtrack();
-                            continue;
-                        }
-                    );
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::GetVariable(norm, arg) => {
-                    self.machine_st[norm] = self.machine_st.registers[arg];
-                    self.machine_st.p += 1;
-                }
-                &Instruction::GetValue(norm, arg) => {
-                    let norm_addr = self.machine_st[norm];
-                    let reg_addr = self.machine_st.registers[arg];
-
-                    unify_fn!(&mut self.machine_st, norm_addr, reg_addr);
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                        continue;
-                    }
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::UnifyConstant(v) => {
-                    match self.machine_st.mode {
-                        MachineMode::Read => {
-                            let addr = self.machine_st.read_s();
-
-                            self.machine_st.write_literal_to_var(addr, v);
-
-                            if self.machine_st.fail {
-                                self.machine_st.backtrack();
-                                continue;
-                            } else {
-                                self.machine_st.s_offset += 1;
-                            }
-                        }
-                        MachineMode::Write => {
-                            self.machine_st.heap.push(v);
-                        }
-                    }
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::UnifyLocalValue(reg) => {
-                    match self.machine_st.mode {
-                        MachineMode::Read => {
-                            let reg_addr = self.machine_st[reg];
-                            let value = self.machine_st.read_s();
-
-                            unify_fn!(&mut self.machine_st, reg_addr, value);
-
-                            if self.machine_st.fail {
-                                self.machine_st.backtrack();
-                                continue;
-                            } else {
-                                self.machine_st.s_offset += 1;
-                            }
-                        }
-                        MachineMode::Write => {
-                            let value = self.machine_st.store(self.machine_st.deref(self.machine_st[reg]));
-                            let h = self.machine_st.heap.len();
-
-                            read_heap_cell!(value,
-                                (HeapCellValueTag::Var | HeapCellValueTag::AttrVar, hc) => {
-                                    let value = self.machine_st.heap[hc];
-
-                                    self.machine_st.heap.push(value);
-                                    self.machine_st.s_offset += 1;
-                                }
-                                _ => {
-                                    self.machine_st.heap.push(heap_loc_as_cell!(h));
-                                    (self.machine_st.bind_fn)(
-                                        &mut self.machine_st,
-                                        Ref::heap_cell(h),
-                                        value,
-                                    );
-                                }
-                            );
-                        }
-                    }
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::UnifyVariable(reg) => {
-                    match self.machine_st.mode {
-                        MachineMode::Read => {
-                            self.machine_st[reg] = self.machine_st.read_s();
-                            self.machine_st.s_offset += 1;
-                        }
-                        MachineMode::Write => {
-                            let h = self.machine_st.heap.len();
-
-                            self.machine_st.heap.push(heap_loc_as_cell!(h));
-                            self.machine_st[reg] = heap_loc_as_cell!(h);
-                        }
-                    }
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::UnifyValue(reg) => {
-                    match self.machine_st.mode {
-                        MachineMode::Read => {
-                            let reg_addr = self.machine_st[reg];
-                            let value = self.machine_st.read_s();
-
-                            unify_fn!(&mut self.machine_st, reg_addr, value);
-
-                            if self.machine_st.fail {
-                                self.machine_st.backtrack();
-                                continue;
-                            } else {
-                                self.machine_st.s_offset += 1;
-                            }
-                        }
-                        MachineMode::Write => {
-                            let h = self.machine_st.heap.len();
-                            self.machine_st.heap.push(heap_loc_as_cell!(h));
-
-                            let addr = self.machine_st.store(self.machine_st[reg]);
-                            (self.machine_st.bind_fn)(&mut self.machine_st, Ref::heap_cell(h), addr);
-
-                            // the former code of this match arm was:
-
-                            // let addr = self.machine_st.store(self.machine_st[reg]);
-                            // self.machine_st.heap.push(HeapCellValue::Addr(addr));
-
-                            // the old code didn't perform the occurs
-                            // check when enabled and so it was changed to
-                            // the above, which is only slightly less
-                            // efficient when the occurs_check is disabled.
-                        }
-                    }
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::UnifyVoid(n) => {
-                    match self.machine_st.mode {
-                        MachineMode::Read => {
-                            self.machine_st.s_offset += n;
-                        }
-                        MachineMode::Write => {
-                            let h = self.machine_st.heap.len();
-
-                            for i in h..h + n {
-                                self.machine_st.heap.push(heap_loc_as_cell!(i));
-                            }
-                        }
-                    }
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::IndexingCode(ref indexing_lines) => {
-                    match &indexing_lines[self.machine_st.oip as usize] {
-                        IndexingLine::Indexing(_) => {
-                            self.execute_switch_on_term();
-
-                            if self.machine_st.fail {
-                                self.machine_st.backtrack();
-                            }
-                        }
-                        IndexingLine::IndexedChoice(ref indexed_choice) => {
-                            match &indexed_choice[self.machine_st.iip as usize] {
-                                &IndexedChoiceInstruction::Try(offset) => {
-                                    self.indexed_try(offset);
-                                }
-                                &IndexedChoiceInstruction::Retry(l) => {
-                                    self.retry(l);
-
-                                    try_or_throw!(
-                                        self.machine_st,
-                                        (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                                    );
-                                }
-                                &IndexedChoiceInstruction::DefaultRetry(l) => {
-                                    self.retry(l);
-                                }
-                                &IndexedChoiceInstruction::Trust(l) => {
-                                    self.trust(l);
-
-                                    try_or_throw!(
-                                        self.machine_st,
-                                        (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                                    );
-                                }
-                                &IndexedChoiceInstruction::DefaultTrust(l) => {
-                                    self.trust(l);
-                                }
-                            }
-                        }
-                        IndexingLine::DynamicIndexedChoice(_) => {
-                            let p = self.machine_st.p;
-
-                            match self.find_living_dynamic(self.machine_st.oip, self.machine_st.iip) {
-                                Some((offset, oi, ii, is_next_clause)) => {
-                                    self.machine_st.p = p;
-                                    self.machine_st.oip = oi;
-                                    self.machine_st.iip = ii;
-
-                                    match self.machine_st.dynamic_mode {
-                                        FirstOrNext::First if !is_next_clause => {
-                                            self.machine_st.p = p + offset;
-                                        }
-                                        FirstOrNext::First => {
-                                            // there's a leading DynamicElse that sets self.machine_st.cc.
-                                            // self.machine_st.cc = self.machine_st.global_clock;
-
-                                            // see that there is a following dynamic_else
-                                            // clause so we avoid generating a choice
-                                            // point in case there isn't.
-                                            match self.find_living_dynamic(oi, ii + 1) {
+                                    FirstOrNext::Next => {
+                                        let n = self
+                                            .machine_st
+                                            .stack
+                                            .index_or_frame(self.machine_st.b)
+                                            .prelude
+                                            .num_cells;
+
+                                        self.machine_st.cc = cell_as_fixnum!(
+                                            self.machine_st.stack
+                                                [stack_loc!(OrFrame, self.machine_st.b, n - 1)]
+                                        )
+                                        .get_num()
+                                            as usize;
+
+                                        if next_i > 0 {
+                                            match self.find_living_dynamic_else(p + next_i) {
                                                 Some(_) => {
-                                                    self.machine_st.registers[self.machine_st.num_of_args + 1] =
-                                                        fixnum_as_cell!(Fixnum::build_with(self.machine_st.cc as i64));
-
-                                                    self.machine_st.num_of_args += 1;
-                                                    self.indexed_try(offset);
-                                                    self.machine_st.num_of_args -= 1;
+                                                    self.retry_me_else(next_i);
                                                 }
                                                 None => {
-                                                    self.machine_st.p = p + offset;
-                                                    self.machine_st.oip = 0;
-                                                    self.machine_st.iip = 0;
+                                                    self.trust_me();
                                                 }
                                             }
+                                        } else {
+                                            self.trust_me();
                                         }
-                                        FirstOrNext::Next => {
-                                            let b = self.machine_st.b;
-                                            let n = self.machine_st
-                                                .stack
-                                                .index_or_frame(b)
-                                                .prelude
-                                                .num_cells;
 
-                                            self.machine_st.cc = cell_as_fixnum!(
-                                                self.machine_st.stack[stack_loc!(OrFrame, b, n-1)]
-                                            ).get_num() as usize;
+                                        try_or_throw!(
+                                            self.machine_st,
+                                            (self.machine_st.increment_call_count_fn)(
+                                                &mut self.machine_st
+                                            )
+                                        );
+                                    }
+                                }
+                            }
+                            None => {
+                                self.machine_st.fail = true;
+                            }
+                        }
 
-                                            if is_next_clause {
-                                                match self.find_living_dynamic(self.machine_st.oip, self.machine_st.iip + 1) {
-                                                    // if we're executing the last instruction
-                                                    // of the internal block pointed to by
-                                                    // self.machine_st.iip, we want trust, not retry.
-                                                    // this is true iff ii + 1 < len.
-                                                    Some(_) => {
-                                                        self.retry(offset);
+                        self.machine_st.dynamic_mode = FirstOrNext::Next;
 
-                                                        try_or_throw!(
-                                                            self.machine_st,
-                                                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                                                        );
-                                                    }
-                                                    _ => {
-                                                        self.trust(offset);
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::DynamicInternalElse(..) => {
+                        let p = self.machine_st.p;
 
-                                                        try_or_throw!(
-                                                            self.machine_st,
-                                                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
-                                                        );
-                                                    }
-                                                }
-                                            } else {
-                                                self.trust(offset);
+                        match self.find_living_dynamic_else(p) {
+                            Some((p, next_i)) => {
+                                self.machine_st.p = p;
+                                self.machine_st.oip = 0;
+                                self.machine_st.iip = 0;
 
-                                                try_or_throw!(
-                                                    self.machine_st,
-                                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                match self.machine_st.dynamic_mode {
+                                    FirstOrNext::First if next_i == 0 => {
+                                        self.machine_st.p += 1;
+                                    }
+                                    FirstOrNext::First => {
+                                        match self.find_living_dynamic_else(p + next_i) {
+                                            Some(_) => {
+                                                self.machine_st.registers
+                                                    [self.machine_st.num_of_args + 1] = fixnum_as_cell!(
+                                                    Fixnum::build_with(self.machine_st.cc as i64)
                                                 );
+
+                                                self.machine_st.num_of_args += 1;
+                                                self.try_me_else(next_i);
+                                                self.machine_st.num_of_args -= 1;
+                                            }
+                                            None => {
+                                                self.machine_st.p += 1;
                                             }
                                         }
                                     }
-                                }
-                                None => {
-                                    self.machine_st.fail = true;
+                                    FirstOrNext::Next => {
+                                        let n = self
+                                            .machine_st
+                                            .stack
+                                            .index_or_frame(self.machine_st.b)
+                                            .prelude
+                                            .num_cells;
+
+                                        self.machine_st.cc = cell_as_fixnum!(
+                                            self.machine_st.stack
+                                                [stack_loc!(OrFrame, self.machine_st.b, n - 1)]
+                                        )
+                                        .get_num()
+                                            as usize;
+
+                                        if next_i > 0 {
+                                            match self.find_living_dynamic_else(p + next_i) {
+                                                Some(_) => {
+                                                    self.retry_me_else(next_i);
+                                                }
+                                                None => {
+                                                    self.trust_me();
+                                                }
+                                            }
+                                        } else {
+                                            self.trust_me();
+                                        }
+
+                                        try_or_throw!(
+                                            self.machine_st,
+                                            (self.machine_st.increment_call_count_fn)(
+                                                &mut self.machine_st
+                                            )
+                                        );
+                                    }
                                 }
                             }
+                            None => {
+                                self.machine_st.fail = true;
+                            }
+                        }
 
-                            self.machine_st.dynamic_mode = FirstOrNext::Next;
+                        self.machine_st.dynamic_mode = FirstOrNext::Next;
 
-                            if self.machine_st.fail {
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::TryMeElse(offset) => {
+                        self.try_me_else(offset);
+                    }
+                    &Instruction::DefaultRetryMeElse(offset) => {
+                        self.retry_me_else(offset);
+                    }
+                    &Instruction::DefaultTrustMe(_) => {
+                        self.trust_me();
+                    }
+                    &Instruction::RetryMeElse(offset) => {
+                        self.retry_me_else(offset);
+
+                        try_or_throw!(
+                            self.machine_st,
+                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                        );
+                    }
+                    &Instruction::TrustMe(_) => {
+                        self.trust_me();
+
+                        try_or_throw!(
+                            self.machine_st,
+                            (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                        );
+                    }
+                    &Instruction::NeckCut => {
+                        self.machine_st.neck_cut();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::GetLevel(r) => {
+                        let b0 = self.machine_st.b0;
+
+                        self.machine_st[r] = fixnum_as_cell!(Fixnum::as_cutpoint(b0 as i64));
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::GetPrevLevel(r) => {
+                        let prev_b = self
+                            .machine_st
+                            .stack
+                            .index_or_frame(self.machine_st.b)
+                            .prelude
+                            .b;
+
+                        self.machine_st[r] = fixnum_as_cell!(Fixnum::as_cutpoint(prev_b as i64));
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::GetCutPoint(r) => {
+                        self.machine_st[r] =
+                            fixnum_as_cell!(Fixnum::as_cutpoint(self.machine_st.b as i64));
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Cut(r) => {
+                        let value = self.machine_st[r];
+                        self.machine_st.cut_body(value);
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                            continue;
+                        }
+
+                        if (self.machine_st.run_cleaners_fn)(self) {
+                            continue;
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::Allocate(num_cells) => {
+                        self.machine_st.allocate(num_cells);
+                    }
+                    &Instruction::DefaultCallAcyclicTerm => {
+                        let addr = self.machine_st.registers[1];
+
+                        if self.machine_st.is_cyclic_term(addr) {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::DefaultExecuteAcyclicTerm => {
+                        let addr = self.machine_st.registers[1];
+
+                        if self.machine_st.is_cyclic_term(addr) {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::DefaultCallArg => {
+                        try_or_throw!(self.machine_st, self.machine_st.try_arg());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::DefaultExecuteArg => {
+                        try_or_throw!(self.machine_st, self.machine_st.try_arg());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::DefaultCallCompare => {
+                        try_or_throw!(self.machine_st, self.machine_st.compare());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::DefaultExecuteCompare => {
+                        try_or_throw!(self.machine_st, self.machine_st.compare());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::DefaultCallTermGreaterThan => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Greater) = compare_term_test!(self.machine_st, a1, a2)
+                        {
+                            self.machine_st.p += 1;
+                        } else {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::DefaultExecuteTermGreaterThan => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Greater) = compare_term_test!(self.machine_st, a1, a2)
+                        {
+                            self.machine_st.p = self.machine_st.cp;
+                        } else {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::DefaultCallTermLessThan => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Less) = compare_term_test!(self.machine_st, a1, a2) {
+                            self.machine_st.p += 1;
+                        } else {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::DefaultExecuteTermLessThan => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Less) = compare_term_test!(self.machine_st, a1, a2) {
+                            self.machine_st.p = self.machine_st.cp;
+                        } else {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::DefaultCallTermGreaterThanOrEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        match compare_term_test!(self.machine_st, a1, a2) {
+                            Some(Ordering::Greater | Ordering::Equal) => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
                                 self.machine_st.backtrack();
                             }
                         }
                     }
-                }
-                &Instruction::PutConstant(_, c, reg) => {
-                    self.machine_st[reg] = c;
-                    self.machine_st.p += 1;
-                }
-                &Instruction::PutList(_, reg) => {
-                    self.machine_st[reg] = list_loc_as_cell!(self.machine_st.heap.len());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::PutPartialString(_, string, reg, has_tail) => {
-                    let pstr_addr = if has_tail {
-                        if string != atom!("") {
-                            let h = self.machine_st.heap.len();
-                            self.machine_st.heap.push(string_as_pstr_cell!(string));
+                    &Instruction::DefaultExecuteTermGreaterThanOrEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
 
-                            // the tail will be pushed by the next
-                            // instruction, so don't push one here.
-
-                            pstr_loc_as_cell!(h)
-                        } else {
-                            empty_list_as_cell!()
+                        match compare_term_test!(self.machine_st, a1, a2) {
+                            Some(Ordering::Greater | Ordering::Equal) => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
                         }
-                    } else {
-                        string_as_cstr_cell!(string)
-                    };
-
-                    self.machine_st[reg] = pstr_addr;
-                    self.machine_st.p += 1;
-                }
-                &Instruction::PutStructure(name, arity, reg) => {
-                    let h = self.machine_st.heap.len();
-
-                    self.machine_st.heap.push(atom_as_cell!(name, arity));
-                    self.machine_st[reg] = str_loc_as_cell!(h);
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::PutUnsafeValue(perm_slot, arg) => {
-                    let s = stack_loc!(AndFrame, self.machine_st.e, perm_slot);
-                    let addr = self.machine_st.store(self.machine_st.deref(stack_loc_as_cell!(s)));
-
-                    if addr.is_protected(self.machine_st.e) {
-                        self.machine_st.registers[arg] = addr;
-                    } else {
-                        let h = self.machine_st.heap.len();
-
-                        self.machine_st.heap.push(heap_loc_as_cell!(h));
-                        (self.machine_st.bind_fn)(&mut self.machine_st, Ref::heap_cell(h), addr);
-
-                        self.machine_st.registers[arg] = heap_loc_as_cell!(h);
                     }
+                    &Instruction::DefaultCallTermLessThanOrEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
 
-                    self.machine_st.p += 1;
-                }
-                &Instruction::PutValue(norm, arg) => {
-                    self.machine_st.registers[arg] = self.machine_st[norm];
-                    self.machine_st.p += 1;
-                }
-                &Instruction::PutVariable(norm, arg) => {
-                    match norm {
-                        RegType::Perm(n) => {
-                            self.machine_st[norm] = stack_loc_as_cell!(AndFrame, self.machine_st.e, n);
-                            self.machine_st.registers[arg] = self.machine_st[norm];
+                        match compare_term_test!(self.machine_st, a1, a2) {
+                            Some(Ordering::Less | Ordering::Equal) => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
                         }
-                        RegType::Temp(_) => {
-                            let h = self.machine_st.heap.len();
-                            self.machine_st.heap.push(heap_loc_as_cell!(h));
+                    }
+                    &Instruction::DefaultExecuteTermLessThanOrEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
 
-                            self.machine_st[norm] = heap_loc_as_cell!(h);
-                            self.machine_st.registers[arg] = heap_loc_as_cell!(h);
+                        match compare_term_test!(self.machine_st, a1, a2) {
+                            Some(Ordering::Less | Ordering::Equal) => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
                         }
-                    };
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::SetConstant(c) => {
-                    self.machine_st.heap.push(c);
-                    self.machine_st.p += 1;
-                }
-                &Instruction::SetLocalValue(reg) => {
-                    let addr = self.machine_st.deref(self.machine_st[reg]);
-                    let stored_v = self.machine_st.store(addr);
-
-                    if stored_v.is_stack_var() {
-                        let h = self.machine_st.heap.len();
-                        self.machine_st.heap.push(heap_loc_as_cell!(h));
-                        (self.machine_st.bind_fn)(&mut self.machine_st, Ref::heap_cell(h), stored_v);
-                    } else {
-                        self.machine_st.heap.push(stored_v);
                     }
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::SetVariable(reg) => {
-                    let h = self.machine_st.heap.len();
-
-                    self.machine_st.heap.push(heap_loc_as_cell!(h));
-                    self.machine_st[reg] = heap_loc_as_cell!(h);
-
-                    self.machine_st.p += 1;
-                }
-                &Instruction::SetValue(reg) => {
-                    let heap_val = self.machine_st.store(self.machine_st[reg]);
-                    self.machine_st.heap.push(heap_val);
-                    self.machine_st.p += 1;
-                }
-                &Instruction::SetVoid(n) => {
-                    let h = self.machine_st.heap.len();
-
-                    for i in h..h + n {
-                        self.machine_st.heap.push(heap_loc_as_cell!(i));
-                    }
-
-                    self.machine_st.p += 1;
-                }
-                //
-                &Instruction::CallAtomChars => {
-                    self.atom_chars();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteAtomChars => {
-                    self.atom_chars();
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallAtomCodes => {
-                    try_or_throw!(self.machine_st, self.atom_codes());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p += 1;
-                    }
-                }
-                &Instruction::ExecuteAtomCodes => {
-                    try_or_throw!(self.machine_st, self.atom_codes());
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    } else {
-                        self.machine_st.p = self.machine_st.cp;
-                    }
-                }
-                &Instruction::CallAtomLength => {
-                    self.atom_length();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteAtomLength => {
-                    self.atom_length();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallBindFromRegister => {
-                    self.bind_from_register();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteBindFromRegister => {
-                    self.bind_from_register();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallContinuation => {
-                    try_or_throw!(self.machine_st, self.call_continuation(false));
-                }
-                &Instruction::ExecuteContinuation => {
-                    try_or_throw!(self.machine_st, self.call_continuation(true));
-                }
-                &Instruction::CallCharCode => {
-                    try_or_throw!(self.machine_st, self.char_code());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCharCode => {
-                    try_or_throw!(self.machine_st, self.char_code());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCharType => {
-                    self.char_type();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCharType => {
-                    self.char_type();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCharsToNumber => {
-                    try_or_throw!(self.machine_st, self.chars_to_number());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCharsToNumber => {
-                    try_or_throw!(self.machine_st, self.chars_to_number());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCodesToNumber => {
-                    try_or_throw!(self.machine_st, self.codes_to_number());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCodesToNumber => {
-                    try_or_throw!(self.machine_st, self.codes_to_number());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCopyTermWithoutAttrVars => {
-                    self.copy_term_without_attr_vars();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCopyTermWithoutAttrVars => {
-                    self.copy_term_without_attr_vars();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCheckCutPoint => {
-                    self.check_cut_point();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCheckCutPoint => {
-                    self.check_cut_point();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallClose => {
-                    try_or_throw!(self.machine_st, self.close());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteClose => {
-                    try_or_throw!(self.machine_st, self.close());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallCopyToLiftedHeap => {
-                    self.copy_to_lifted_heap();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteCopyToLiftedHeap => {
-                    self.copy_to_lifted_heap();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallCreatePartialString => {
-                    self.create_partial_string();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCreatePartialString => {
-                    self.create_partial_string();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCurrentHostname => {
-                    self.current_hostname();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCurrentHostname => {
-                    self.current_hostname();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCurrentInput => {
-                    try_or_throw!(self.machine_st, self.current_input());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCurrentInput => {
-                    try_or_throw!(self.machine_st, self.current_input());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCurrentOutput => {
-                    try_or_throw!(self.machine_st, self.current_output());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCurrentOutput => {
-                    try_or_throw!(self.machine_st, self.current_output());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDirectoryFiles => {
-                    try_or_throw!(self.machine_st, self.directory_files());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDirectoryFiles => {
-                    try_or_throw!(self.machine_st, self.directory_files());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallFileSize => {
-                    self.file_size();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteFileSize => {
-                    self.file_size();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallFileExists => {
-                    self.file_exists();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteFileExists => {
-                    self.file_exists();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDirectoryExists => {
-                    self.directory_exists();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDirectoryExists => {
-                    self.directory_exists();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDirectorySeparator => {
-                    self.directory_separator();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDirectorySeparator => {
-                    self.directory_separator();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallMakeDirectory => {
-                    self.make_directory();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteMakeDirectory => {
-                    self.make_directory();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallMakeDirectoryPath => {
-                    self.make_directory_path();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteMakeDirectoryPath => {
-                    self.make_directory_path();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDeleteFile => {
-                    self.delete_file();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDeleteFile => {
-                    self.delete_file();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallRenameFile => {
-                    self.rename_file();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteRenameFile => {
-                    self.rename_file();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-		&Instruction::CallFileCopy => {
-		    self.file_copy();
-		    step_or_fail!(self, self.machine_st.p += 1);
-		}
-		&Instruction::ExecuteFileCopy => {
-		    self.file_copy();
-		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-		}
-                &Instruction::CallWorkingDirectory => {
-                    try_or_throw!(self.machine_st, self.working_directory());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteWorkingDirectory => {
-                    try_or_throw!(self.machine_st, self.working_directory());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDeleteDirectory => {
-                    self.delete_directory();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDeleteDirectory => {
-                    self.delete_directory();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPathCanonical => {
-                    try_or_throw!(self.machine_st, self.path_canonical());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePathCanonical => {
-                    try_or_throw!(self.machine_st, self.path_canonical());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallFileTime => {
-                    self.file_time();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteFileTime => {
-                    self.file_time();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDynamicModuleResolution(arity) => {
-                    let (module_name, key) = try_or_throw!(
-                        self.machine_st,
-                        self.dynamic_module_resolution(arity - 2)
-                    );
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.call_clause(module_name, key)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::ExecuteDynamicModuleResolution(arity) => {
-                    let (module_name, key) = try_or_throw!(
-                        self.machine_st,
-                        self.dynamic_module_resolution(arity - 2)
-                    );
-
-                    try_or_throw!(
-                        self.machine_st,
-                        self.execute_clause(module_name, key)
-                    );
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::CallFetchGlobalVar => {
-                    self.fetch_global_var();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteFetchGlobalVar => {
-                    self.fetch_global_var();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallFirstStream => {
-                    self.first_stream();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteFirstStream => {
-                    self.first_stream();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallFlushOutput => {
-                    try_or_throw!(self.machine_st, self.flush_output());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteFlushOutput => {
-                    try_or_throw!(self.machine_st, self.flush_output());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallGetByte => {
-                    try_or_throw!(self.machine_st, self.get_byte());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetByte => {
-                    try_or_throw!(self.machine_st, self.get_byte());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetChar => {
-                    try_or_throw!(self.machine_st, self.get_char());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetChar => {
-                    try_or_throw!(self.machine_st, self.get_char());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetNChars => {
-                    try_or_throw!(self.machine_st, self.get_n_chars());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetNChars => {
-                    try_or_throw!(self.machine_st, self.get_n_chars());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetCode => {
-                    try_or_throw!(self.machine_st, self.get_code());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetCode => {
-                    try_or_throw!(self.machine_st, self.get_code());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetSingleChar => {
-                    try_or_throw!(self.machine_st, self.get_single_char());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetSingleChar => {
-                    try_or_throw!(self.machine_st, self.get_single_char());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallTruncateIfNoLiftedHeapGrowthDiff => {
-                    self.truncate_if_no_lifted_heap_growth_diff();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteTruncateIfNoLiftedHeapGrowthDiff => {
-                    self.truncate_if_no_lifted_heap_growth_diff();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallTruncateIfNoLiftedHeapGrowth => {
-                    self.truncate_if_no_lifted_heap_growth();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteTruncateIfNoLiftedHeapGrowth => {
-                    self.truncate_if_no_lifted_heap_growth();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetAttributedVariableList => {
-                    self.get_attributed_variable_list();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetAttributedVariableList => {
-                    self.get_attributed_variable_list();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetAttrVarQueueDelimiter => {
-                    self.get_attr_var_queue_delimiter();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetAttrVarQueueDelimiter => {
-                    self.get_attr_var_queue_delimiter();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetAttrVarQueueBeyond => {
-                    self.get_attr_var_queue_beyond();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetAttrVarQueueBeyond => {
-                    self.get_attr_var_queue_beyond();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetBValue => {
-                    self.get_b_value();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetBValue => {
-                    self.get_b_value();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetContinuationChunk => {
-                    self.get_continuation_chunk();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetContinuationChunk => {
-                    self.get_continuation_chunk();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLookupDBRef => {
-                    self.lookup_db_ref();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLookupDBRef => {
-                    self.lookup_db_ref();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetNextOpDBRef => {
-                    self.get_next_op_db_ref();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetNextOpDBRef => {
-                    self.get_next_op_db_ref();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallIsPartialString => {
-                    self.is_partial_string();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteIsPartialString => {
-                    self.is_partial_string();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallHalt | &Instruction::ExecuteHalt => {
-                    return self.halt();
-                }
-                &Instruction::CallGetLiftedHeapFromOffset => {
-                    self.get_lifted_heap_from_offset();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetLiftedHeapFromOffset => {
-                    self.get_lifted_heap_from_offset();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetLiftedHeapFromOffsetDiff => {
-                    self.get_lifted_heap_from_offset_diff();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetLiftedHeapFromOffsetDiff => {
-                    self.get_lifted_heap_from_offset_diff();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetSCCCleaner => {
-                    self.get_scc_cleaner();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetSCCCleaner => {
-                    self.get_scc_cleaner();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallHeadIsDynamic => {
-                    self.head_is_dynamic();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteHeadIsDynamic => {
-                    self.head_is_dynamic();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallInstallSCCCleaner => {
-                    self.install_scc_cleaner();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteInstallSCCCleaner => {
-                    self.install_scc_cleaner();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallInstallInferenceCounter => {
-                    try_or_throw!(self.machine_st, self.install_inference_counter());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteInstallInferenceCounter => {
-                    try_or_throw!(self.machine_st, self.install_inference_counter());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLiftedHeapLength => {
-                    self.lifted_heap_length();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLiftedHeapLength => {
-                    self.lifted_heap_length();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLoadLibraryAsStream => {
-                    try_or_throw!(self.machine_st, self.load_library_as_stream());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLoadLibraryAsStream => {
-                    try_or_throw!(self.machine_st, self.load_library_as_stream());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallModuleExists => {
-                    self.module_exists();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteModuleExists => {
-                    self.module_exists();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallNextEP => {
-                    self.next_ep();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteNextEP => {
-                    self.next_ep();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallNoSuchPredicate => {
-                    try_or_throw!(self.machine_st, self.no_such_predicate());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteNoSuchPredicate => {
-                    try_or_throw!(self.machine_st, self.no_such_predicate());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallNumberToChars => {
-                    self.number_to_chars();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteNumberToChars => {
-                    self.number_to_chars();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallNumberToCodes => {
-                    self.number_to_codes();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteNumberToCodes => {
-                    self.number_to_codes();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallOpDeclaration => {
-                    try_or_throw!(self.machine_st, self.op_declaration());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteOpDeclaration => {
-                    try_or_throw!(self.machine_st, self.op_declaration());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallOpen => {
-                    try_or_throw!(self.machine_st, self.open());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteOpen => {
-                    try_or_throw!(self.machine_st, self.open());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSetStreamOptions => {
-                    try_or_throw!(self.machine_st, self.set_stream_options());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSetStreamOptions => {
-                    try_or_throw!(self.machine_st, self.set_stream_options());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallNextStream => {
-                    self.next_stream();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteNextStream => {
-                    self.next_stream();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPartialStringTail => {
-                    self.partial_string_tail();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePartialStringTail => {
-                    self.partial_string_tail();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPeekByte => {
-                    try_or_throw!(self.machine_st, self.peek_byte());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePeekByte => {
-                    try_or_throw!(self.machine_st, self.peek_byte());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPeekChar => {
-                    try_or_throw!(self.machine_st, self.peek_char());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePeekChar => {
-                    try_or_throw!(self.machine_st, self.peek_char());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPeekCode => {
-                    try_or_throw!(self.machine_st, self.peek_code());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePeekCode => {
-                    try_or_throw!(self.machine_st, self.peek_code());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPointsToContinuationResetMarker => {
-                    self.points_to_continuation_reset_marker();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePointsToContinuationResetMarker => {
-                    self.points_to_continuation_reset_marker();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPutByte => {
-                    try_or_throw!(self.machine_st, self.put_byte());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecutePutByte => {
-                    try_or_throw!(self.machine_st, self.put_byte());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallPutChar => {
-                    try_or_throw!(self.machine_st, self.put_char());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecutePutChar => {
-                    try_or_throw!(self.machine_st, self.put_char());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallPutChars => {
-                    try_or_throw!(self.machine_st, self.put_chars());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePutChars => {
-                    try_or_throw!(self.machine_st, self.put_chars());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPutCode => {
-                    try_or_throw!(self.machine_st, self.put_code());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecutePutCode => {
-                    try_or_throw!(self.machine_st, self.put_code());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallReadQueryTerm => {
-                    try_or_throw!(self.machine_st, self.read_query_term());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteReadQueryTerm => {
-                    try_or_throw!(self.machine_st, self.read_query_term());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallReadTerm => {
-                    try_or_throw!(self.machine_st, self.read_term());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteReadTerm => {
-                    try_or_throw!(self.machine_st, self.read_term());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallRedoAttrVarBinding => {
-                    self.redo_attr_var_binding();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteRedoAttrVarBinding => {
-                    self.redo_attr_var_binding();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallRemoveCallPolicyCheck => {
-                    self.remove_call_policy_check();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteRemoveCallPolicyCheck => {
-                    self.remove_call_policy_check();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallRemoveInferenceCounter => {
-                    self.remove_inference_counter();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteRemoveInferenceCounter => {
-                    self.remove_inference_counter();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallResetContinuationMarker => {
-                    self.reset_continuation_marker();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteResetContinuationMarker => {
-                    self.reset_continuation_marker();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallRestoreCutPolicy => {
-                    self.restore_cut_policy();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteRestoreCutPolicy => {
-                    self.restore_cut_policy();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallSetCutPoint(r) => {
-                    if !self.set_cut_point(r) {
+                    &Instruction::DefaultCallCopyTerm => {
+                        self.machine_st.copy_term(AttrVarPolicy::DeepCopy);
                         step_or_fail!(self, self.machine_st.p += 1);
                     }
-                }
-                &Instruction::ExecuteSetCutPoint(r) => {
-                    let cp = self.machine_st.cp;
+                    &Instruction::DefaultExecuteCopyTerm => {
+                        self.machine_st.copy_term(AttrVarPolicy::DeepCopy);
 
-                    if !self.set_cut_point(r) {
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::DefaultCallTermEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if self.machine_st.eq_test(a1, a2) {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::DefaultExecuteTermEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if self.machine_st.eq_test(a1, a2) {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::DefaultCallGround => {
+                        if self.machine_st.ground_test() {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::DefaultExecuteGround => {
+                        if self.machine_st.ground_test() {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::DefaultCallFunctor => {
+                        try_or_throw!(self.machine_st, self.machine_st.try_functor());
+
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::DefaultExecuteFunctor => {
+                        try_or_throw!(self.machine_st, self.machine_st.try_functor());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::DefaultCallTermNotEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Equal) = compare_term_test!(self.machine_st, a1, a2) {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::DefaultExecuteTermNotEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Equal) = compare_term_test!(self.machine_st, a1, a2) {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::DefaultCallSort => {
+                        try_or_throw!(self.machine_st, self.machine_st.sort());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::DefaultExecuteSort => {
+                        try_or_throw!(self.machine_st, self.machine_st.sort());
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                    } else {
-                        // run_cleaners in set_cut_point calls call_by_index.
-                        // replace the effect of call_by_index with that
-                        // of execute_by_index here.
+                    }
+                    &Instruction::DefaultCallKeySort => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.machine_st.keysort(VarComparison::Distinct)
+                        );
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::DefaultExecuteKeySort => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.machine_st.keysort(VarComparison::Distinct)
+                        );
 
-                        self.machine_st.cp = cp;
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
                     }
-                }
-                &Instruction::CallSetInput => {
-                    try_or_throw!(self.machine_st, self.set_input());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSetInput => {
-                    try_or_throw!(self.machine_st, self.set_input());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallSetOutput => {
-                    try_or_throw!(self.machine_st, self.set_output());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSetOutput => {
-                    try_or_throw!(self.machine_st, self.set_output());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallStoreBacktrackableGlobalVar => {
-                    self.store_backtrackable_global_var();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteStoreBacktrackableGlobalVar => {
-                    self.store_backtrackable_global_var();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallStoreGlobalVar => {
-                    self.store_global_var();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteStoreGlobalVar => {
-                    self.store_global_var();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallStreamProperty => {
-                    try_or_throw!(self.machine_st, self.stream_property());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteStreamProperty => {
-                    try_or_throw!(self.machine_st, self.stream_property());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSetStreamPosition => {
-                    try_or_throw!(self.machine_st, self.set_stream_position());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteSetStreamPosition => {
-                    try_or_throw!(self.machine_st, self.set_stream_position());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallInferenceLevel => {
-                    self.inference_level();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteInferenceLevel => {
-                    self.inference_level();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCleanUpBlock => {
-                    self.clean_up_block();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteCleanUpBlock => {
-                    self.clean_up_block();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallFail | &Instruction::ExecuteFail => {
-                    self.machine_st.backtrack();
-                }
-                &Instruction::CallGetBall => {
-                    self.get_ball();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetBall => {
-                    self.get_ball();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetCurrentBlock => {
-                    self.get_current_block();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetCurrentBlock => {
-                    self.get_current_block();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetCurrentSCCBlock => {
-                    self.get_current_scc_block();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetCurrentSCCBlock => {
-                    self.get_current_scc_block();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetCutPoint => {
-                    self.get_cut_point();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetCutPoint => {
-                    self.get_cut_point();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetDoubleQuotes => {
-                    self.get_double_quotes();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetDoubleQuotes => {
-                    self.get_double_quotes();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetUnknown => {
-                    self.get_unknown();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetUnknown => {
-                    self.get_unknown();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallInstallNewBlock => {
-                    self.machine_st.install_new_block(self.machine_st.registers[1]);
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteInstallNewBlock => {
-                    self.machine_st.install_new_block(self.machine_st.registers[1]);
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallMaybe => {
-                    self.maybe();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteMaybe => {
-                    self.maybe();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCpuNow => {
-                    self.cpu_now();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCpuNow => {
-                    self.cpu_now();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDeterministicLengthRundown => {
-                    try_or_throw!(self.machine_st, self.det_length_rundown());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDeterministicLengthRundown => {
-                    try_or_throw!(self.machine_st, self.det_length_rundown());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallHttpOpen => {
-                    #[cfg(feature = "http")]
-                    try_or_throw!(self.machine_st, self.http_open());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteHttpOpen => {
-                    #[cfg(feature = "http")]
-                    try_or_throw!(self.machine_st, self.http_open());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-		&Instruction::CallHttpListen => {
-            #[cfg(feature = "http")]
-		    try_or_throw!(self.machine_st, self.http_listen());
-		    step_or_fail!(self, self.machine_st.p += 1);
-		}
-		&Instruction::ExecuteHttpListen => {
-            #[cfg(feature = "http")]
-		    try_or_throw!(self.machine_st, self.http_listen());
-		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-		}
-		&Instruction::CallHttpAccept => {
-            #[cfg(feature = "http")]
-		    try_or_throw!(self.machine_st, self.http_accept());
-		    step_or_fail!(self, self.machine_st.p += 1);
-		}
-		&Instruction::ExecuteHttpAccept => {
-            #[cfg(feature = "http")]
-		    try_or_throw!(self.machine_st, self.http_accept());
-		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-		}
-		&Instruction::CallHttpAnswer => {
-            #[cfg(feature = "http")]
-		    try_or_throw!(self.machine_st, self.http_answer());
-		    step_or_fail!(self, self.machine_st.p += 1);
-		}
-		&Instruction::ExecuteHttpAnswer => {
-            #[cfg(feature = "http")]
-		    try_or_throw!(self.machine_st, self.http_answer());
-		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-		}
-		&Instruction::CallLoadForeignLib => {
-            #[cfg(feature = "ffi")]
-		    try_or_throw!(self.machine_st, self.load_foreign_lib());
-		    step_or_fail!(self, self.machine_st.p += 1);
-		}
-		&Instruction::ExecuteLoadForeignLib => {
-            #[cfg(feature = "ffi")]
-		    try_or_throw!(self.machine_st, self.load_foreign_lib());
-		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-		}
-		&Instruction::CallForeignCall => {
-            #[cfg(feature = "ffi")]
-		    try_or_throw!(self.machine_st, self.foreign_call());
-		    step_or_fail!(self, self.machine_st.p += 1);
-		}
-		&Instruction::ExecuteForeignCall => {
-            #[cfg(feature = "ffi")]
-		    try_or_throw!(self.machine_st, self.foreign_call());
-		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-		}
-		&Instruction::CallDefineForeignStruct => {
-            #[cfg(feature = "ffi")]
-		    try_or_throw!(self.machine_st, self.define_foreign_struct());
-		    step_or_fail!(self, self.machine_st.p += 1);
-		}
-		&Instruction::ExecuteDefineForeignStruct => {
-            #[cfg(feature = "ffi")]
-		    try_or_throw!(self.machine_st, self.define_foreign_struct());
-		    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-		}
-                &Instruction::CallCurrentTime => {
-                    self.current_time();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCurrentTime => {
-                    self.current_time();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallQuotedToken => {
-                    self.quoted_token();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteQuotedToken => {
-                    self.quoted_token();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallReadFromChars => {
-                    try_or_throw!(self.machine_st, self.read_from_chars());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteReadFromChars => {
-                    try_or_throw!(self.machine_st, self.read_from_chars());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallReadTermFromChars => {
-                    try_or_throw!(self.machine_st, self.read_term_from_chars());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteReadTermFromChars => {
-                    try_or_throw!(self.machine_st, self.read_term_from_chars());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallResetBlock => {
-                    self.reset_block();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteResetBlock => {
-                    self.reset_block();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallResetSCCBlock => {
-                    self.reset_scc_block();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteResetSCCBlock => {
-                    self.reset_scc_block();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallReturnFromVerifyAttr |
-                &Instruction::ExecuteReturnFromVerifyAttr => {
-                    self.return_from_verify_attr();
-                }
-                &Instruction::CallSetBall => {
-                    self.set_ball();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSetBall => {
-                    self.set_ball();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallPushBallStack => {
-                    self.push_ball_stack();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePushBallStack => {
-                    self.push_ball_stack();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPopBallStack => {
-                    self.pop_ball_stack();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecutePopBallStack => {
-                    self.pop_ball_stack();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallPopFromBallStack => {
-                    self.pop_from_ball_stack();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecutePopFromBallStack => {
-                    self.pop_from_ball_stack();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallSetCutPointByDefault(r) => {
-                    self.set_cut_point_by_default(r);
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteSetCutPointByDefault(r) => {
-                    self.set_cut_point_by_default(r);
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSetDoubleQuotes => {
-                    self.set_double_quotes();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteSetDoubleQuotes => {
-                    self.set_double_quotes();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSetUnknown => {
-                    self.set_unknown();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteSetUnknown => {
-                    self.set_unknown();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSetSeed => {
-                    self.set_seed();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteSetSeed => {
-                    self.set_seed();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSkipMaxList => {
-                    try_or_throw!(self.machine_st, self.machine_st.skip_max_list());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteSkipMaxList => {
-                    try_or_throw!(self.machine_st, self.machine_st.skip_max_list());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSleep => {
-                    self.sleep();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSleep => {
-                    self.sleep();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallSocketClientOpen => {
-                    try_or_throw!(self.machine_st, self.socket_client_open());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteSocketClientOpen => {
-                    try_or_throw!(self.machine_st, self.socket_client_open());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSocketServerOpen => {
-                    try_or_throw!(self.machine_st, self.socket_server_open());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteSocketServerOpen => {
-                    try_or_throw!(self.machine_st, self.socket_server_open());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSocketServerAccept => {
-                    try_or_throw!(self.machine_st, self.socket_server_accept());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteSocketServerAccept => {
-                    try_or_throw!(self.machine_st, self.socket_server_accept());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSocketServerClose => {
-                    try_or_throw!(self.machine_st, self.socket_server_close());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSocketServerClose => {
-                    try_or_throw!(self.machine_st, self.socket_server_close());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallTLSAcceptClient => {
-                    #[cfg(feature = "tls")]
-                    try_or_throw!(self.machine_st, self.tls_accept_client());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteTLSAcceptClient => {
-                    #[cfg(feature = "tls")]
-                    try_or_throw!(self.machine_st, self.tls_accept_client());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallTLSClientConnect => {
-                    #[cfg(feature = "tls")]
-                    try_or_throw!(self.machine_st, self.tls_client_connect());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteTLSClientConnect => {
-                    #[cfg(feature = "tls")]
-                    try_or_throw!(self.machine_st, self.tls_client_connect());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSucceed => {
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSucceed => {
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallTermAttributedVariables => {
-                    self.term_attributed_variables();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteTermAttributedVariables => {
-                    self.term_attributed_variables();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallTermVariables => {
-                    self.term_variables();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteTermVariables => {
-                    self.term_variables();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallTermVariablesUnderMaxDepth => {
-                    self.term_variables_under_max_depth();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteTermVariablesUnderMaxDepth => {
-                    self.term_variables_under_max_depth();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallTruncateLiftedHeapTo => {
-                    self.truncate_lifted_heap_to();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteTruncateLiftedHeapTo => {
-                    self.truncate_lifted_heap_to();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallUnifyWithOccursCheck => {
-                    self.unify_with_occurs_check();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteUnifyWithOccursCheck => {
-                    self.unify_with_occurs_check();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallUnwindEnvironments => {
-                    if !self.unwind_environments() {
-                        self.machine_st.p += 1;
+                    &Instruction::DefaultCallIs(r, at) => {
+                        try_or_throw!(self.machine_st, self.machine_st.is(r, at));
+                        step_or_fail!(self, self.machine_st.p += 1);
                     }
-                }
-                &Instruction::ExecuteUnwindEnvironments => {
-                    if !self.unwind_environments() {
+                    &Instruction::DefaultExecuteIs(r, at) => {
+                        try_or_throw!(self.machine_st, self.machine_st.is(r, at));
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    Instruction::DefaultCallGetNumber(at) => {
+                        try_or_throw!(self.machine_st, self.machine_st.get_number(at));
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    Instruction::DefaultExecuteGetNumber(at) => {
+                        try_or_throw!(self.machine_st, self.machine_st.get_number(at));
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallAcyclicTerm => {
+                        let addr = self.machine_st.registers[1];
+
+                        if self.machine_st.is_cyclic_term(addr) {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteAcyclicTerm => {
+                        let addr = self.machine_st.registers[1];
+
+                        if self.machine_st.is_cyclic_term(addr) {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallArg => {
+                        try_or_throw!(self.machine_st, self.machine_st.try_arg());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteArg => {
+                        try_or_throw!(self.machine_st, self.machine_st.try_arg());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallCompare => {
+                        try_or_throw!(self.machine_st, self.machine_st.compare());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteCompare => {
+                        try_or_throw!(self.machine_st, self.machine_st.compare());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallTermGreaterThan => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Greater) = compare_term_test!(self.machine_st, a1, a2)
+                        {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        } else {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::ExecuteTermGreaterThan => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Greater) = compare_term_test!(self.machine_st, a1, a2)
+                        {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        } else {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::CallTermLessThan => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Less) = compare_term_test!(self.machine_st, a1, a2) {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        } else {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::ExecuteTermLessThan => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Less) = compare_term_test!(self.machine_st, a1, a2) {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        } else {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::CallTermGreaterThanOrEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        match compare_term_test!(self.machine_st, a1, a2) {
+                            Some(Ordering::Greater | Ordering::Equal) => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteTermGreaterThanOrEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        match compare_term_test!(self.machine_st, a1, a2) {
+                            Some(Ordering::Greater | Ordering::Equal) => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallTermLessThanOrEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        match compare_term_test!(self.machine_st, a1, a2) {
+                            Some(Ordering::Less | Ordering::Equal) => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteTermLessThanOrEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        match compare_term_test!(self.machine_st, a1, a2) {
+                            Some(Ordering::Less | Ordering::Equal) => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallCopyTerm => {
+                        self.machine_st.copy_term(AttrVarPolicy::DeepCopy);
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteCopyTerm => {
+                        self.machine_st.copy_term(AttrVarPolicy::DeepCopy);
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallTermEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if self.machine_st.eq_test(a1, a2) {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteTermEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if self.machine_st.eq_test(a1, a2) {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallGround => {
+                        if self.machine_st.ground_test() {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteGround => {
+                        if self.machine_st.ground_test() {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallFunctor => {
+                        try_or_throw!(self.machine_st, self.machine_st.try_functor());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteFunctor => {
+                        try_or_throw!(self.machine_st, self.machine_st.try_functor());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallTermNotEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Equal) = compare_term_test!(self.machine_st, a1, a2) {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteTermNotEqual => {
+                        let a1 = self.machine_st.registers[1];
+                        let a2 = self.machine_st.registers[2];
+
+                        if let Some(Ordering::Equal) = compare_term_test!(self.machine_st, a1, a2) {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallSort => {
+                        try_or_throw!(self.machine_st, self.machine_st.sort());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteSort => {
+                        try_or_throw!(self.machine_st, self.machine_st.sort());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallKeySort => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.machine_st.keysort(VarComparison::Distinct)
+                        );
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteKeySort => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.machine_st.keysort(VarComparison::Distinct)
+                        );
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallKeySortWithConstantVarOrdering => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.machine_st.keysort(VarComparison::Indistinct)
+                        );
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteKeySortWithConstantVarOrdering => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.machine_st.keysort(VarComparison::Indistinct)
+                        );
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallIs(r, at) => {
+                        try_or_throw!(self.machine_st, self.machine_st.is(r, at));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteIs(r, at) => {
+                        try_or_throw!(self.machine_st, self.machine_st.is(r, at));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    Instruction::CallGetNumber(at) => {
+                        try_or_throw!(self.machine_st, self.machine_st.get_number(at));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    Instruction::ExecuteGetNumber(at) => {
+                        try_or_throw!(self.machine_st, self.machine_st.get_number(at));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallN(arity) => {
+                        let pred = self.machine_st.registers[1];
+
+                        for i in 2..arity + 1 {
+                            self.machine_st.registers[i - 1] = self.machine_st.registers[i];
+                        }
+
+                        self.machine_st.registers[arity] = pred;
+
+                        try_or_throw!(self.machine_st, self.call_n(atom!("user"), arity));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+                        }
+                    }
+                    &Instruction::ExecuteN(arity) => {
+                        let pred = self.machine_st.registers[1];
+
+                        for i in 2..arity + 1 {
+                            self.machine_st.registers[i - 1] = self.machine_st.registers[i];
+                        }
+
+                        self.machine_st.registers[arity] = pred;
+
+                        try_or_throw!(self.machine_st, self.execute_n(atom!("user"), arity));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+                        }
+                    }
+                    &Instruction::DefaultCallN(arity) => {
+                        let pred = self.machine_st.registers[1];
+
+                        for i in 2..arity + 1 {
+                            self.machine_st.registers[i - 1] = self.machine_st.registers[i];
+                        }
+
+                        self.machine_st.registers[arity] = pred;
+
+                        try_or_throw!(self.machine_st, self.call_n(atom!("user"), arity));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::DefaultExecuteN(arity) => {
+                        let pred = self.machine_st.registers[1];
+
+                        for i in 2..arity + 1 {
+                            self.machine_st.registers[i - 1] = self.machine_st.registers[i];
+                        }
+
+                        self.machine_st.registers[arity] = pred;
+
+                        try_or_throw!(self.machine_st, self.execute_n(atom!("user"), arity));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::CallNumberLessThanOrEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Less | Ordering::Equal => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteNumberLessThanOrEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Less | Ordering::Equal => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallNumberEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Equal => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteNumberEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Equal => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallNumberNotEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Equal => {
+                                self.machine_st.backtrack();
+                            }
+                            _ => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p += 1;
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteNumberNotEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Equal => {
+                                self.machine_st.backtrack();
+                            }
+                            _ => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                        }
+                    }
+                    &Instruction::CallNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Greater | Ordering::Equal => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Greater | Ordering::Equal => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallNumberGreaterThan(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Greater => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteNumberGreaterThan(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Greater => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallNumberLessThan(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Less => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteNumberLessThan(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Less => {
+                                try_or_throw!(
+                                    self.machine_st,
+                                    (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                                );
+
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultCallNumberLessThanOrEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Less | Ordering::Equal => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultExecuteNumberLessThanOrEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Less | Ordering::Equal => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultCallNumberNotEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Equal => {
+                                self.machine_st.backtrack();
+                            }
+                            _ => {
+                                self.machine_st.p += 1;
+                            }
+                        }
+                    }
+                    &Instruction::DefaultExecuteNumberNotEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Equal => {
+                                self.machine_st.backtrack();
+                            }
+                            _ => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                        }
+                    }
+                    &Instruction::DefaultCallNumberEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Equal => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultExecuteNumberEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Equal => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultCallNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Greater | Ordering::Equal => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultExecuteNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Greater | Ordering::Equal => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultCallNumberGreaterThan(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Greater => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultExecuteNumberGreaterThan(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Greater => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultCallNumberLessThan(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Less => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::DefaultExecuteNumberLessThan(ref at_1, ref at_2) => {
+                        let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
+                        let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
+
+                        match n1.cmp(&n2) {
+                            Ordering::Less => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    //
+                    &Instruction::CallIsAtom(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        read_heap_cell!(d,
+                            (HeapCellValueTag::Atom, (_name, arity)) => {
+                                if arity == 0 {
+                                    self.machine_st.p += 1;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            (HeapCellValueTag::Str, s) => {
+                                let arity = cell_as_atom_cell!(self.machine_st.heap[s])
+                                    .get_arity();
+
+                                if arity == 0 {
+                                    self.machine_st.p += 1;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            (HeapCellValueTag::Char) => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        );
+                    }
+                    &Instruction::ExecuteIsAtom(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        read_heap_cell!(d,
+                            (HeapCellValueTag::Atom, (_name, arity)) => {
+                                if arity == 0 {
+                                    self.machine_st.p = self.machine_st.cp;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            (HeapCellValueTag::Str, s) => {
+                                let arity = cell_as_atom_cell!(self.machine_st.heap[s])
+                                    .get_arity();
+
+                                if arity == 0 {
+                                    self.machine_st.p = self.machine_st.cp;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            (HeapCellValueTag::Char) => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        );
+                    }
+                    &Instruction::CallIsAtomic(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        read_heap_cell!(d,
+                            (HeapCellValueTag::Char | HeapCellValueTag::Fixnum | HeapCellValueTag::F64 |
+                             HeapCellValueTag::Cons) => {
+                                self.machine_st.p += 1;
+                            }
+                            (HeapCellValueTag::Atom, (_name, arity)) => {
+                                if arity == 0 {
+                                    self.machine_st.p += 1;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            (HeapCellValueTag::Str, s) => {
+                                let arity = cell_as_atom_cell!(self.machine_st.heap[s])
+                                    .get_arity();
+
+                                if arity == 0 {
+                                    self.machine_st.p += 1;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        );
+                    }
+                    &Instruction::ExecuteIsAtomic(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        read_heap_cell!(d,
+                            (HeapCellValueTag::Char | HeapCellValueTag::Fixnum | HeapCellValueTag::F64 |
+                             HeapCellValueTag::Cons) => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            (HeapCellValueTag::Atom, (_name, arity)) => {
+                                if arity == 0 {
+                                    self.machine_st.p = self.machine_st.cp;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            (HeapCellValueTag::Str, s) => {
+                                let arity = cell_as_atom_cell!(self.machine_st.heap[s])
+                                    .get_arity();
+
+                                if arity == 0 {
+                                    self.machine_st.p = self.machine_st.cp;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        );
+                    }
+                    &Instruction::CallIsCompound(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        read_heap_cell!(d,
+                            (HeapCellValueTag::Lis |
+                             HeapCellValueTag::PStrLoc |
+                             HeapCellValueTag::CStr) => {
+                                self.machine_st.p += 1;
+                            }
+                            (HeapCellValueTag::Str, s) => {
+                                let arity = cell_as_atom_cell!(self.machine_st.heap[s])
+                                    .get_arity();
+
+                                if arity > 0 {
+                                    self.machine_st.p += 1;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            (HeapCellValueTag::Atom, (_name, arity)) => {
+                                if arity > 0 {
+                                    self.machine_st.p += 1;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        );
+                    }
+                    &Instruction::ExecuteIsCompound(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        read_heap_cell!(d,
+                            (HeapCellValueTag::Lis |
+                             HeapCellValueTag::PStrLoc |
+                             HeapCellValueTag::CStr) => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            (HeapCellValueTag::Str, s) => {
+                                let arity = cell_as_atom_cell!(self.machine_st.heap[s])
+                                    .get_arity();
+
+                                if arity > 0 {
+                                    self.machine_st.p = self.machine_st.cp;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            (HeapCellValueTag::Atom, (_name, arity)) => {
+                                if arity > 0 {
+                                    self.machine_st.p = self.machine_st.cp;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        );
+                    }
+                    &Instruction::CallIsInteger(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match Number::try_from(d) {
+                            Ok(Number::Fixnum(_) | Number::Integer(_)) => {
+                                self.machine_st.p += 1;
+                            }
+                            Ok(Number::Rational(n)) => {
+                                if n.denominator().is_one() {
+                                    self.machine_st.p += 1;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteIsInteger(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match Number::try_from(d) {
+                            Ok(Number::Fixnum(_) | Number::Integer(_)) => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            Ok(Number::Rational(n)) => {
+                                if n.denominator().is_one() {
+                                    self.machine_st.p = self.machine_st.cp;
+                                } else {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallIsNumber(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match Number::try_from(d) {
+                            Ok(_) => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteIsNumber(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match Number::try_from(d) {
+                            Ok(_) => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallIsRational(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        read_heap_cell!(d,
+                            (HeapCellValueTag::Cons, ptr) => {
+                                match_untyped_arena_ptr!(ptr,
+                                     (ArenaHeaderTag::Rational | ArenaHeaderTag::Integer, _r) => {
+                                         self.machine_st.p += 1;
+                                     }
+                                     _ => {
+                                         self.machine_st.backtrack();
+                                     }
+                                );
+                            }
+                            (HeapCellValueTag::Fixnum) => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        );
+                    }
+                    &Instruction::ExecuteIsRational(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        read_heap_cell!(d,
+                            (HeapCellValueTag::Cons, ptr) => {
+                                match_untyped_arena_ptr!(ptr,
+                                     (ArenaHeaderTag::Rational | ArenaHeaderTag::Integer, _r) => {
+                                         self.machine_st.p = self.machine_st.cp;
+                                     }
+                                     _ => {
+                                         self.machine_st.backtrack();
+                                     }
+                                );
+                            }
+                            (HeapCellValueTag::Fixnum) => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        );
+                    }
+                    &Instruction::CallIsFloat(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match Number::try_from(d) {
+                            Ok(Number::Float(_)) => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteIsFloat(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match Number::try_from(d) {
+                            Ok(Number::Float(_)) => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallIsNonVar(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match d.get_tag() {
+                            HeapCellValueTag::AttrVar
+                            | HeapCellValueTag::Var
+                            | HeapCellValueTag::StackVar => {
+                                self.machine_st.backtrack();
+                            }
+                            _ => {
+                                self.machine_st.p += 1;
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteIsNonVar(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match d.get_tag() {
+                            HeapCellValueTag::AttrVar
+                            | HeapCellValueTag::Var
+                            | HeapCellValueTag::StackVar => {
+                                self.machine_st.backtrack();
+                            }
+                            _ => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                        }
+                    }
+                    &Instruction::CallIsVar(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match d.get_tag() {
+                            HeapCellValueTag::AttrVar
+                            | HeapCellValueTag::Var
+                            | HeapCellValueTag::StackVar => {
+                                self.machine_st.p += 1;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::ExecuteIsVar(r) => {
+                        let d = self
+                            .machine_st
+                            .store(self.machine_st.deref(self.machine_st[r]));
+
+                        match d.get_tag() {
+                            HeapCellValueTag::AttrVar
+                            | HeapCellValueTag::Var
+                            | HeapCellValueTag::StackVar => {
+                                self.machine_st.p = self.machine_st.cp;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                            }
+                        }
+                    }
+                    &Instruction::CallNamed(arity, name, ref idx) => {
+                        let idx = idx.get();
+
+                        try_or_throw!(self.machine_st, self.try_call(name, arity, idx));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+                        }
+                    }
+                    &Instruction::ExecuteNamed(arity, name, ref idx) => {
+                        let idx = idx.get();
+
+                        try_or_throw!(self.machine_st, self.try_execute(name, arity, idx));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            try_or_throw!(
+                                self.machine_st,
+                                (self.machine_st.increment_call_count_fn)(&mut self.machine_st)
+                            );
+                        }
+                    }
+                    &Instruction::DefaultCallNamed(arity, name, ref idx) => {
+                        let idx = idx.get();
+
+                        try_or_throw!(self.machine_st, self.try_call(name, arity, idx));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::DefaultExecuteNamed(arity, name, ref idx) => {
+                        let idx = idx.get();
+
+                        try_or_throw!(self.machine_st, self.try_execute(name, arity, idx));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::Deallocate => self.machine_st.deallocate(),
+                    &Instruction::JmpByCall(offset) => {
+                        self.machine_st.p += offset;
+                    }
+                    &Instruction::RevJmpBy(offset) => {
+                        self.machine_st.p -= offset;
+                    }
+                    &Instruction::Proceed => {
                         self.machine_st.p = self.machine_st.cp;
                     }
-                }
-                &Instruction::CallUnwindStack | &Instruction::ExecuteUnwindStack => {
-                    self.machine_st.unwind_stack();
-                    self.machine_st.backtrack();
-                }
-                &Instruction::CallWAMInstructions => {
-                    try_or_throw!(self.machine_st, self.wam_instructions());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteWAMInstructions => {
-                    try_or_throw!(self.machine_st, self.wam_instructions());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallInlinedInstructions => {
-                    self.inlined_instructions();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteInlinedInstructions => {
-                    self.inlined_instructions();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallWriteTerm => {
-                    try_or_throw!(self.machine_st, self.write_term());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteWriteTerm => {
-                    try_or_throw!(self.machine_st, self.write_term());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallWriteTermToChars => {
-                    try_or_throw!(self.machine_st, self.write_term_to_chars());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteWriteTermToChars => {
-                    try_or_throw!(self.machine_st, self.write_term_to_chars());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallScryerPrologVersion => {
-                    self.scryer_prolog_version();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteScryerPrologVersion => {
-                    self.scryer_prolog_version();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCryptoRandomByte => {
-                    self.crypto_random_byte();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCryptoRandomByte => {
-                    self.crypto_random_byte();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCryptoDataHash => {
-                    self.crypto_data_hash();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCryptoDataHash => {
-                    self.crypto_data_hash();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCryptoDataHKDF => {
-                    self.crypto_data_hkdf();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCryptoDataHKDF => {
-                    self.crypto_data_hkdf();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCryptoPasswordHash => {
-                    self.crypto_password_hash();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCryptoPasswordHash => {
-                    self.crypto_password_hash();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCryptoDataEncrypt => {
-                    self.crypto_data_encrypt();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCryptoDataEncrypt => {
-                    self.crypto_data_encrypt();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCryptoDataDecrypt => {
-                    self.crypto_data_decrypt();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCryptoDataDecrypt => {
-                    self.crypto_data_decrypt();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCryptoCurveScalarMult => {
-                    self.crypto_curve_scalar_mult();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCryptoCurveScalarMult => {
-                    self.crypto_curve_scalar_mult();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallEd25519Sign => {
-                    self.ed25519_sign();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteEd25519Sign => {
-                    self.ed25519_sign();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallEd25519Verify => {
-                    self.ed25519_verify();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteEd25519Verify => {
-                    self.ed25519_verify();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallEd25519NewKeyPair => {
-                    self.ed25519_new_key_pair();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteEd25519NewKeyPair => {
-                    self.ed25519_new_key_pair();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallEd25519KeyPairPublicKey => {
-                    self.ed25519_key_pair_public_key();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteEd25519KeyPairPublicKey => {
-                    self.ed25519_key_pair_public_key();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCurve25519ScalarMult => {
-                    self.curve25519_scalar_mult();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCurve25519ScalarMult => {
-                    self.curve25519_scalar_mult();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallFirstNonOctet => {
-                    self.first_non_octet();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteFirstNonOctet => {
-                    self.first_non_octet();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLoadHTML => {
-                    self.load_html();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLoadHTML => {
-                    self.load_html();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLoadXML => {
-                    self.load_xml();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLoadXML => {
-                    self.load_xml();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallGetEnv => {
-                    self.get_env();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetEnv => {
-                    self.get_env();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSetEnv => {
-                    self.set_env();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSetEnv => {
-                    self.set_env();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallUnsetEnv => {
-                    self.unset_env();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteUnsetEnv => {
-                    self.unset_env();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallShell => {
-                    self.shell();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteShell => {
-                    self.shell();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPID => {
-                    self.pid();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePID => {
-                    self.pid();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCharsBase64 => {
-                    try_or_throw!(self.machine_st, self.chars_base64());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCharsBase64 => {
-                    try_or_throw!(self.machine_st, self.chars_base64());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDevourWhitespace => {
-                    try_or_throw!(self.machine_st, self.devour_whitespace());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDevourWhitespace => {
-                    try_or_throw!(self.machine_st, self.devour_whitespace());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallIsSTOEnabled => {
-                    self.is_sto_enabled();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteIsSTOEnabled => {
-                    self.is_sto_enabled();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallSetSTOAsUnify => {
-                    self.set_sto_as_unify();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSetSTOAsUnify => {
-                    self.set_sto_as_unify();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallSetNSTOAsUnify => {
-                    self.set_nsto_as_unify();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSetNSTOAsUnify => {
-                    self.set_nsto_as_unify();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallSetSTOWithErrorAsUnify => {
-                    self.set_sto_with_error_as_unify();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteSetSTOWithErrorAsUnify => {
-                    self.set_sto_with_error_as_unify();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallHomeDirectory => {
-                    self.home_directory();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteHomeDirectory => {
-                    self.home_directory();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDebugHook => {
-                    self.debug_hook();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteDebugHook => {
-                    self.debug_hook();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallPopCount => {
-                    self.pop_count();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePopCount => {
-                    self.pop_count();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallAddDiscontiguousPredicate => {
-                    try_or_throw!(self.machine_st, self.add_discontiguous_predicate());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAddDiscontiguousPredicate => {
-                    try_or_throw!(self.machine_st, self.add_discontiguous_predicate());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallAddDynamicPredicate => {
-                    try_or_throw!(self.machine_st, self.add_dynamic_predicate());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAddDynamicPredicate => {
-                    try_or_throw!(self.machine_st, self.add_dynamic_predicate());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallAddMultifilePredicate => {
-                    try_or_throw!(self.machine_st, self.add_multifile_predicate());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAddMultifilePredicate => {
-                    try_or_throw!(self.machine_st, self.add_multifile_predicate());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallAddGoalExpansionClause => {
-                    try_or_throw!(self.machine_st, self.add_goal_expansion_clause());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAddGoalExpansionClause => {
-                    try_or_throw!(self.machine_st, self.add_goal_expansion_clause());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallAddTermExpansionClause => {
-                    try_or_throw!(self.machine_st, self.add_term_expansion_clause());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAddTermExpansionClause => {
-                    try_or_throw!(self.machine_st, self.add_term_expansion_clause());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallAddInSituFilenameModule => {
-                    try_or_throw!(self.machine_st, self.add_in_situ_filename_module());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAddInSituFilenameModule => {
-                    try_or_throw!(self.machine_st, self.add_in_situ_filename_module());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallClauseToEvacuable => {
-                    try_or_throw!(self.machine_st, self.clause_to_evacuable());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteClauseToEvacuable => {
-                    try_or_throw!(self.machine_st, self.clause_to_evacuable());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallScopedClauseToEvacuable => {
-                    try_or_throw!(self.machine_st, self.scoped_clause_to_evacuable());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteScopedClauseToEvacuable => {
-                    try_or_throw!(self.machine_st, self.scoped_clause_to_evacuable());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallConcludeLoad => {
-                    try_or_throw!(self.machine_st, self.conclude_load());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteConcludeLoad => {
-                    try_or_throw!(self.machine_st, self.conclude_load());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallDeclareModule => {
-                    try_or_throw!(self.machine_st, self.declare_module());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteDeclareModule => {
-                    try_or_throw!(self.machine_st, self.declare_module());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallLoadCompiledLibrary => {
-                    try_or_throw!(self.machine_st, self.load_compiled_library());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLoadCompiledLibrary => {
-                    try_or_throw!(self.machine_st, self.load_compiled_library());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLoadContextSource => {
-                    self.load_context_source();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLoadContextSource => {
-                    self.load_context_source();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLoadContextFile => {
-                    self.load_context_file();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLoadContextFile => {
-                    self.load_context_file();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLoadContextDirectory => {
-                    self.load_context_directory();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLoadContextDirectory => {
-                    self.load_context_directory();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLoadContextModule => {
-                    self.load_context_module(self.machine_st.registers[1]);
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLoadContextModule => {
-                    self.load_context_module(self.machine_st.registers[1]);
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallLoadContextStream => {
-                    self.load_context_stream();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteLoadContextStream => {
-                    self.load_context_stream();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPopLoadContext => {
-                    self.pop_load_context();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecutePopLoadContext => {
-                    self.pop_load_context();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallPopLoadStatePayload => {
-                    self.pop_load_state_payload();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecutePopLoadStatePayload => {
-                    self.pop_load_state_payload();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallPushLoadContext => {
-                    try_or_throw!(self.machine_st, self.push_load_context());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecutePushLoadContext => {
-                    try_or_throw!(self.machine_st, self.push_load_context());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallPushLoadStatePayload => {
-                    self.push_load_state_payload();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePushLoadStatePayload => {
-                    self.push_load_state_payload();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallUseModule => {
-                    try_or_throw!(self.machine_st, self.use_module());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteUseModule => {
-                    try_or_throw!(self.machine_st, self.use_module());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallBuiltInProperty => {
-                    let key = self
-                        .machine_st
-                        .read_predicate_key(self.machine_st.registers[1], self.machine_st.registers[2]);
+                    &Instruction::GetConstant(_, c, reg) => {
+                        let value = self.machine_st.deref(self.machine_st[reg]);
+                        self.machine_st.write_literal_to_var(value, c);
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::GetList(_, reg) => {
+                        let deref_v = self.machine_st.deref(self.machine_st[reg]);
+                        let store_v = self.machine_st.store(deref_v);
 
-                    self.machine_st.fail = !self.indices.builtin_property(key);
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteBuiltInProperty => {
-                    let key = self
-                        .machine_st
-                        .read_predicate_key(self.machine_st.registers[1], self.machine_st.registers[2]);
+                        read_heap_cell!(store_v,
+                            (HeapCellValueTag::PStrLoc, h) => {
+                                let (h, n) = pstr_loc_and_offset(&self.machine_st.heap, h);
 
-                    self.machine_st.fail = !self.indices.builtin_property(key);
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallMetaPredicateProperty => {
-                    self.meta_predicate_property();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteMetaPredicateProperty => {
-                    self.meta_predicate_property();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallMultifileProperty => {
-                    self.multifile_property();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteMultifileProperty => {
-                    self.multifile_property();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDiscontiguousProperty => {
-                    self.discontiguous_property();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDiscontiguousProperty => {
-                    self.discontiguous_property();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDynamicProperty => {
-                    self.dynamic_property();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDynamicProperty => {
-                    self.dynamic_property();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallAbolishClause => {
-                    try_or_throw!(self.machine_st, self.abolish_clause());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAbolishClause => {
-                    try_or_throw!(self.machine_st, self.abolish_clause());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallAsserta => {
-                    try_or_throw!(self.machine_st, self.compile_assert(AppendOrPrepend::Prepend));
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAsserta => {
-                    try_or_throw!(self.machine_st, self.compile_assert(AppendOrPrepend::Prepend));
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallAssertz => {
-                    try_or_throw!(self.machine_st, self.compile_assert(AppendOrPrepend::Append));
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAssertz => {
-                    try_or_throw!(self.machine_st, self.compile_assert(AppendOrPrepend::Append));
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallRetract => {
-                    try_or_throw!(self.machine_st, self.retract_clause());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteRetract => {
-                    try_or_throw!(self.machine_st, self.retract_clause());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallIsConsistentWithTermQueue => {
-                    try_or_throw!(self.machine_st, self.is_consistent_with_term_queue());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteIsConsistentWithTermQueue => {
-                    try_or_throw!(self.machine_st, self.is_consistent_with_term_queue());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::CallFlushTermQueue => {
-                    try_or_throw!(self.machine_st, self.flush_term_queue());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteFlushTermQueue => {
-                    try_or_throw!(self.machine_st, self.flush_term_queue());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallRemoveModuleExports => {
-                    try_or_throw!(self.machine_st, self.remove_module_exports());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteRemoveModuleExports => {
-                    try_or_throw!(self.machine_st, self.remove_module_exports());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallAddNonCountedBacktracking => {
-                    try_or_throw!(self.machine_st, self.add_non_counted_backtracking());
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteAddNonCountedBacktracking => {
-                    try_or_throw!(self.machine_st, self.add_non_counted_backtracking());
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallPredicateDefined => {
-                    self.machine_st.fail = !self.predicate_defined();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePredicateDefined => {
-                    self.machine_st.fail = !self.predicate_defined();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallStripModule => {
-                    self.strip_module();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteStripModule => {
-                    self.strip_module();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPrepareCallClause(arity) => {
-                    try_or_throw!(self.machine_st, self.prepare_call_clause(arity));
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePrepareCallClause(arity) => {
-                    try_or_throw!(self.machine_st, self.prepare_call_clause(arity));
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallCompileInlineOrExpandedGoal => {
-                    try_or_throw!(self.machine_st, self.compile_inline_or_expanded_goal());
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteCompileInlineOrExpandedGoal => {
-                    try_or_throw!(self.machine_st, self.compile_inline_or_expanded_goal());
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallIsExpandedOrInlined => {
-                    self.machine_st.fail = !self.is_expanded_or_inlined();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteIsExpandedOrInlined => {
-                    self.machine_st.fail = !self.is_expanded_or_inlined();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallFastCallN(arity) => {
-                    let call_at_index = |wam: &mut Machine, name, arity, ptr| {
-                        wam.try_call(name, arity, ptr)
-                    };
+                                self.machine_st.s = HeapPtr::PStrChar(h, n.get_num() as usize);
+                                self.machine_st.s_offset = 0;
+                                self.machine_st.mode = MachineMode::Read;
+                            }
+                            (HeapCellValueTag::CStr) => {
+                                let h = self.machine_st.heap.len();
+                                self.machine_st.heap.push(store_v);
 
-                    try_or_throw!(self.machine_st, self.fast_call(arity, call_at_index));
+                                self.machine_st.s = HeapPtr::PStrChar(h, 0);
+                                self.machine_st.s_offset = 0;
+                                self.machine_st.mode = MachineMode::Read;
+                            }
+                            (HeapCellValueTag::Str, s) => {
+                                let (name, arity) = cell_as_atom_cell!(self.machine_st.heap[s])
+                                    .get_name_and_arity();
 
-                    if self.machine_st.fail {
+                                if name == atom!(".") && arity == 2 {
+                                    self.machine_st.s = HeapPtr::HeapCell(s+1);
+                                    self.machine_st.s_offset = 0;
+                                    self.machine_st.mode = MachineMode::Read;
+                                } else {
+                                    self.machine_st.backtrack();
+                                    continue;
+                                }
+                            }
+                            (HeapCellValueTag::Lis, l) => {
+                                self.machine_st.s = HeapPtr::HeapCell(l);
+                                self.machine_st.s_offset = 0;
+                                self.machine_st.mode = MachineMode::Read;
+                            }
+                            (HeapCellValueTag::AttrVar | HeapCellValueTag::Var | HeapCellValueTag::StackVar) => {
+                                let h = self.machine_st.heap.len();
+
+                                self.machine_st.heap.push(list_loc_as_cell!(h+1));
+                                self.machine_st.bind(store_v.as_var().unwrap(), heap_loc_as_cell!(h));
+
+                                self.machine_st.mode = MachineMode::Write;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                                continue;
+                            }
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::GetPartialString(_, string, reg, has_tail) => {
+                        let deref_v = self.machine_st.deref(self.machine_st[reg]);
+                        let store_v = self.machine_st.store(deref_v);
+
+                        read_heap_cell!(store_v,
+                            (HeapCellValueTag::Str |
+                             HeapCellValueTag::Lis |
+                             HeapCellValueTag::PStrLoc |
+                             HeapCellValueTag::CStr) => {
+                                self.machine_st.match_partial_string(store_v, string, has_tail);
+                            }
+                            (HeapCellValueTag::AttrVar |
+                             HeapCellValueTag::StackVar |
+                             HeapCellValueTag::Var) => {
+                                let target_cell = self.machine_st.push_str_to_heap(
+                                    string.as_str(),
+                                    has_tail,
+                                );
+
+                                self.machine_st.bind(
+                                    store_v.as_var().unwrap(),
+                                    target_cell,
+                                );
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                                continue;
+                            }
+                        );
+
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::GetStructure(_lvl, name, arity, reg) => {
+                        let deref_v = self.machine_st.deref(self.machine_st[reg]);
+                        let store_v = self.machine_st.store(deref_v);
+
+                        read_heap_cell!(store_v,
+                            (HeapCellValueTag::Str, a) => {
+                                read_heap_cell!(self.machine_st.heap[a],
+                                    (HeapCellValueTag::Atom, (result_name, result_arity)) => {
+                                        if arity == result_arity && name == result_name {
+                                            self.machine_st.s = HeapPtr::HeapCell(a + 1);
+                                            self.machine_st.s_offset = 0;
+                                            self.machine_st.mode = MachineMode::Read;
+                                        } else {
+                                            self.machine_st.backtrack();
+                                            continue;
+                                        }
+                                    }
+                                    _ => {
+                                        unreachable!();
+                                    }
+                                );
+                            }
+                            (HeapCellValueTag::AttrVar | HeapCellValueTag::Var | HeapCellValueTag::StackVar) => {
+                                let h = self.machine_st.heap.len();
+
+                                self.machine_st.heap.push(str_loc_as_cell!(h+1));
+                                self.machine_st.heap.push(atom_as_cell!(name, arity));
+
+                                self.machine_st.bind(store_v.as_var().unwrap(), heap_loc_as_cell!(h));
+                                self.machine_st.mode = MachineMode::Write;
+                            }
+                            _ => {
+                                self.machine_st.backtrack();
+                                continue;
+                            }
+                        );
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::GetVariable(norm, arg) => {
+                        self.machine_st[norm] = self.machine_st.registers[arg];
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::GetValue(norm, arg) => {
+                        let norm_addr = self.machine_st[norm];
+                        let reg_addr = self.machine_st.registers[arg];
+
+                        unify_fn!(&mut self.machine_st, norm_addr, reg_addr);
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                            continue;
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::UnifyConstant(v) => {
+                        match self.machine_st.mode {
+                            MachineMode::Read => {
+                                let addr = self.machine_st.read_s();
+
+                                self.machine_st.write_literal_to_var(addr, v);
+
+                                if self.machine_st.fail {
+                                    self.machine_st.backtrack();
+                                    continue;
+                                } else {
+                                    self.machine_st.s_offset += 1;
+                                }
+                            }
+                            MachineMode::Write => {
+                                self.machine_st.heap.push(v);
+                            }
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::UnifyLocalValue(reg) => {
+                        match self.machine_st.mode {
+                            MachineMode::Read => {
+                                let reg_addr = self.machine_st[reg];
+                                let value = self.machine_st.read_s();
+
+                                unify_fn!(&mut self.machine_st, reg_addr, value);
+
+                                if self.machine_st.fail {
+                                    self.machine_st.backtrack();
+                                    continue;
+                                } else {
+                                    self.machine_st.s_offset += 1;
+                                }
+                            }
+                            MachineMode::Write => {
+                                let value = self
+                                    .machine_st
+                                    .store(self.machine_st.deref(self.machine_st[reg]));
+                                let h = self.machine_st.heap.len();
+
+                                read_heap_cell!(value,
+                                    (HeapCellValueTag::Var | HeapCellValueTag::AttrVar, hc) => {
+                                        let value = self.machine_st.heap[hc];
+
+                                        self.machine_st.heap.push(value);
+                                        self.machine_st.s_offset += 1;
+                                    }
+                                    _ => {
+                                        self.machine_st.heap.push(heap_loc_as_cell!(h));
+                                        (self.machine_st.bind_fn)(
+                                            &mut self.machine_st,
+                                            Ref::heap_cell(h),
+                                            value,
+                                        );
+                                    }
+                                );
+                            }
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::UnifyVariable(reg) => {
+                        match self.machine_st.mode {
+                            MachineMode::Read => {
+                                self.machine_st[reg] = self.machine_st.read_s();
+                                self.machine_st.s_offset += 1;
+                            }
+                            MachineMode::Write => {
+                                let h = self.machine_st.heap.len();
+
+                                self.machine_st.heap.push(heap_loc_as_cell!(h));
+                                self.machine_st[reg] = heap_loc_as_cell!(h);
+                            }
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::UnifyValue(reg) => {
+                        match self.machine_st.mode {
+                            MachineMode::Read => {
+                                let reg_addr = self.machine_st[reg];
+                                let value = self.machine_st.read_s();
+
+                                unify_fn!(&mut self.machine_st, reg_addr, value);
+
+                                if self.machine_st.fail {
+                                    self.machine_st.backtrack();
+                                    continue;
+                                } else {
+                                    self.machine_st.s_offset += 1;
+                                }
+                            }
+                            MachineMode::Write => {
+                                let h = self.machine_st.heap.len();
+                                self.machine_st.heap.push(heap_loc_as_cell!(h));
+
+                                let addr = self.machine_st.store(self.machine_st[reg]);
+                                (self.machine_st.bind_fn)(
+                                    &mut self.machine_st,
+                                    Ref::heap_cell(h),
+                                    addr,
+                                );
+
+                                // the former code of this match arm was:
+
+                                // let addr = self.machine_st.store(self.machine_st[reg]);
+                                // self.machine_st.heap.push(HeapCellValue::Addr(addr));
+
+                                // the old code didn't perform the occurs
+                                // check when enabled and so it was changed to
+                                // the above, which is only slightly less
+                                // efficient when the occurs_check is disabled.
+                            }
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::UnifyVoid(n) => {
+                        match self.machine_st.mode {
+                            MachineMode::Read => {
+                                self.machine_st.s_offset += n;
+                            }
+                            MachineMode::Write => {
+                                let h = self.machine_st.heap.len();
+
+                                for i in h..h + n {
+                                    self.machine_st.heap.push(heap_loc_as_cell!(i));
+                                }
+                            }
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::IndexingCode(ref indexing_lines) => {
+                        match &indexing_lines[self.machine_st.oip as usize] {
+                            IndexingLine::Indexing(_) => {
+                                self.execute_switch_on_term();
+
+                                if self.machine_st.fail {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                            IndexingLine::IndexedChoice(ref indexed_choice) => {
+                                match &indexed_choice[self.machine_st.iip as usize] {
+                                    &IndexedChoiceInstruction::Try(offset) => {
+                                        self.indexed_try(offset);
+                                    }
+                                    &IndexedChoiceInstruction::Retry(l) => {
+                                        self.retry(l);
+
+                                        try_or_throw!(
+                                            self.machine_st,
+                                            (self.machine_st.increment_call_count_fn)(
+                                                &mut self.machine_st
+                                            )
+                                        );
+                                    }
+                                    &IndexedChoiceInstruction::DefaultRetry(l) => {
+                                        self.retry(l);
+                                    }
+                                    &IndexedChoiceInstruction::Trust(l) => {
+                                        self.trust(l);
+
+                                        try_or_throw!(
+                                            self.machine_st,
+                                            (self.machine_st.increment_call_count_fn)(
+                                                &mut self.machine_st
+                                            )
+                                        );
+                                    }
+                                    &IndexedChoiceInstruction::DefaultTrust(l) => {
+                                        self.trust(l);
+                                    }
+                                }
+                            }
+                            IndexingLine::DynamicIndexedChoice(_) => {
+                                let p = self.machine_st.p;
+
+                                match self
+                                    .find_living_dynamic(self.machine_st.oip, self.machine_st.iip)
+                                {
+                                    Some((offset, oi, ii, is_next_clause)) => {
+                                        self.machine_st.p = p;
+                                        self.machine_st.oip = oi;
+                                        self.machine_st.iip = ii;
+
+                                        match self.machine_st.dynamic_mode {
+                                            FirstOrNext::First if !is_next_clause => {
+                                                self.machine_st.p = p + offset;
+                                            }
+                                            FirstOrNext::First => {
+                                                // there's a leading DynamicElse that sets self.machine_st.cc.
+                                                // self.machine_st.cc = self.machine_st.global_clock;
+
+                                                // see that there is a following dynamic_else
+                                                // clause so we avoid generating a choice
+                                                // point in case there isn't.
+                                                match self.find_living_dynamic(oi, ii + 1) {
+                                                    Some(_) => {
+                                                        self.machine_st.registers
+                                                            [self.machine_st.num_of_args + 1] =
+                                                            fixnum_as_cell!(Fixnum::build_with(
+                                                                self.machine_st.cc as i64
+                                                            ));
+
+                                                        self.machine_st.num_of_args += 1;
+                                                        self.indexed_try(offset);
+                                                        self.machine_st.num_of_args -= 1;
+                                                    }
+                                                    None => {
+                                                        self.machine_st.p = p + offset;
+                                                        self.machine_st.oip = 0;
+                                                        self.machine_st.iip = 0;
+                                                    }
+                                                }
+                                            }
+                                            FirstOrNext::Next => {
+                                                let b = self.machine_st.b;
+                                                let n = self
+                                                    .machine_st
+                                                    .stack
+                                                    .index_or_frame(b)
+                                                    .prelude
+                                                    .num_cells;
+
+                                                self.machine_st.cc = cell_as_fixnum!(
+                                                    self.machine_st.stack
+                                                        [stack_loc!(OrFrame, b, n - 1)]
+                                                )
+                                                .get_num()
+                                                    as usize;
+
+                                                if is_next_clause {
+                                                    match self.find_living_dynamic(
+                                                        self.machine_st.oip,
+                                                        self.machine_st.iip + 1,
+                                                    ) {
+                                                        // if we're executing the last instruction
+                                                        // of the internal block pointed to by
+                                                        // self.machine_st.iip, we want trust, not retry.
+                                                        // this is true iff ii + 1 < len.
+                                                        Some(_) => {
+                                                            self.retry(offset);
+
+                                                            try_or_throw!(
+                                                                self.machine_st,
+                                                                (self
+                                                                    .machine_st
+                                                                    .increment_call_count_fn)(
+                                                                    &mut self.machine_st
+                                                                )
+                                                            );
+                                                        }
+                                                        _ => {
+                                                            self.trust(offset);
+
+                                                            try_or_throw!(
+                                                                self.machine_st,
+                                                                (self
+                                                                    .machine_st
+                                                                    .increment_call_count_fn)(
+                                                                    &mut self.machine_st
+                                                                )
+                                                            );
+                                                        }
+                                                    }
+                                                } else {
+                                                    self.trust(offset);
+
+                                                    try_or_throw!(
+                                                        self.machine_st,
+                                                        (self.machine_st.increment_call_count_fn)(
+                                                            &mut self.machine_st
+                                                        )
+                                                    );
+                                                }
+                                            }
+                                        }
+                                    }
+                                    None => {
+                                        self.machine_st.fail = true;
+                                    }
+                                }
+
+                                self.machine_st.dynamic_mode = FirstOrNext::Next;
+
+                                if self.machine_st.fail {
+                                    self.machine_st.backtrack();
+                                }
+                            }
+                        }
+                    }
+                    &Instruction::PutConstant(_, c, reg) => {
+                        self.machine_st[reg] = c;
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::PutList(_, reg) => {
+                        self.machine_st[reg] = list_loc_as_cell!(self.machine_st.heap.len());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::PutPartialString(_, string, reg, has_tail) => {
+                        let pstr_addr = if has_tail {
+                            if string != atom!("") {
+                                let h = self.machine_st.heap.len();
+                                self.machine_st.heap.push(string_as_pstr_cell!(string));
+
+                                // the tail will be pushed by the next
+                                // instruction, so don't push one here.
+
+                                pstr_loc_as_cell!(h)
+                            } else {
+                                empty_list_as_cell!()
+                            }
+                        } else {
+                            string_as_cstr_cell!(string)
+                        };
+
+                        self.machine_st[reg] = pstr_addr;
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::PutStructure(name, arity, reg) => {
+                        let h = self.machine_st.heap.len();
+
+                        self.machine_st.heap.push(atom_as_cell!(name, arity));
+                        self.machine_st[reg] = str_loc_as_cell!(h);
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::PutUnsafeValue(perm_slot, arg) => {
+                        let s = stack_loc!(AndFrame, self.machine_st.e, perm_slot);
+                        let addr = self
+                            .machine_st
+                            .store(self.machine_st.deref(stack_loc_as_cell!(s)));
+
+                        if addr.is_protected(self.machine_st.e) {
+                            self.machine_st.registers[arg] = addr;
+                        } else {
+                            let h = self.machine_st.heap.len();
+
+                            self.machine_st.heap.push(heap_loc_as_cell!(h));
+                            (self.machine_st.bind_fn)(
+                                &mut self.machine_st,
+                                Ref::heap_cell(h),
+                                addr,
+                            );
+
+                            self.machine_st.registers[arg] = heap_loc_as_cell!(h);
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::PutValue(norm, arg) => {
+                        self.machine_st.registers[arg] = self.machine_st[norm];
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::PutVariable(norm, arg) => {
+                        match norm {
+                            RegType::Perm(n) => {
+                                self.machine_st[norm] =
+                                    stack_loc_as_cell!(AndFrame, self.machine_st.e, n);
+                                self.machine_st.registers[arg] = self.machine_st[norm];
+                            }
+                            RegType::Temp(_) => {
+                                let h = self.machine_st.heap.len();
+                                self.machine_st.heap.push(heap_loc_as_cell!(h));
+
+                                self.machine_st[norm] = heap_loc_as_cell!(h);
+                                self.machine_st.registers[arg] = heap_loc_as_cell!(h);
+                            }
+                        };
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::SetConstant(c) => {
+                        self.machine_st.heap.push(c);
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::SetLocalValue(reg) => {
+                        let addr = self.machine_st.deref(self.machine_st[reg]);
+                        let stored_v = self.machine_st.store(addr);
+
+                        if stored_v.is_stack_var() {
+                            let h = self.machine_st.heap.len();
+                            self.machine_st.heap.push(heap_loc_as_cell!(h));
+                            (self.machine_st.bind_fn)(
+                                &mut self.machine_st,
+                                Ref::heap_cell(h),
+                                stored_v,
+                            );
+                        } else {
+                            self.machine_st.heap.push(stored_v);
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::SetVariable(reg) => {
+                        let h = self.machine_st.heap.len();
+
+                        self.machine_st.heap.push(heap_loc_as_cell!(h));
+                        self.machine_st[reg] = heap_loc_as_cell!(h);
+
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::SetValue(reg) => {
+                        let heap_val = self.machine_st.store(self.machine_st[reg]);
+                        self.machine_st.heap.push(heap_val);
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::SetVoid(n) => {
+                        let h = self.machine_st.heap.len();
+
+                        for i in h..h + n {
+                            self.machine_st.heap.push(heap_loc_as_cell!(i));
+                        }
+
+                        self.machine_st.p += 1;
+                    }
+                    //
+                    &Instruction::CallAtomChars => {
+                        self.atom_chars();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteAtomChars => {
+                        self.atom_chars();
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallAtomCodes => {
+                        try_or_throw!(self.machine_st, self.atom_codes());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteAtomCodes => {
+                        try_or_throw!(self.machine_st, self.atom_codes());
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        } else {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallAtomLength => {
+                        self.atom_length();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteAtomLength => {
+                        self.atom_length();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallBindFromRegister => {
+                        self.bind_from_register();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteBindFromRegister => {
+                        self.bind_from_register();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallContinuation => {
+                        try_or_throw!(self.machine_st, self.call_continuation(false));
+                    }
+                    &Instruction::ExecuteContinuation => {
+                        try_or_throw!(self.machine_st, self.call_continuation(true));
+                    }
+                    &Instruction::CallCharCode => {
+                        try_or_throw!(self.machine_st, self.char_code());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCharCode => {
+                        try_or_throw!(self.machine_st, self.char_code());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCharType => {
+                        self.char_type();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCharType => {
+                        self.char_type();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCharsToNumber => {
+                        try_or_throw!(self.machine_st, self.chars_to_number());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCharsToNumber => {
+                        try_or_throw!(self.machine_st, self.chars_to_number());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCodesToNumber => {
+                        try_or_throw!(self.machine_st, self.codes_to_number());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCodesToNumber => {
+                        try_or_throw!(self.machine_st, self.codes_to_number());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCopyTermWithoutAttrVars => {
+                        self.copy_term_without_attr_vars();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCopyTermWithoutAttrVars => {
+                        self.copy_term_without_attr_vars();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCheckCutPoint => {
+                        self.check_cut_point();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCheckCutPoint => {
+                        self.check_cut_point();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallClose => {
+                        try_or_throw!(self.machine_st, self.close());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteClose => {
+                        try_or_throw!(self.machine_st, self.close());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallCopyToLiftedHeap => {
+                        self.copy_to_lifted_heap();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteCopyToLiftedHeap => {
+                        self.copy_to_lifted_heap();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallCreatePartialString => {
+                        self.create_partial_string();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCreatePartialString => {
+                        self.create_partial_string();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCurrentHostname => {
+                        self.current_hostname();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCurrentHostname => {
+                        self.current_hostname();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCurrentInput => {
+                        try_or_throw!(self.machine_st, self.current_input());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCurrentInput => {
+                        try_or_throw!(self.machine_st, self.current_input());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCurrentOutput => {
+                        try_or_throw!(self.machine_st, self.current_output());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCurrentOutput => {
+                        try_or_throw!(self.machine_st, self.current_output());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDirectoryFiles => {
+                        try_or_throw!(self.machine_st, self.directory_files());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDirectoryFiles => {
+                        try_or_throw!(self.machine_st, self.directory_files());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallFileSize => {
+                        self.file_size();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteFileSize => {
+                        self.file_size();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallFileExists => {
+                        self.file_exists();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteFileExists => {
+                        self.file_exists();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDirectoryExists => {
+                        self.directory_exists();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDirectoryExists => {
+                        self.directory_exists();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDirectorySeparator => {
+                        self.directory_separator();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDirectorySeparator => {
+                        self.directory_separator();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallMakeDirectory => {
+                        self.make_directory();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteMakeDirectory => {
+                        self.make_directory();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallMakeDirectoryPath => {
+                        self.make_directory_path();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteMakeDirectoryPath => {
+                        self.make_directory_path();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDeleteFile => {
+                        self.delete_file();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDeleteFile => {
+                        self.delete_file();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallRenameFile => {
+                        self.rename_file();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteRenameFile => {
+                        self.rename_file();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallFileCopy => {
+                        self.file_copy();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteFileCopy => {
+                        self.file_copy();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallWorkingDirectory => {
+                        try_or_throw!(self.machine_st, self.working_directory());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteWorkingDirectory => {
+                        try_or_throw!(self.machine_st, self.working_directory());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDeleteDirectory => {
+                        self.delete_directory();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDeleteDirectory => {
+                        self.delete_directory();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPathCanonical => {
+                        try_or_throw!(self.machine_st, self.path_canonical());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePathCanonical => {
+                        try_or_throw!(self.machine_st, self.path_canonical());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallFileTime => {
+                        self.file_time();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteFileTime => {
+                        self.file_time();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDynamicModuleResolution(arity) => {
+                        let (module_name, key) = try_or_throw!(
+                            self.machine_st,
+                            self.dynamic_module_resolution(arity - 2)
+                        );
+
+                        try_or_throw!(self.machine_st, self.call_clause(module_name, key));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::ExecuteDynamicModuleResolution(arity) => {
+                        let (module_name, key) = try_or_throw!(
+                            self.machine_st,
+                            self.dynamic_module_resolution(arity - 2)
+                        );
+
+                        try_or_throw!(self.machine_st, self.execute_clause(module_name, key));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::CallFetchGlobalVar => {
+                        self.fetch_global_var();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteFetchGlobalVar => {
+                        self.fetch_global_var();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallFirstStream => {
+                        self.first_stream();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteFirstStream => {
+                        self.first_stream();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallFlushOutput => {
+                        try_or_throw!(self.machine_st, self.flush_output());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteFlushOutput => {
+                        try_or_throw!(self.machine_st, self.flush_output());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallGetByte => {
+                        try_or_throw!(self.machine_st, self.get_byte());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetByte => {
+                        try_or_throw!(self.machine_st, self.get_byte());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetChar => {
+                        try_or_throw!(self.machine_st, self.get_char());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetChar => {
+                        try_or_throw!(self.machine_st, self.get_char());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetNChars => {
+                        try_or_throw!(self.machine_st, self.get_n_chars());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetNChars => {
+                        try_or_throw!(self.machine_st, self.get_n_chars());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetCode => {
+                        try_or_throw!(self.machine_st, self.get_code());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetCode => {
+                        try_or_throw!(self.machine_st, self.get_code());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetSingleChar => {
+                        try_or_throw!(self.machine_st, self.get_single_char());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetSingleChar => {
+                        try_or_throw!(self.machine_st, self.get_single_char());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallTruncateIfNoLiftedHeapGrowthDiff => {
+                        self.truncate_if_no_lifted_heap_growth_diff();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteTruncateIfNoLiftedHeapGrowthDiff => {
+                        self.truncate_if_no_lifted_heap_growth_diff();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallTruncateIfNoLiftedHeapGrowth => {
+                        self.truncate_if_no_lifted_heap_growth();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteTruncateIfNoLiftedHeapGrowth => {
+                        self.truncate_if_no_lifted_heap_growth();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetAttributedVariableList => {
+                        self.get_attributed_variable_list();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetAttributedVariableList => {
+                        self.get_attributed_variable_list();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetAttrVarQueueDelimiter => {
+                        self.get_attr_var_queue_delimiter();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetAttrVarQueueDelimiter => {
+                        self.get_attr_var_queue_delimiter();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetAttrVarQueueBeyond => {
+                        self.get_attr_var_queue_beyond();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetAttrVarQueueBeyond => {
+                        self.get_attr_var_queue_beyond();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetBValue => {
+                        self.get_b_value();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetBValue => {
+                        self.get_b_value();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetContinuationChunk => {
+                        self.get_continuation_chunk();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetContinuationChunk => {
+                        self.get_continuation_chunk();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLookupDBRef => {
+                        self.lookup_db_ref();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLookupDBRef => {
+                        self.lookup_db_ref();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetNextOpDBRef => {
+                        self.get_next_op_db_ref();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetNextOpDBRef => {
+                        self.get_next_op_db_ref();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallIsPartialString => {
+                        self.is_partial_string();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteIsPartialString => {
+                        self.is_partial_string();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallHalt | &Instruction::ExecuteHalt => {
+                        return self.halt();
+                    }
+                    &Instruction::CallGetLiftedHeapFromOffset => {
+                        self.get_lifted_heap_from_offset();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetLiftedHeapFromOffset => {
+                        self.get_lifted_heap_from_offset();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetLiftedHeapFromOffsetDiff => {
+                        self.get_lifted_heap_from_offset_diff();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetLiftedHeapFromOffsetDiff => {
+                        self.get_lifted_heap_from_offset_diff();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetSCCCleaner => {
+                        self.get_scc_cleaner();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetSCCCleaner => {
+                        self.get_scc_cleaner();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallHeadIsDynamic => {
+                        self.head_is_dynamic();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteHeadIsDynamic => {
+                        self.head_is_dynamic();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallInstallSCCCleaner => {
+                        self.install_scc_cleaner();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteInstallSCCCleaner => {
+                        self.install_scc_cleaner();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallInstallInferenceCounter => {
+                        try_or_throw!(self.machine_st, self.install_inference_counter());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteInstallInferenceCounter => {
+                        try_or_throw!(self.machine_st, self.install_inference_counter());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLiftedHeapLength => {
+                        self.lifted_heap_length();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLiftedHeapLength => {
+                        self.lifted_heap_length();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLoadLibraryAsStream => {
+                        try_or_throw!(self.machine_st, self.load_library_as_stream());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadLibraryAsStream => {
+                        try_or_throw!(self.machine_st, self.load_library_as_stream());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallModuleExists => {
+                        self.module_exists();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteModuleExists => {
+                        self.module_exists();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallNextEP => {
+                        self.next_ep();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteNextEP => {
+                        self.next_ep();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallNoSuchPredicate => {
+                        try_or_throw!(self.machine_st, self.no_such_predicate());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteNoSuchPredicate => {
+                        try_or_throw!(self.machine_st, self.no_such_predicate());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallNumberToChars => {
+                        self.number_to_chars();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteNumberToChars => {
+                        self.number_to_chars();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallNumberToCodes => {
+                        self.number_to_codes();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteNumberToCodes => {
+                        self.number_to_codes();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallOpDeclaration => {
+                        try_or_throw!(self.machine_st, self.op_declaration());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteOpDeclaration => {
+                        try_or_throw!(self.machine_st, self.op_declaration());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallOpen => {
+                        try_or_throw!(self.machine_st, self.open());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteOpen => {
+                        try_or_throw!(self.machine_st, self.open());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSetStreamOptions => {
+                        try_or_throw!(self.machine_st, self.set_stream_options());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSetStreamOptions => {
+                        try_or_throw!(self.machine_st, self.set_stream_options());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallNextStream => {
+                        self.next_stream();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteNextStream => {
+                        self.next_stream();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPartialStringTail => {
+                        self.partial_string_tail();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePartialStringTail => {
+                        self.partial_string_tail();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPeekByte => {
+                        try_or_throw!(self.machine_st, self.peek_byte());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePeekByte => {
+                        try_or_throw!(self.machine_st, self.peek_byte());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPeekChar => {
+                        try_or_throw!(self.machine_st, self.peek_char());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePeekChar => {
+                        try_or_throw!(self.machine_st, self.peek_char());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPeekCode => {
+                        try_or_throw!(self.machine_st, self.peek_code());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePeekCode => {
+                        try_or_throw!(self.machine_st, self.peek_code());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPointsToContinuationResetMarker => {
+                        self.points_to_continuation_reset_marker();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePointsToContinuationResetMarker => {
+                        self.points_to_continuation_reset_marker();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPutByte => {
+                        try_or_throw!(self.machine_st, self.put_byte());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecutePutByte => {
+                        try_or_throw!(self.machine_st, self.put_byte());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallPutChar => {
+                        try_or_throw!(self.machine_st, self.put_char());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecutePutChar => {
+                        try_or_throw!(self.machine_st, self.put_char());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallPutChars => {
+                        try_or_throw!(self.machine_st, self.put_chars());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePutChars => {
+                        try_or_throw!(self.machine_st, self.put_chars());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPutCode => {
+                        try_or_throw!(self.machine_st, self.put_code());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecutePutCode => {
+                        try_or_throw!(self.machine_st, self.put_code());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallReadQueryTerm => {
+                        try_or_throw!(self.machine_st, self.read_query_term());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteReadQueryTerm => {
+                        try_or_throw!(self.machine_st, self.read_query_term());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallReadTerm => {
+                        try_or_throw!(self.machine_st, self.read_term());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteReadTerm => {
+                        try_or_throw!(self.machine_st, self.read_term());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallRedoAttrVarBinding => {
+                        self.redo_attr_var_binding();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteRedoAttrVarBinding => {
+                        self.redo_attr_var_binding();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallRemoveCallPolicyCheck => {
+                        self.remove_call_policy_check();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteRemoveCallPolicyCheck => {
+                        self.remove_call_policy_check();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallRemoveInferenceCounter => {
+                        self.remove_inference_counter();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteRemoveInferenceCounter => {
+                        self.remove_inference_counter();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallResetContinuationMarker => {
+                        self.reset_continuation_marker();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteResetContinuationMarker => {
+                        self.reset_continuation_marker();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallRestoreCutPolicy => {
+                        self.restore_cut_policy();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteRestoreCutPolicy => {
+                        self.restore_cut_policy();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallSetCutPoint(r) => {
+                        if !self.set_cut_point(r) {
+                            step_or_fail!(self, self.machine_st.p += 1);
+                        }
+                    }
+                    &Instruction::ExecuteSetCutPoint(r) => {
+                        let cp = self.machine_st.cp;
+
+                        if !self.set_cut_point(r) {
+                            step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                        } else {
+                            // run_cleaners in set_cut_point calls call_by_index.
+                            // replace the effect of call_by_index with that
+                            // of execute_by_index here.
+
+                            self.machine_st.cp = cp;
+                        }
+                    }
+                    &Instruction::CallSetInput => {
+                        try_or_throw!(self.machine_st, self.set_input());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSetInput => {
+                        try_or_throw!(self.machine_st, self.set_input());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallSetOutput => {
+                        try_or_throw!(self.machine_st, self.set_output());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSetOutput => {
+                        try_or_throw!(self.machine_st, self.set_output());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallStoreBacktrackableGlobalVar => {
+                        self.store_backtrackable_global_var();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteStoreBacktrackableGlobalVar => {
+                        self.store_backtrackable_global_var();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallStoreGlobalVar => {
+                        self.store_global_var();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteStoreGlobalVar => {
+                        self.store_global_var();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallStreamProperty => {
+                        try_or_throw!(self.machine_st, self.stream_property());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteStreamProperty => {
+                        try_or_throw!(self.machine_st, self.stream_property());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSetStreamPosition => {
+                        try_or_throw!(self.machine_st, self.set_stream_position());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSetStreamPosition => {
+                        try_or_throw!(self.machine_st, self.set_stream_position());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallInferenceLevel => {
+                        self.inference_level();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteInferenceLevel => {
+                        self.inference_level();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCleanUpBlock => {
+                        self.clean_up_block();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteCleanUpBlock => {
+                        self.clean_up_block();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallFail | &Instruction::ExecuteFail => {
+                        self.machine_st.backtrack();
+                    }
+                    &Instruction::CallGetBall => {
+                        self.get_ball();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetBall => {
+                        self.get_ball();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetCurrentBlock => {
+                        self.get_current_block();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetCurrentBlock => {
+                        self.get_current_block();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetCurrentSCCBlock => {
+                        self.get_current_scc_block();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetCurrentSCCBlock => {
+                        self.get_current_scc_block();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetCutPoint => {
+                        self.get_cut_point();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetCutPoint => {
+                        self.get_cut_point();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetDoubleQuotes => {
+                        self.get_double_quotes();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetDoubleQuotes => {
+                        self.get_double_quotes();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetUnknown => {
+                        self.get_unknown();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetUnknown => {
+                        self.get_unknown();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallInstallNewBlock => {
+                        self.machine_st
+                            .install_new_block(self.machine_st.registers[1]);
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteInstallNewBlock => {
+                        self.machine_st
+                            .install_new_block(self.machine_st.registers[1]);
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallMaybe => {
+                        self.maybe();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteMaybe => {
+                        self.maybe();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCpuNow => {
+                        self.cpu_now();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCpuNow => {
+                        self.cpu_now();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDeterministicLengthRundown => {
+                        try_or_throw!(self.machine_st, self.det_length_rundown());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDeterministicLengthRundown => {
+                        try_or_throw!(self.machine_st, self.det_length_rundown());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallHttpOpen => {
+                        #[cfg(feature = "http")]
+                        try_or_throw!(self.machine_st, self.http_open());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteHttpOpen => {
+                        #[cfg(feature = "http")]
+                        try_or_throw!(self.machine_st, self.http_open());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallHttpListen => {
+                        #[cfg(feature = "http")]
+                        try_or_throw!(self.machine_st, self.http_listen());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteHttpListen => {
+                        #[cfg(feature = "http")]
+                        try_or_throw!(self.machine_st, self.http_listen());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallHttpAccept => {
+                        #[cfg(feature = "http")]
+                        try_or_throw!(self.machine_st, self.http_accept());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteHttpAccept => {
+                        #[cfg(feature = "http")]
+                        try_or_throw!(self.machine_st, self.http_accept());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallHttpAnswer => {
+                        #[cfg(feature = "http")]
+                        try_or_throw!(self.machine_st, self.http_answer());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteHttpAnswer => {
+                        #[cfg(feature = "http")]
+                        try_or_throw!(self.machine_st, self.http_answer());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLoadForeignLib => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.load_foreign_lib());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadForeignLib => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.load_foreign_lib());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallForeignCall => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.foreign_call());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteForeignCall => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.foreign_call());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDefineForeignStruct => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.define_foreign_struct());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDefineForeignStruct => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.define_foreign_struct());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCurrentTime => {
+                        self.current_time();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCurrentTime => {
+                        self.current_time();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallQuotedToken => {
+                        self.quoted_token();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteQuotedToken => {
+                        self.quoted_token();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallReadFromChars => {
+                        try_or_throw!(self.machine_st, self.read_from_chars());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteReadFromChars => {
+                        try_or_throw!(self.machine_st, self.read_from_chars());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallReadTermFromChars => {
+                        try_or_throw!(self.machine_st, self.read_term_from_chars());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteReadTermFromChars => {
+                        try_or_throw!(self.machine_st, self.read_term_from_chars());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallResetBlock => {
+                        self.reset_block();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteResetBlock => {
+                        self.reset_block();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallResetSCCBlock => {
+                        self.reset_scc_block();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteResetSCCBlock => {
+                        self.reset_scc_block();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallReturnFromVerifyAttr
+                    | &Instruction::ExecuteReturnFromVerifyAttr => {
+                        self.return_from_verify_attr();
+                    }
+                    &Instruction::CallSetBall => {
+                        self.set_ball();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSetBall => {
+                        self.set_ball();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallPushBallStack => {
+                        self.push_ball_stack();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePushBallStack => {
+                        self.push_ball_stack();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPopBallStack => {
+                        self.pop_ball_stack();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecutePopBallStack => {
+                        self.pop_ball_stack();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallPopFromBallStack => {
+                        self.pop_from_ball_stack();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecutePopFromBallStack => {
+                        self.pop_from_ball_stack();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallSetCutPointByDefault(r) => {
+                        self.set_cut_point_by_default(r);
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSetCutPointByDefault(r) => {
+                        self.set_cut_point_by_default(r);
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSetDoubleQuotes => {
+                        self.set_double_quotes();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSetDoubleQuotes => {
+                        self.set_double_quotes();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSetUnknown => {
+                        self.set_unknown();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSetUnknown => {
+                        self.set_unknown();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSetSeed => {
+                        self.set_seed();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSetSeed => {
+                        self.set_seed();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSkipMaxList => {
+                        try_or_throw!(self.machine_st, self.machine_st.skip_max_list());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSkipMaxList => {
+                        try_or_throw!(self.machine_st, self.machine_st.skip_max_list());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSleep => {
+                        self.sleep();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSleep => {
+                        self.sleep();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallSocketClientOpen => {
+                        try_or_throw!(self.machine_st, self.socket_client_open());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSocketClientOpen => {
+                        try_or_throw!(self.machine_st, self.socket_client_open());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSocketServerOpen => {
+                        try_or_throw!(self.machine_st, self.socket_server_open());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSocketServerOpen => {
+                        try_or_throw!(self.machine_st, self.socket_server_open());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSocketServerAccept => {
+                        try_or_throw!(self.machine_st, self.socket_server_accept());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSocketServerAccept => {
+                        try_or_throw!(self.machine_st, self.socket_server_accept());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSocketServerClose => {
+                        try_or_throw!(self.machine_st, self.socket_server_close());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSocketServerClose => {
+                        try_or_throw!(self.machine_st, self.socket_server_close());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallTLSAcceptClient => {
+                        #[cfg(feature = "tls")]
+                        try_or_throw!(self.machine_st, self.tls_accept_client());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteTLSAcceptClient => {
+                        #[cfg(feature = "tls")]
+                        try_or_throw!(self.machine_st, self.tls_accept_client());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallTLSClientConnect => {
+                        #[cfg(feature = "tls")]
+                        try_or_throw!(self.machine_st, self.tls_client_connect());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteTLSClientConnect => {
+                        #[cfg(feature = "tls")]
+                        try_or_throw!(self.machine_st, self.tls_client_connect());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSucceed => {
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSucceed => {
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallTermAttributedVariables => {
+                        self.term_attributed_variables();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteTermAttributedVariables => {
+                        self.term_attributed_variables();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallTermVariables => {
+                        self.term_variables();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteTermVariables => {
+                        self.term_variables();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallTermVariablesUnderMaxDepth => {
+                        self.term_variables_under_max_depth();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteTermVariablesUnderMaxDepth => {
+                        self.term_variables_under_max_depth();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallTruncateLiftedHeapTo => {
+                        self.truncate_lifted_heap_to();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteTruncateLiftedHeapTo => {
+                        self.truncate_lifted_heap_to();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallUnifyWithOccursCheck => {
+                        self.unify_with_occurs_check();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteUnifyWithOccursCheck => {
+                        self.unify_with_occurs_check();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallUnwindEnvironments => {
+                        if !self.unwind_environments() {
+                            self.machine_st.p += 1;
+                        }
+                    }
+                    &Instruction::ExecuteUnwindEnvironments => {
+                        if !self.unwind_environments() {
+                            self.machine_st.p = self.machine_st.cp;
+                        }
+                    }
+                    &Instruction::CallUnwindStack | &Instruction::ExecuteUnwindStack => {
+                        self.machine_st.unwind_stack();
+                        self.machine_st.backtrack();
+                    }
+                    &Instruction::CallWAMInstructions => {
+                        try_or_throw!(self.machine_st, self.wam_instructions());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteWAMInstructions => {
+                        try_or_throw!(self.machine_st, self.wam_instructions());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallInlinedInstructions => {
+                        self.inlined_instructions();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteInlinedInstructions => {
+                        self.inlined_instructions();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallWriteTerm => {
+                        try_or_throw!(self.machine_st, self.write_term());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteWriteTerm => {
+                        try_or_throw!(self.machine_st, self.write_term());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallWriteTermToChars => {
+                        try_or_throw!(self.machine_st, self.write_term_to_chars());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteWriteTermToChars => {
+                        try_or_throw!(self.machine_st, self.write_term_to_chars());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallScryerPrologVersion => {
+                        self.scryer_prolog_version();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteScryerPrologVersion => {
+                        self.scryer_prolog_version();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCryptoRandomByte => {
+                        self.crypto_random_byte();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCryptoRandomByte => {
+                        self.crypto_random_byte();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCryptoDataHash => {
+                        self.crypto_data_hash();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCryptoDataHash => {
+                        self.crypto_data_hash();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCryptoDataHKDF => {
+                        self.crypto_data_hkdf();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCryptoDataHKDF => {
+                        self.crypto_data_hkdf();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCryptoPasswordHash => {
+                        self.crypto_password_hash();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCryptoPasswordHash => {
+                        self.crypto_password_hash();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCryptoDataEncrypt => {
+                        self.crypto_data_encrypt();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCryptoDataEncrypt => {
+                        self.crypto_data_encrypt();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCryptoDataDecrypt => {
+                        self.crypto_data_decrypt();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCryptoDataDecrypt => {
+                        self.crypto_data_decrypt();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCryptoCurveScalarMult => {
+                        self.crypto_curve_scalar_mult();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCryptoCurveScalarMult => {
+                        self.crypto_curve_scalar_mult();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallEd25519Sign => {
+                        self.ed25519_sign();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteEd25519Sign => {
+                        self.ed25519_sign();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallEd25519Verify => {
+                        self.ed25519_verify();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteEd25519Verify => {
+                        self.ed25519_verify();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallEd25519NewKeyPair => {
+                        self.ed25519_new_key_pair();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteEd25519NewKeyPair => {
+                        self.ed25519_new_key_pair();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallEd25519KeyPairPublicKey => {
+                        self.ed25519_key_pair_public_key();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteEd25519KeyPairPublicKey => {
+                        self.ed25519_key_pair_public_key();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCurve25519ScalarMult => {
+                        self.curve25519_scalar_mult();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCurve25519ScalarMult => {
+                        self.curve25519_scalar_mult();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallFirstNonOctet => {
+                        self.first_non_octet();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteFirstNonOctet => {
+                        self.first_non_octet();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLoadHTML => {
+                        self.load_html();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadHTML => {
+                        self.load_html();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLoadXML => {
+                        self.load_xml();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadXML => {
+                        self.load_xml();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetEnv => {
+                        self.get_env();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetEnv => {
+                        self.get_env();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSetEnv => {
+                        self.set_env();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSetEnv => {
+                        self.set_env();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallUnsetEnv => {
+                        self.unset_env();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteUnsetEnv => {
+                        self.unset_env();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallShell => {
+                        self.shell();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteShell => {
+                        self.shell();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPID => {
+                        self.pid();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePID => {
+                        self.pid();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCharsBase64 => {
+                        try_or_throw!(self.machine_st, self.chars_base64());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCharsBase64 => {
+                        try_or_throw!(self.machine_st, self.chars_base64());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDevourWhitespace => {
+                        try_or_throw!(self.machine_st, self.devour_whitespace());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDevourWhitespace => {
+                        try_or_throw!(self.machine_st, self.devour_whitespace());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallIsSTOEnabled => {
+                        self.is_sto_enabled();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteIsSTOEnabled => {
+                        self.is_sto_enabled();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallSetSTOAsUnify => {
+                        self.set_sto_as_unify();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSetSTOAsUnify => {
+                        self.set_sto_as_unify();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallSetNSTOAsUnify => {
+                        self.set_nsto_as_unify();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSetNSTOAsUnify => {
+                        self.set_nsto_as_unify();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallSetSTOWithErrorAsUnify => {
+                        self.set_sto_with_error_as_unify();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteSetSTOWithErrorAsUnify => {
+                        self.set_sto_with_error_as_unify();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallHomeDirectory => {
+                        self.home_directory();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteHomeDirectory => {
+                        self.home_directory();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDebugHook => {
+                        self.debug_hook();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteDebugHook => {
+                        self.debug_hook();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallPopCount => {
+                        self.pop_count();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePopCount => {
+                        self.pop_count();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallAddDiscontiguousPredicate => {
+                        try_or_throw!(self.machine_st, self.add_discontiguous_predicate());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAddDiscontiguousPredicate => {
+                        try_or_throw!(self.machine_st, self.add_discontiguous_predicate());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallAddDynamicPredicate => {
+                        try_or_throw!(self.machine_st, self.add_dynamic_predicate());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAddDynamicPredicate => {
+                        try_or_throw!(self.machine_st, self.add_dynamic_predicate());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallAddMultifilePredicate => {
+                        try_or_throw!(self.machine_st, self.add_multifile_predicate());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAddMultifilePredicate => {
+                        try_or_throw!(self.machine_st, self.add_multifile_predicate());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallAddGoalExpansionClause => {
+                        try_or_throw!(self.machine_st, self.add_goal_expansion_clause());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAddGoalExpansionClause => {
+                        try_or_throw!(self.machine_st, self.add_goal_expansion_clause());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallAddTermExpansionClause => {
+                        try_or_throw!(self.machine_st, self.add_term_expansion_clause());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAddTermExpansionClause => {
+                        try_or_throw!(self.machine_st, self.add_term_expansion_clause());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallAddInSituFilenameModule => {
+                        try_or_throw!(self.machine_st, self.add_in_situ_filename_module());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAddInSituFilenameModule => {
+                        try_or_throw!(self.machine_st, self.add_in_situ_filename_module());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallClauseToEvacuable => {
+                        try_or_throw!(self.machine_st, self.clause_to_evacuable());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteClauseToEvacuable => {
+                        try_or_throw!(self.machine_st, self.clause_to_evacuable());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallScopedClauseToEvacuable => {
+                        try_or_throw!(self.machine_st, self.scoped_clause_to_evacuable());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteScopedClauseToEvacuable => {
+                        try_or_throw!(self.machine_st, self.scoped_clause_to_evacuable());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallConcludeLoad => {
+                        try_or_throw!(self.machine_st, self.conclude_load());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteConcludeLoad => {
+                        try_or_throw!(self.machine_st, self.conclude_load());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallDeclareModule => {
+                        try_or_throw!(self.machine_st, self.declare_module());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteDeclareModule => {
+                        try_or_throw!(self.machine_st, self.declare_module());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallLoadCompiledLibrary => {
+                        try_or_throw!(self.machine_st, self.load_compiled_library());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadCompiledLibrary => {
+                        try_or_throw!(self.machine_st, self.load_compiled_library());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLoadContextSource => {
+                        self.load_context_source();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadContextSource => {
+                        self.load_context_source();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLoadContextFile => {
+                        self.load_context_file();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadContextFile => {
+                        self.load_context_file();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLoadContextDirectory => {
+                        self.load_context_directory();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadContextDirectory => {
+                        self.load_context_directory();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLoadContextModule => {
+                        self.load_context_module(self.machine_st.registers[1]);
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadContextModule => {
+                        self.load_context_module(self.machine_st.registers[1]);
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallLoadContextStream => {
+                        self.load_context_stream();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteLoadContextStream => {
+                        self.load_context_stream();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPopLoadContext => {
+                        self.pop_load_context();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecutePopLoadContext => {
+                        self.pop_load_context();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallPopLoadStatePayload => {
+                        self.pop_load_state_payload();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecutePopLoadStatePayload => {
+                        self.pop_load_state_payload();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallPushLoadContext => {
+                        try_or_throw!(self.machine_st, self.push_load_context());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecutePushLoadContext => {
+                        try_or_throw!(self.machine_st, self.push_load_context());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallPushLoadStatePayload => {
+                        self.push_load_state_payload();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePushLoadStatePayload => {
+                        self.push_load_state_payload();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallUseModule => {
+                        try_or_throw!(self.machine_st, self.use_module());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteUseModule => {
+                        try_or_throw!(self.machine_st, self.use_module());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallBuiltInProperty => {
+                        let key = self.machine_st.read_predicate_key(
+                            self.machine_st.registers[1],
+                            self.machine_st.registers[2],
+                        );
+
+                        self.machine_st.fail = !self.indices.builtin_property(key);
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteBuiltInProperty => {
+                        let key = self.machine_st.read_predicate_key(
+                            self.machine_st.registers[1],
+                            self.machine_st.registers[2],
+                        );
+
+                        self.machine_st.fail = !self.indices.builtin_property(key);
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallMetaPredicateProperty => {
+                        self.meta_predicate_property();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteMetaPredicateProperty => {
+                        self.meta_predicate_property();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallMultifileProperty => {
+                        self.multifile_property();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteMultifileProperty => {
+                        self.multifile_property();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDiscontiguousProperty => {
+                        self.discontiguous_property();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDiscontiguousProperty => {
+                        self.discontiguous_property();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDynamicProperty => {
+                        self.dynamic_property();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDynamicProperty => {
+                        self.dynamic_property();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallAbolishClause => {
+                        try_or_throw!(self.machine_st, self.abolish_clause());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAbolishClause => {
+                        try_or_throw!(self.machine_st, self.abolish_clause());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallAsserta => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.compile_assert(AppendOrPrepend::Prepend)
+                        );
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAsserta => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.compile_assert(AppendOrPrepend::Prepend)
+                        );
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallAssertz => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.compile_assert(AppendOrPrepend::Append)
+                        );
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAssertz => {
+                        try_or_throw!(
+                            self.machine_st,
+                            self.compile_assert(AppendOrPrepend::Append)
+                        );
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallRetract => {
+                        try_or_throw!(self.machine_st, self.retract_clause());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteRetract => {
+                        try_or_throw!(self.machine_st, self.retract_clause());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallIsConsistentWithTermQueue => {
+                        try_or_throw!(self.machine_st, self.is_consistent_with_term_queue());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteIsConsistentWithTermQueue => {
+                        try_or_throw!(self.machine_st, self.is_consistent_with_term_queue());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::CallFlushTermQueue => {
+                        try_or_throw!(self.machine_st, self.flush_term_queue());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteFlushTermQueue => {
+                        try_or_throw!(self.machine_st, self.flush_term_queue());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallRemoveModuleExports => {
+                        try_or_throw!(self.machine_st, self.remove_module_exports());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteRemoveModuleExports => {
+                        try_or_throw!(self.machine_st, self.remove_module_exports());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallAddNonCountedBacktracking => {
+                        try_or_throw!(self.machine_st, self.add_non_counted_backtracking());
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteAddNonCountedBacktracking => {
+                        try_or_throw!(self.machine_st, self.add_non_counted_backtracking());
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallPredicateDefined => {
+                        self.machine_st.fail = !self.predicate_defined();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePredicateDefined => {
+                        self.machine_st.fail = !self.predicate_defined();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallStripModule => {
+                        self.strip_module();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteStripModule => {
+                        self.strip_module();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPrepareCallClause(arity) => {
+                        try_or_throw!(self.machine_st, self.prepare_call_clause(arity));
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePrepareCallClause(arity) => {
+                        try_or_throw!(self.machine_st, self.prepare_call_clause(arity));
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallCompileInlineOrExpandedGoal => {
+                        try_or_throw!(self.machine_st, self.compile_inline_or_expanded_goal());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteCompileInlineOrExpandedGoal => {
+                        try_or_throw!(self.machine_st, self.compile_inline_or_expanded_goal());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallIsExpandedOrInlined => {
+                        self.machine_st.fail = !self.is_expanded_or_inlined();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteIsExpandedOrInlined => {
+                        self.machine_st.fail = !self.is_expanded_or_inlined();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallFastCallN(arity) => {
+                        let call_at_index =
+                            |wam: &mut Machine, name, arity, ptr| wam.try_call(name, arity, ptr);
+
+                        try_or_throw!(self.machine_st, self.fast_call(arity, call_at_index));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::ExecuteFastCallN(arity) => {
+                        let call_at_index =
+                            |wam: &mut Machine, name, arity, ptr| wam.try_execute(name, arity, ptr);
+
+                        try_or_throw!(self.machine_st, self.fast_call(arity, call_at_index));
+
+                        if self.machine_st.fail {
+                            self.machine_st.backtrack();
+                        }
+                    }
+                    &Instruction::CallGetClauseP => {
+                        let module_name = cell_as_atom!(self.deref_register(3));
+
+                        let (n, p) = self.get_clause_p(module_name);
+
+                        let r = self.machine_st.registers[2];
+                        let r = self.machine_st.store(self.machine_st.deref(r));
+
+                        let h = self.machine_st.heap.len();
+                        self.machine_st
+                            .heap
+                            .extend(functor!(atom!("-"), [fixnum(n), fixnum(p)]));
+
+                        let r = r.as_var().unwrap();
+                        self.machine_st.bind(r, str_loc_as_cell!(h));
+
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetClauseP => {
+                        let module_name = cell_as_atom!(self.deref_register(3));
+
+                        let (n, p) = self.get_clause_p(module_name);
+
+                        let r = self.machine_st.registers[2];
+                        let r = self.machine_st.store(self.machine_st.deref(r));
+
+                        let h = self.machine_st.heap.len();
+                        self.machine_st
+                            .heap
+                            .extend(functor!(atom!("-"), [fixnum(n), fixnum(p)]));
+
+                        let r = r.as_var().unwrap();
+                        self.machine_st.bind(r, str_loc_as_cell!(h));
+
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallInvokeClauseAtP => {
+                        let key_cell = self.machine_st.registers[1];
+                        let key = self.machine_st.name_and_arity_from_heap(key_cell).unwrap();
+
+                        let l = self.machine_st.registers[3];
+                        let l = self.machine_st.store(self.machine_st.deref(l));
+
+                        let l = match Number::try_from(l) {
+                            Ok(Number::Fixnum(l)) => l.get_num() as usize,
+                            _ => unreachable!(),
+                        };
+
+                        let p = self.machine_st.registers[4];
+                        let p = self.machine_st.store(self.machine_st.deref(p));
+
+                        let p = match Number::try_from(p) {
+                            Ok(Number::Fixnum(p)) => p.get_num() as usize,
+                            _ => unreachable!(),
+                        };
+
+                        let module_name = cell_as_atom!(self.deref_register(6));
+
+                        let compilation_target = match module_name {
+                            atom!("user") => CompilationTarget::User,
+                            _ => CompilationTarget::Module(module_name),
+                        };
+
+                        let skeleton = self
+                            .indices
+                            .get_predicate_skeleton_mut(&compilation_target, &key)
+                            .unwrap();
+
+                        match skeleton.target_pos_of_clause_clause_loc(l) {
+                            Some(n) => {
+                                let r = self
+                                    .machine_st
+                                    .store(self.machine_st.deref(self.machine_st.registers[5]));
+
+                                self.machine_st
+                                    .unify_fixnum(Fixnum::build_with(n as i64), r);
+                            }
+                            None => {}
+                        }
+
+                        self.machine_st.call_at_index(2, p);
+                    }
+                    &Instruction::ExecuteInvokeClauseAtP => {
+                        let key_cell = self.machine_st.registers[1];
+                        let key = self.machine_st.name_and_arity_from_heap(key_cell).unwrap();
+
+                        let l = self.machine_st.registers[3];
+                        let l = self.machine_st.store(self.machine_st.deref(l));
+
+                        let l = match Number::try_from(l) {
+                            Ok(Number::Fixnum(l)) => l.get_num() as usize,
+                            _ => unreachable!(),
+                        };
+
+                        let p = self.machine_st.registers[4];
+                        let p = self.machine_st.store(self.machine_st.deref(p));
+
+                        let p = match Number::try_from(p) {
+                            Ok(Number::Fixnum(p)) => p.get_num() as usize,
+                            _ => unreachable!(),
+                        };
+
+                        let module_name = cell_as_atom!(self.deref_register(6));
+
+                        let compilation_target = match module_name {
+                            atom!("user") => CompilationTarget::User,
+                            _ => CompilationTarget::Module(module_name),
+                        };
+
+                        let skeleton = self
+                            .indices
+                            .get_predicate_skeleton_mut(&compilation_target, &key)
+                            .unwrap();
+
+                        match skeleton.target_pos_of_clause_clause_loc(l) {
+                            Some(n) => {
+                                let r = self
+                                    .machine_st
+                                    .store(self.machine_st.deref(self.machine_st.registers[5]));
+
+                                self.machine_st
+                                    .unify_fixnum(Fixnum::build_with(n as i64), r);
+                            }
+                            None => {}
+                        }
+
+                        self.machine_st.execute_at_index(2, p);
+                    }
+                    &Instruction::CallGetFromAttributedVarList => {
+                        self.get_from_attributed_variable_list();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetFromAttributedVarList => {
+                        self.get_from_attributed_variable_list();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallPutToAttributedVarList => {
+                        self.put_to_attributed_variable_list();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecutePutToAttributedVarList => {
+                        self.put_to_attributed_variable_list();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDeleteFromAttributedVarList => {
+                        self.delete_from_attributed_variable_list();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDeleteFromAttributedVarList => {
+                        self.delete_from_attributed_variable_list();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDeleteAllAttributesFromVar => {
+                        self.delete_all_attributes_from_var();
+                        self.machine_st.p += 1;
+                    }
+                    &Instruction::ExecuteDeleteAllAttributesFromVar => {
+                        self.delete_all_attributes_from_var();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallUnattributedVar => {
+                        self.machine_st.unattributed_var();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteUnattributedVar => {
+                        self.machine_st.unattributed_var();
+                        self.machine_st.p = self.machine_st.cp;
+                    }
+                    &Instruction::CallGetDBRefs => {
+                        self.get_db_refs();
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetDBRefs => {
+                        self.get_db_refs();
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                }
+            }
+
+            let interrupted = INTERRUPT.load(std::sync::atomic::Ordering::Relaxed);
+
+            match INTERRUPT.compare_exchange(
+                interrupted,
+                false,
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+            ) {
+                Ok(interruption) => {
+                    if interruption {
+                        self.machine_st.throw_interrupt_exception();
                         self.machine_st.backtrack();
                     }
                 }
-                &Instruction::ExecuteFastCallN(arity) => {
-                    let call_at_index = |wam: &mut Machine, name, arity, ptr| {
-                        wam.try_execute(name, arity, ptr)
-                    };
-
-                    try_or_throw!(self.machine_st, self.fast_call(arity, call_at_index));
-
-                    if self.machine_st.fail {
-                        self.machine_st.backtrack();
-                    }
-                }
-                &Instruction::CallGetClauseP => {
-                    let module_name = cell_as_atom!(self.deref_register(3));
-
-                    let (n, p) = self.get_clause_p(module_name);
-
-                    let r = self.machine_st.registers[2];
-                    let r = self.machine_st.store(self.machine_st.deref(r));
-
-                    let h = self.machine_st.heap.len();
-                    self.machine_st.heap.extend(functor!(atom!("-"), [fixnum(n), fixnum(p)]));
-
-                    let r = r.as_var().unwrap();
-                    self.machine_st.bind(r, str_loc_as_cell!(h));
-
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetClauseP => {
-                    let module_name = cell_as_atom!(self.deref_register(3));
-
-                    let (n, p) = self.get_clause_p(module_name);
-
-                    let r = self.machine_st.registers[2];
-                    let r = self.machine_st.store(self.machine_st.deref(r));
-
-                    let h = self.machine_st.heap.len();
-                    self.machine_st.heap.extend(functor!(atom!("-"), [fixnum(n), fixnum(p)]));
-
-                    let r = r.as_var().unwrap();
-                    self.machine_st.bind(r, str_loc_as_cell!(h));
-
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallInvokeClauseAtP => {
-                    let key_cell = self.machine_st.registers[1];
-                    let key = self.machine_st.name_and_arity_from_heap(key_cell).unwrap();
-
-                    let l = self.machine_st.registers[3];
-                    let l = self.machine_st.store(self.machine_st.deref(l));
-
-                    let l = match Number::try_from(l) {
-                        Ok(Number::Fixnum(l)) => l.get_num() as usize,
-                        _ => unreachable!(),
-                    };
-
-                    let p = self.machine_st.registers[4];
-                    let p = self.machine_st.store(self.machine_st.deref(p));
-
-                    let p = match Number::try_from(p) {
-                        Ok(Number::Fixnum(p)) => p.get_num() as usize,
-                        _ => unreachable!(),
-                    };
-
-                    let module_name = cell_as_atom!(self.deref_register(6));
-
-                    let compilation_target = match module_name {
-                        atom!("user") => CompilationTarget::User,
-                        _ => CompilationTarget::Module(module_name),
-                    };
-
-                    let skeleton = self.indices.get_predicate_skeleton_mut(
-                        &compilation_target,
-                        &key,
-                    ).unwrap();
-
-                    match skeleton.target_pos_of_clause_clause_loc(l) {
-                        Some(n) => {
-                            let r = self.machine_st.store(self.machine_st.deref(
-                                self.machine_st.registers[5],
-                            ));
-
-                            self.machine_st.unify_fixnum(Fixnum::build_with(n as i64), r);
-                        }
-                        None => {}
-                    }
-
-                    self.machine_st.call_at_index(2, p);
-                }
-                &Instruction::ExecuteInvokeClauseAtP => {
-                    let key_cell = self.machine_st.registers[1];
-                    let key = self.machine_st.name_and_arity_from_heap(key_cell).unwrap();
-
-                    let l = self.machine_st.registers[3];
-                    let l = self.machine_st.store(self.machine_st.deref(l));
-
-                    let l = match Number::try_from(l) {
-                        Ok(Number::Fixnum(l)) => l.get_num() as usize,
-                        _ => unreachable!(),
-                    };
-
-                    let p = self.machine_st.registers[4];
-                    let p = self.machine_st.store(self.machine_st.deref(p));
-
-                    let p = match Number::try_from(p) {
-                        Ok(Number::Fixnum(p)) => p.get_num() as usize,
-                        _ => unreachable!(),
-                    };
-
-                    let module_name = cell_as_atom!(self.deref_register(6));
-
-                    let compilation_target = match module_name {
-                        atom!("user") => CompilationTarget::User,
-                        _ => CompilationTarget::Module(module_name),
-                    };
-
-                    let skeleton = self.indices.get_predicate_skeleton_mut(
-                        &compilation_target,
-                        &key,
-                    ).unwrap();
-
-                    match skeleton.target_pos_of_clause_clause_loc(l) {
-                        Some(n) => {
-                            let r = self.machine_st.store(self.machine_st.deref(
-                                self.machine_st.registers[5],
-                            ));
-
-                            self.machine_st.unify_fixnum(Fixnum::build_with(n as i64), r);
-                        }
-                        None => {}
-                    }
-
-                    self.machine_st.execute_at_index(2, p);
-                }
-                &Instruction::CallGetFromAttributedVarList => {
-                    self.get_from_attributed_variable_list();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetFromAttributedVarList => {
-                    self.get_from_attributed_variable_list();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallPutToAttributedVarList => {
-                    self.put_to_attributed_variable_list();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecutePutToAttributedVarList => {
-                    self.put_to_attributed_variable_list();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDeleteFromAttributedVarList => {
-                    self.delete_from_attributed_variable_list();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteDeleteFromAttributedVarList => {
-                    self.delete_from_attributed_variable_list();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
-                &Instruction::CallDeleteAllAttributesFromVar => {
-                    self.delete_all_attributes_from_var();
-                    self.machine_st.p += 1;
-                }
-                &Instruction::ExecuteDeleteAllAttributesFromVar => {
-                    self.delete_all_attributes_from_var();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallUnattributedVar => {
-                    self.machine_st.unattributed_var();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteUnattributedVar => {
-                    self.machine_st.unattributed_var();
-                    self.machine_st.p = self.machine_st.cp;
-                }
-                &Instruction::CallGetDBRefs => {
-                    self.get_db_refs();
-                    step_or_fail!(self, self.machine_st.p += 1);
-                }
-                &Instruction::ExecuteGetDBRefs => {
-                    self.get_db_refs();
-                    step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
-                }
+                Err(_) => unreachable!(),
             }
-        }
-
-        let interrupted = INTERRUPT.load(std::sync::atomic::Ordering::Relaxed);
-
-        match INTERRUPT.compare_exchange(
-            interrupted,
-            false,
-            std::sync::atomic::Ordering::Relaxed,
-            std::sync::atomic::Ordering::Relaxed,
-        ) {
-            Ok(interruption) => {
-                if interruption {
-                    self.machine_st.throw_interrupt_exception();
-                    self.machine_st.backtrack();
-                }
-            }
-            Err(_) => unreachable!(),
-        }
         }
 
         std::process::ExitCode::SUCCESS

--- a/src/machine/gc.rs
+++ b/src/machine/gc.rs
@@ -647,7 +647,7 @@ mod tests {
         let pstr_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "abc ",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
@@ -672,7 +672,7 @@ mod tests {
         let pstr_second_var_cell = put_partial_string(
             &mut wam.machine_st.heap,
             "def",
-            &mut wam.machine_st.atom_tbl,
+            &mut wam.machine_st.atom_tbl.blocking_write(),
         );
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 

--- a/src/machine/gc.rs
+++ b/src/machine/gc.rs
@@ -644,11 +644,8 @@ mod tests {
         // two-part complete string, then a three-part cyclic string
         // involving an uncompacted list of chars.
 
-        let pstr_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "abc ",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "abc ", &wam.machine_st.atom_tbl);
         let pstr_cell = wam.machine_st.heap[pstr_var_cell.get_value() as usize];
 
         mark_cells(&mut wam.machine_st.heap, pstr_loc_as_cell!(0));
@@ -669,11 +666,8 @@ mod tests {
 
         wam.machine_st.heap.push(pstr_loc_as_cell!(2));
 
-        let pstr_second_var_cell = put_partial_string(
-            &mut wam.machine_st.heap,
-            "def",
-            &mut wam.machine_st.atom_tbl.blocking_write(),
-        );
+        let pstr_second_var_cell =
+            put_partial_string(&mut wam.machine_st.heap, "def", &wam.machine_st.atom_tbl);
         let pstr_second_cell = wam.machine_st.heap[pstr_second_var_cell.get_value() as usize];
 
         mark_cells(&mut wam.machine_st.heap, pstr_loc_as_cell!(0));

--- a/src/machine/heap.rs
+++ b/src/machine/heap.rs
@@ -1,3 +1,5 @@
+use tokio::sync::RwLock;
+
 use crate::arena::*;
 use crate::atom_table::*;
 use crate::forms::*;
@@ -133,7 +135,7 @@ pub fn print_heap_terms<'a, I: Iterator<Item = &'a HeapCellValue>>(heap: I, h: u
 pub(crate) fn put_complete_string(
     heap: &mut Heap,
     s: &str,
-    atom_tbl: &mut AtomTable,
+    atom_tbl: &RwLock<AtomTable>,
 ) -> HeapCellValue {
     match allocate_pstr(heap, s, atom_tbl) {
         Some(h) => {
@@ -160,7 +162,7 @@ pub(crate) fn put_complete_string(
 pub(crate) fn put_partial_string(
     heap: &mut Heap,
     s: &str,
-    atom_tbl: &mut AtomTable,
+    atom_tbl: &RwLock<AtomTable>,
 ) -> HeapCellValue {
     match allocate_pstr(heap, s, atom_tbl) {
         Some(h) => {
@@ -176,7 +178,7 @@ pub(crate) fn put_partial_string(
 pub(crate) fn allocate_pstr(
     heap: &mut Heap,
     mut src: &str,
-    atom_tbl: &mut AtomTable,
+    atom_tbl: &RwLock<AtomTable>,
 ) -> Option<usize> {
     let orig_h = heap.len();
 

--- a/src/machine/heap.rs
+++ b/src/machine/heap.rs
@@ -1,5 +1,3 @@
-use tokio::sync::RwLock;
-
 use crate::arena::*;
 use crate::atom_table::*;
 use crate::forms::*;
@@ -132,11 +130,7 @@ pub fn print_heap_terms<'a, I: Iterator<Item = &'a HeapCellValue>>(heap: I, h: u
 }
 
 #[inline]
-pub(crate) fn put_complete_string(
-    heap: &mut Heap,
-    s: &str,
-    atom_tbl: &RwLock<AtomTable>,
-) -> HeapCellValue {
+pub(crate) fn put_complete_string(heap: &mut Heap, s: &str, atom_tbl: &AtomTable) -> HeapCellValue {
     match allocate_pstr(heap, s, atom_tbl) {
         Some(h) => {
             heap.pop(); // pop the trailing variable cell from the heap planted by allocate_pstr.
@@ -159,11 +153,7 @@ pub(crate) fn put_complete_string(
 }
 
 #[inline]
-pub(crate) fn put_partial_string(
-    heap: &mut Heap,
-    s: &str,
-    atom_tbl: &RwLock<AtomTable>,
-) -> HeapCellValue {
+pub(crate) fn put_partial_string(heap: &mut Heap, s: &str, atom_tbl: &AtomTable) -> HeapCellValue {
     match allocate_pstr(heap, s, atom_tbl) {
         Some(h) => {
             pstr_loc_as_cell!(h)
@@ -175,11 +165,7 @@ pub(crate) fn put_partial_string(
 }
 
 #[inline]
-pub(crate) fn allocate_pstr(
-    heap: &mut Heap,
-    mut src: &str,
-    atom_tbl: &RwLock<AtomTable>,
-) -> Option<usize> {
+pub(crate) fn allocate_pstr(heap: &mut Heap, mut src: &str, atom_tbl: &AtomTable) -> Option<usize> {
     let orig_h = heap.len();
 
     loop {

--- a/src/machine/load_state.rs
+++ b/src/machine/load_state.rs
@@ -1150,7 +1150,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
     pub(crate) fn use_module(&mut self, module_src: ModuleSource) -> Result<(), SessionError> {
         let (stream, listing_src) = match module_src {
             ModuleSource::File(filename) => {
-                let mut path_buf = PathBuf::from(filename.as_str());
+                let mut path_buf = PathBuf::from(&*filename.as_str());
                 path_buf.set_extension("pl");
 
                 let file = File::open(&path_buf)?;
@@ -1164,7 +1164,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                     ListingSource::File(filename, path_buf),
                 )
             }
-            ModuleSource::Library(library) => match LIBRARIES.borrow().get(library.as_str()) {
+            ModuleSource::Library(library) => match LIBRARIES.borrow().get(&*library.as_str()) {
                 Some(code) => {
                     if let Some(ref module) = self.wam_prelude.indices.modules.get(&library) {
                         if let ListingSource::DynamicallyGenerated = &module.listing_src {
@@ -1232,7 +1232,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
     ) -> Result<(), SessionError> {
         let (stream, listing_src) = match module_src {
             ModuleSource::File(filename) => {
-                let mut path_buf = PathBuf::from(filename.as_str());
+                let mut path_buf = PathBuf::from(&*filename.as_str());
                 path_buf.set_extension("pl");
                 let file = File::open(&path_buf)?;
 
@@ -1245,7 +1245,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                     ListingSource::File(filename, path_buf),
                 )
             }
-            ModuleSource::Library(library) => match LIBRARIES.borrow().get(library.as_str()) {
+            ModuleSource::Library(library) => match LIBRARIES.borrow().get(&*library.as_str()) {
                 Some(code) => {
                     if self.wam_prelude.indices.modules.contains_key(&library) {
                         return self.import_qualified_module(library, exports);

--- a/src/machine/loader.rs
+++ b/src/machine/loader.rs
@@ -1076,7 +1076,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
         let export_list = machine_st.read_term_from_heap(cell)?;
         let atom_tbl = &mut LS::machine_st(&mut self.payload).atom_tbl;
-        let export_list = setup_module_export_list(export_list, &mut atom_tbl.blocking_write())?;
+        let export_list = setup_module_export_list(export_list, &atom_tbl)?;
 
         Ok(export_list.into_iter().collect())
     }
@@ -1420,7 +1420,7 @@ impl MachineState {
                             term_stack.push(Term::PartialString(Cell::default(), string, tail));
                         }
                         Ok((string, None)) => {
-                            let atom = self.atom_tbl.blocking_write().build_with(&string);
+                            let atom = AtomTable::build_with(&self.atom_tbl, &string);
                             term_stack.push(Term::CompleteString(Cell::default(), atom));
                         }
                         Err(cons_term) => term_stack.push(cons_term),
@@ -1917,11 +1917,7 @@ impl Machine {
     pub(crate) fn load_context_source(&mut self) {
         if let Some(load_context) = self.load_contexts.last() {
             let path_str = load_context.path.to_str().unwrap();
-            let path_atom = self
-                .machine_st
-                .atom_tbl
-                .blocking_write()
-                .build_with(path_str);
+            let path_atom = AtomTable::build_with(&self.machine_st.atom_tbl, path_str);
 
             self.machine_st
                 .unify_atom(path_atom, self.machine_st.registers[1]);
@@ -1935,11 +1931,8 @@ impl Machine {
             match load_context.path.file_name() {
                 Some(file_name) if load_context.path.is_file() => {
                     let file_name_str = file_name.to_str().unwrap();
-                    let file_name_atom = self
-                        .machine_st
-                        .atom_tbl
-                        .blocking_write()
-                        .build_with(file_name_str);
+                    let file_name_atom =
+                        AtomTable::build_with(&self.machine_st.atom_tbl, file_name_str);
 
                     self.machine_st
                         .unify_atom(file_name_atom, self.machine_st.registers[1]);
@@ -1958,11 +1951,8 @@ impl Machine {
         if let Some(load_context) = self.load_contexts.last() {
             if let Some(directory) = load_context.path.parent() {
                 let directory_str = directory.to_str().unwrap();
-                let directory_atom = self
-                    .machine_st
-                    .atom_tbl
-                    .blocking_write()
-                    .build_with(directory_str);
+                let directory_atom =
+                    AtomTable::build_with(&self.machine_st.atom_tbl, directory_str);
 
                 self.machine_st
                     .unify_atom(directory_atom, self.machine_st.registers[1]);

--- a/src/machine/loader.rs
+++ b/src/machine/loader.rs
@@ -230,9 +230,7 @@ macro_rules! predicate_queue {
 
 pub type LiveLoadState = LoadStatePayload<LiveTermStream>;
 
-pub struct BootstrappingLoadState<'a>(
-    pub LoadStatePayload<BootstrappingTermStream<'a>>
-);
+pub struct BootstrappingLoadState<'a>(pub LoadStatePayload<BootstrappingTermStream<'a>>);
 
 impl<'a> Deref for BootstrappingLoadState<'a> {
     type Target = LoadStatePayload<BootstrappingTermStream<'a>>;
@@ -253,9 +251,12 @@ impl<'a> DerefMut for BootstrappingLoadState<'a> {
 pub trait LoadState<'a>: Sized {
     type Evacuable;
     type TS: TermStream;
-    type LoaderFieldType: DerefMut<Target=LoadStatePayload<Self::TS>>;
+    type LoaderFieldType: DerefMut<Target = LoadStatePayload<Self::TS>>;
 
-    fn new(machine_st: &'a mut MachineState, payload: LoadStatePayload<Self::TS>) -> Self::LoaderFieldType;
+    fn new(
+        machine_st: &'a mut MachineState,
+        payload: LoadStatePayload<Self::TS>,
+    ) -> Self::LoaderFieldType;
     fn evacuate(loader: Loader<'a, Self>) -> Result<Self::Evacuable, SessionError>;
     fn should_drop_load_state(loader: &Loader<'a, Self>) -> bool;
     fn reset_machine(loader: &mut Loader<'a, Self>);
@@ -293,14 +294,23 @@ impl<'a> LoadState<'a> for LiveLoadAndMachineState<'a> {
     type Evacuable = TypedArenaPtr<LiveLoadState>;
 
     #[inline(always)]
-    fn new(machine_st: &'a mut MachineState, payload: LoadStatePayload<Self::TS>) -> Self::LoaderFieldType {
+    fn new(
+        machine_st: &'a mut MachineState,
+        payload: LoadStatePayload<Self::TS>,
+    ) -> Self::LoaderFieldType {
         let load_state = arena_alloc!(payload, &mut machine_st.arena);
-        LiveLoadAndMachineState { load_state, machine_st }
+        LiveLoadAndMachineState {
+            load_state,
+            machine_st,
+        }
     }
 
     #[inline(always)]
     fn evacuate(mut loader: Loader<'a, Self>) -> Result<Self::Evacuable, SessionError> {
-        loader.payload.load_state.set_tag(ArenaHeaderTag::InactiveLoadState);
+        loader
+            .payload
+            .load_state
+            .set_tag(ArenaHeaderTag::InactiveLoadState);
         Ok(loader.payload.load_state)
     }
 
@@ -332,7 +342,11 @@ impl<'a> LoadState<'a> for LiveLoadAndMachineState<'a> {
         }
 
         if let Some(builtins) = loader.wam_prelude.indices.modules.get(&atom!("builtins")) {
-            if builtins.module_decl.exports.contains(&ModuleExport::PredicateKey(key)) {
+            if builtins
+                .module_decl
+                .exports
+                .contains(&ModuleExport::PredicateKey(key))
+            {
                 return Err(SessionError::CannotOverwriteBuiltIn(key));
             }
         }
@@ -358,10 +372,7 @@ impl<'a> LoadState<'a> for BootstrappingLoadState<'a> {
 
         let repo_len = loader.wam_prelude.code.len();
 
-        loader
-            .payload
-            .retraction_info
-            .reset(repo_len);
+        loader.payload.retraction_info.reset(repo_len);
 
         loader.remove_module_op_exports();
 
@@ -419,22 +430,27 @@ impl<'a> LoadState<'a> for InlineLoadState<'a> {
     type Evacuable = ();
 
     #[inline(always)]
-    fn new(machine_st: &'a mut MachineState, payload: LoadStatePayload<Self::TS>) -> Self::LoaderFieldType {
-	InlineLoadState { machine_st, payload }
+    fn new(
+        machine_st: &'a mut MachineState,
+        payload: LoadStatePayload<Self::TS>,
+    ) -> Self::LoaderFieldType {
+        InlineLoadState {
+            machine_st,
+            payload,
+        }
     }
 
     fn evacuate(_loader: Loader<'a, Self>) -> Result<Self::Evacuable, SessionError> {
-	Ok(())
+        Ok(())
     }
 
     #[inline(always)]
     fn should_drop_load_state(_loader: &Loader<'a, Self>) -> bool {
-	false
+        false
     }
 
     #[inline(always)]
-    fn reset_machine(_loader: &mut Loader<'a, Self>) {
-    }
+    fn reset_machine(_loader: &mut Loader<'a, Self>) {}
 
     #[inline(always)]
     fn machine_st(load_state: &mut Self::LoaderFieldType) -> &mut MachineState {
@@ -548,7 +564,12 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         atom!("user") => {
                             self.wam_prelude.indices.meta_predicates.remove(&key);
                         }
-                        _ => match self.wam_prelude.indices.modules.get_mut(&target_module_name) {
+                        _ => match self
+                            .wam_prelude
+                            .indices
+                            .modules
+                            .get_mut(&target_module_name)
+                        {
                             Some(ref mut module) => {
                                 module.meta_predicates.remove(&key);
                             }
@@ -566,7 +587,12 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                                 .meta_predicates
                                 .insert((name, meta_specs.len()), meta_specs);
                         }
-                        _ => match self.wam_prelude.indices.modules.get_mut(&target_module_name) {
+                        _ => match self
+                            .wam_prelude
+                            .indices
+                            .modules
+                            .get_mut(&target_module_name)
+                        {
                             Some(ref mut module) => {
                                 module
                                     .meta_predicates
@@ -773,9 +799,9 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 }
                 RetractionRecord::ReplacedChoiceOffset(instr_loc, offset) => {
                     match self.wam_prelude.code[instr_loc] {
-                        Instruction::TryMeElse(ref mut o) |
-                        Instruction::RetryMeElse(ref mut o) |
-                        Instruction::DefaultRetryMeElse(ref mut o) => {
+                        Instruction::TryMeElse(ref mut o)
+                        | Instruction::RetryMeElse(ref mut o)
+                        | Instruction::DefaultRetryMeElse(ref mut o) => {
                             *o = offset;
                         }
                         _ => {
@@ -792,16 +818,18 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 }
                 RetractionRecord::ReplacedSwitchOnTermVarIndex(index_loc, old_v) => {
                     match self.wam_prelude.code[index_loc] {
-                        Instruction::IndexingCode(ref mut indexing_code) => match &mut indexing_code[0] {
-                            IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
-                                _,
-                                ref mut v,
-                                ..,
-                            )) => {
-                                *v = old_v;
+                        Instruction::IndexingCode(ref mut indexing_code) => {
+                            match &mut indexing_code[0] {
+                                IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
+                                    _,
+                                    ref mut v,
+                                    ..,
+                                )) => {
+                                    *v = old_v;
+                                }
+                                _ => {}
                             }
-                            _ => {}
-                        },
+                        }
                         _ => {}
                     }
                 }
@@ -941,7 +969,9 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         .get_predicate_skeleton_mut(&compilation_target, &key)
                     {
                         Some(skeleton) => {
-                            if let Some(removed_clauses) = &mut skeleton.core.retracted_dynamic_clauses {
+                            if let Some(removed_clauses) =
+                                &mut skeleton.core.retracted_dynamic_clauses
+                            {
                                 let clause_index_info = removed_clauses.pop().unwrap();
 
                                 skeleton
@@ -1001,10 +1031,15 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 RetractionRecord::RemovedSkeleton(compilation_target, key, skeleton) => {
                     match compilation_target {
                         CompilationTarget::User => {
-                            self.wam_prelude.indices.extensible_predicates.insert(key, skeleton);
+                            self.wam_prelude
+                                .indices
+                                .extensible_predicates
+                                .insert(key, skeleton);
                         }
                         CompilationTarget::Module(module_name) => {
-                            if let Some(module) = self.wam_prelude.indices.modules.get_mut(&module_name) {
+                            if let Some(module) =
+                                self.wam_prelude.indices.modules.get_mut(&module_name)
+                            {
                                 module.extensible_predicates.insert(key, skeleton);
                             }
                         }
@@ -1012,16 +1047,8 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 }
                 RetractionRecord::ReplacedDynamicElseOffset(instr_loc, next) => {
                     match self.wam_prelude.code[instr_loc] {
-                        Instruction::DynamicElse(
-                            _,
-                            _,
-                            NextOrFail::Next(ref mut o),
-                        )
-                        | Instruction::DynamicInternalElse(
-                            _,
-                            _,
-                            NextOrFail::Next(ref mut o),
-                        ) => {
+                        Instruction::DynamicElse(_, _, NextOrFail::Next(ref mut o))
+                        | Instruction::DynamicInternalElse(_, _, NextOrFail::Next(ref mut o)) => {
                             *o = next;
                         }
                         _ => {}
@@ -1029,16 +1056,8 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 }
                 RetractionRecord::AppendedNextOrFail(instr_loc, fail) => {
                     match self.wam_prelude.code[instr_loc] {
-                        Instruction::DynamicElse(
-                            _,
-                            _,
-                            ref mut next_or_fail,
-                        )
-                        | Instruction::DynamicInternalElse(
-                            _,
-                            _,
-                            ref mut next_or_fail,
-                        ) => {
+                        Instruction::DynamicElse(_, _, ref mut next_or_fail)
+                        | Instruction::DynamicInternalElse(_, _, ref mut next_or_fail) => {
                             *next_or_fail = fail;
                         }
                         _ => {}
@@ -1064,8 +1083,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
     fn add_clause_clause(&mut self, term: Term) -> Result<(), CompilationError> {
         match term {
-            Term::Clause(_, atom!(":-"), mut terms) if terms.len() == 2 =>
-            {
+            Term::Clause(_, atom!(":-"), mut terms) if terms.len() == 2 => {
                 let body = terms.pop().unwrap();
                 let head = terms.pop().unwrap();
 
@@ -1096,20 +1114,14 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
         match &compilation_target {
             CompilationTarget::User => {
-                match self
-                    .wam_prelude
-                    .indices
-                    .extensible_predicates
-                    .get_mut(&key)
-                {
+                match self.wam_prelude.indices.extensible_predicates.get_mut(&key) {
                     Some(skeleton) => {
                         if !*flag_accessor(&mut skeleton.core) {
                             *flag_accessor(&mut skeleton.core) = true;
 
-                            self.payload.retraction_info.push_record(retraction_fn(
-                                compilation_target,
-                                key,
-                            ));
+                            self.payload
+                                .retraction_info
+                                .push_record(retraction_fn(compilation_target, key));
                         }
                     }
                     None => {
@@ -1117,11 +1129,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             let mut skeleton = PredicateSkeleton::new();
                             *flag_accessor(&mut skeleton.core) = true;
 
-                            self.add_extensible_predicate(
-                                key,
-                                skeleton,
-                                CompilationTarget::User,
-                            );
+                            self.add_extensible_predicate(key, skeleton, CompilationTarget::User);
                         } else {
                             throw_permission_error = true;
                         }
@@ -1135,10 +1143,9 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             if !*flag_accessor(&mut skeleton.core) {
                                 *flag_accessor(&mut skeleton.core) = true;
 
-                                self.payload.retraction_info.push_record(retraction_fn(
-                                    compilation_target,
-                                    key,
-                                ));
+                                self.payload
+                                    .retraction_info
+                                    .push_record(retraction_fn(compilation_target, key));
                             }
                         }
                         None => {
@@ -1146,11 +1153,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                                 let mut skeleton = PredicateSkeleton::new();
                                 *flag_accessor(&mut skeleton.core) = true;
 
-                                self.add_extensible_predicate(
-                                    key,
-                                    skeleton,
-                                    compilation_target,
-                                );
+                                self.add_extensible_predicate(key, skeleton, compilation_target);
                             } else {
                                 throw_permission_error = true;
                             }
@@ -1162,11 +1165,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         let mut skeleton = PredicateSkeleton::new();
                         *flag_accessor(&mut skeleton.core) = true;
 
-                        self.add_extensible_predicate(
-                            key,
-                            skeleton,
-                            compilation_target,
-                        );
+                        self.add_extensible_predicate(key, skeleton, compilation_target);
                     }
                 }
             }
@@ -1178,15 +1177,12 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
             match payload_compilation_target {
                 CompilationTarget::User => {
-                    match self
-                        .wam_prelude
-                        .indices
-                        .get_local_predicate_skeleton_mut(
-                            payload_compilation_target,
-                            compilation_target,
-                            listing_src_file_name,
-                            key,
-                        ) {
+                    match self.wam_prelude.indices.get_local_predicate_skeleton_mut(
+                        payload_compilation_target,
+                        compilation_target,
+                        listing_src_file_name,
+                        key,
+                    ) {
                         Some(skeleton) => {
                             if !*flag_accessor(skeleton) {
                                 *flag_accessor(skeleton) = true;
@@ -1196,11 +1192,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             let mut skeleton = LocalPredicateSkeleton::new();
                             *flag_accessor(&mut skeleton) = true;
 
-                            self.add_local_extensible_predicate(
-                                compilation_target,
-                                key,
-                                skeleton,
-                            );
+                            self.add_local_extensible_predicate(compilation_target, key, skeleton);
                         }
                     }
                 }
@@ -1232,11 +1224,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             let mut skeleton = LocalPredicateSkeleton::new();
                             *flag_accessor(&mut skeleton) = true;
 
-                            self.add_local_extensible_predicate(
-                                compilation_target,
-                                key,
-                                skeleton,
-                            );
+                            self.add_local_extensible_predicate(compilation_target, key, skeleton);
                         }
                     }
                 }
@@ -1336,10 +1324,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             let is_dynamic = self
                 .wam_prelude
                 .indices
-                .get_predicate_skeleton(
-                    &predicates_compilation_target,
-                    &(predicate_name, arity),
-                )
+                .get_predicate_skeleton(&predicates_compilation_target, &(predicate_name, arity))
                 .map(|skeleton| skeleton.core.is_dynamic)
                 .unwrap_or(false);
 
@@ -1356,15 +1341,12 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
         let predicates_compilation_target = self.payload.predicates.compilation_target;
         let listing_src_file_name = self.listing_src_file_name();
 
-        let clause_locs = match self
-            .wam_prelude
-            .indices
-            .get_local_predicate_skeleton_mut(
-                payload_compilation_target,
-                predicates_compilation_target,
-                listing_src_file_name,
-                *key,
-            ) {
+        let clause_locs = match self.wam_prelude.indices.get_local_predicate_skeleton_mut(
+            payload_compilation_target,
+            predicates_compilation_target,
+            listing_src_file_name,
+            *key,
+        ) {
             Some(skeleton) if !skeleton.clause_clause_locs.is_empty() => {
                 mem::replace(&mut skeleton.clause_clause_locs, VecDeque::new())
             }
@@ -1380,11 +1362,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             ),
         );
 
-        self.retract_local_clauses_impl(
-            predicates_compilation_target,
-            *key,
-            &clause_locs,
-        );
+        self.retract_local_clauses_impl(predicates_compilation_target, *key, &clause_locs);
 
         if is_dynamic {
             let clause_clause_compilation_target = match predicates_compilation_target {
@@ -1399,7 +1377,10 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
 impl<'a> MachinePreludeView<'a> {
     #[inline]
-    pub(super) fn composite_op_dir(&self, compilation_target: &CompilationTarget) -> CompositeOpDir {
+    pub(super) fn composite_op_dir(
+        &self,
+        compilation_target: &CompilationTarget,
+    ) -> CompositeOpDir {
         match compilation_target {
             CompilationTarget::User => CompositeOpDir::new(&self.indices.op_dir, None),
             CompilationTarget::Module(ref module_name) => {
@@ -1417,7 +1398,10 @@ impl<'a> MachinePreludeView<'a> {
 }
 
 impl MachineState {
-    pub(super) fn read_term_from_heap(&mut self, term_addr: HeapCellValue) -> Result<Term, SessionError> {
+    pub(super) fn read_term_from_heap(
+        &mut self,
+        term_addr: HeapCellValue,
+    ) -> Result<Term, SessionError> {
         let mut term_stack = vec![];
         let mut iter = stackful_post_order_iter(&mut self.heap, &mut self.stack, term_addr);
 
@@ -1550,9 +1534,9 @@ impl Machine {
     }
 
     pub(crate) fn load_compiled_library(&mut self) -> CallResult {
-        let library = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let library = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         if let Some(module) = self.indices.modules.get(&library) {
             if let ListingSource::DynamicallyGenerated = module.listing_src {
@@ -1583,9 +1567,9 @@ impl Machine {
     }
 
     pub(crate) fn declare_module(&mut self) -> CallResult {
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let mut loader = self.loader_from_heap_evacuable(temp_v!(3));
 
@@ -1652,7 +1636,11 @@ impl Machine {
 
         let arity = self.deref_register(3);
         let arity = match Number::try_from(arity) {
-            Ok(Number::Integer(n)) if &*n >= &Integer::from(0) && &*n <= &Integer::from(MAX_ARITY) => Ok(n.to_usize().unwrap()),
+            Ok(Number::Integer(n))
+                if &*n >= &Integer::from(0) && &*n <= &Integer::from(MAX_ARITY) =>
+            {
+                Ok(n.to_usize().unwrap())
+            }
             Ok(Number::Fixnum(n)) if n.get_num() >= 0 && n.get_num() <= MAX_ARITY as i64 => {
                 Ok(usize::try_from(n.get_num()).unwrap())
             }
@@ -1692,9 +1680,9 @@ impl Machine {
     }
 
     pub(crate) fn add_goal_expansion_clause(&mut self) -> CallResult {
-        let target_module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let target_module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let mut loader = self.loader_from_heap_evacuable(temp_v!(3));
 
@@ -1714,7 +1702,8 @@ impl Machine {
 
             if let Some(indexing_term) = indexing_arg {
                 if let Some(indexing_name) = indexing_term.name() {
-                    loader.wam_prelude
+                    loader
+                        .wam_prelude
                         .indices
                         .goal_expansion_indices
                         .insert((indexing_name, indexing_term.arity()));
@@ -1789,16 +1778,19 @@ impl Machine {
         &'a mut self,
         r: RegType,
     ) -> Loader<'a, LiveLoadAndMachineState<'a>> {
-        let mut load_state = cell_as_load_state_payload!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st[r]))
-        );
+        let mut load_state = cell_as_load_state_payload!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st[r])));
 
         load_state.set_tag(ArenaHeaderTag::LiveLoadState);
 
         let (wam_prelude, machine_st) = self.prelude_view_and_machine_st();
 
         Loader {
-            payload: LiveLoadAndMachineState { load_state, machine_st },
+            payload: LiveLoadAndMachineState {
+                load_state,
+                machine_st,
+            },
             wam_prelude,
         }
     }
@@ -1806,26 +1798,21 @@ impl Machine {
     #[inline]
     pub(crate) fn push_load_state_payload(&mut self) {
         let payload = arena_alloc!(
-            LoadStatePayload::new(
-                self.code.len(),
-                LiveTermStream::new(ListingSource::User),
-            ),
+            LoadStatePayload::new(self.code.len(), LiveTermStream::new(ListingSource::User),),
             &mut self.machine_st.arena
         );
 
         let var = self.machine_st.deref(self.machine_st.registers[1]);
 
-        self.machine_st.bind(
-            var.as_var().unwrap(),
-            typed_arena_ptr_as_cell!(payload),
-        );
+        self.machine_st
+            .bind(var.as_var().unwrap(), typed_arena_ptr_as_cell!(payload));
     }
 
     #[inline]
     pub(crate) fn pop_load_state_payload(&mut self) {
-        let load_state_payload = self.machine_st.store(
-            self.machine_st.deref(self.machine_st.registers[1])
-        );
+        let load_state_payload = self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1]));
 
         // unlike in loader_from_heap_evacuable,
         // pop_load_state_payload is allowed to fail to find a
@@ -1863,11 +1850,12 @@ impl Machine {
             2,
         )?;
 
-        let path = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[2]))
-        );
+        let path = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[2])));
 
-        self.load_contexts.push(LoadContext::new(path.as_str(), stream));
+        self.load_contexts
+            .push(LoadContext::new(path.as_str(), stream));
         Ok(())
     }
 
@@ -1876,9 +1864,7 @@ impl Machine {
         result: Result<TypedArenaPtr<LiveLoadState>, SessionError>,
     ) -> CallResult {
         match result {
-            Ok(_payload) => {
-                Ok(())
-            }
+            Ok(_payload) => Ok(()),
             Err(e) => {
                 let err = self.machine_st.session_error(e);
                 let stub = functor_stub(atom!("load"), 1);
@@ -1889,9 +1875,9 @@ impl Machine {
     }
 
     pub(crate) fn scoped_clause_to_evacuable(&mut self) -> CallResult {
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let loader = self.loader_from_heap_evacuable(temp_v!(3));
 
@@ -1933,7 +1919,8 @@ impl Machine {
             let path_str = load_context.path.to_str().unwrap();
             let path_atom = self.machine_st.atom_tbl.build_with(path_str);
 
-            self.machine_st.unify_atom(path_atom, self.machine_st.registers[1]);
+            self.machine_st
+                .unify_atom(path_atom, self.machine_st.registers[1]);
         } else {
             self.machine_st.fail = true;
         }
@@ -1946,7 +1933,8 @@ impl Machine {
                     let file_name_str = file_name.to_str().unwrap();
                     let file_name_atom = self.machine_st.atom_tbl.build_with(file_name_str);
 
-                    self.machine_st.unify_atom(file_name_atom, self.machine_st.registers[1]);
+                    self.machine_st
+                        .unify_atom(file_name_atom, self.machine_st.registers[1]);
                     return;
                 }
                 _ => {
@@ -1964,7 +1952,8 @@ impl Machine {
                 let directory_str = directory.to_str().unwrap();
                 let directory_atom = self.machine_st.atom_tbl.build_with(directory_str);
 
-                self.machine_st.unify_atom(directory_atom, self.machine_st.registers[1]);
+                self.machine_st
+                    .unify_atom(directory_atom, self.machine_st.registers[1]);
                 return;
             }
         }
@@ -1999,11 +1988,9 @@ impl Machine {
             _ => CompilationTarget::Module(module_name),
         };
 
-        let stub_gen = || {
-            match append_or_prepend {
-                AppendOrPrepend::Append  => functor_stub(atom!("assertz"), 1),
-                AppendOrPrepend::Prepend => functor_stub(atom!("asserta"), 1),
-            }
+        let stub_gen = || match append_or_prepend {
+            AppendOrPrepend::Append => functor_stub(atom!("assertz"), 1),
+            AppendOrPrepend::Prepend => functor_stub(atom!("asserta"), 1),
         };
 
         let head = self.deref_register(2);
@@ -2019,7 +2006,8 @@ impl Machine {
 
             loader.payload.compilation_target = compilation_target;
 
-            let head = LiveLoadAndMachineState::machine_st(&mut loader.payload).read_term_from_heap(head)?;
+            let head = LiveLoadAndMachineState::machine_st(&mut loader.payload)
+                .read_term_from_heap(head)?;
 
             let name = if let Some(name) = head.name() {
                 name
@@ -2031,32 +2019,24 @@ impl Machine {
             let is_builtin = loader.wam_prelude.indices.builtin_property((name, arity));
 
             let is_dynamic_predicate = loader
-                  .wam_prelude
-                  .indices
-                  .is_dynamic_predicate(
-                      module_name,
-                      (name, arity),
-                  );
+                .wam_prelude
+                .indices
+                .is_dynamic_predicate(module_name, (name, arity));
 
-            let no_such_predicate =
-                if !is_dynamic_predicate && !is_builtin {
-                    let idx_tag = loader
-                        .wam_prelude
-                        .indices
-                        .get_predicate_code_index(
-                            name,
-                            arity,
-                            module_name,
-                        )
-                        .map(|code_idx| code_idx.get_tag())
-                        .unwrap_or(IndexPtrTag::DynamicUndefined);
+            let no_such_predicate = if !is_dynamic_predicate && !is_builtin {
+                let idx_tag = loader
+                    .wam_prelude
+                    .indices
+                    .get_predicate_code_index(name, arity, module_name)
+                    .map(|code_idx| code_idx.get_tag())
+                    .unwrap_or(IndexPtrTag::DynamicUndefined);
 
-                    idx_tag == IndexPtrTag::DynamicUndefined || idx_tag == IndexPtrTag::Undefined
-                } else if is_builtin {
-                    return Err(SessionError::CannotOverwriteBuiltIn((name, arity)));
-                } else {
-                    is_dynamic_predicate
-                };
+                idx_tag == IndexPtrTag::DynamicUndefined || idx_tag == IndexPtrTag::Undefined
+            } else if is_builtin {
+                return Err(SessionError::CannotOverwriteBuiltIn((name, arity)));
+            } else {
+                is_dynamic_predicate
+            };
 
             if !no_such_predicate {
                 LiveLoadAndMachineState::machine_st(&mut loader.payload).fail = true;
@@ -2098,23 +2078,18 @@ impl Machine {
         match compile_assert() {
             Ok(_) => Ok(()),
             Err(SessionError::CompilationError(
-                CompilationError::InvalidRuleHead |
-                CompilationError::InadmissibleFact
+                CompilationError::InvalidRuleHead | CompilationError::InadmissibleFact,
             )) => {
-                let err = self.machine_st.type_error(
-                    ValidType::Callable,
-                    self.machine_st.registers[2],
-                );
+                let err = self
+                    .machine_st
+                    .type_error(ValidType::Callable, self.machine_st.registers[2]);
 
                 Err(self.machine_st.error_form(err, stub_gen()))
             }
-            Err(SessionError::CompilationError(
-                CompilationError::InadmissibleQueryTerm
-            )) => {
-                let err = self.machine_st.type_error(
-                    ValidType::Callable,
-                    self.machine_st.registers[3],
-                );
+            Err(SessionError::CompilationError(CompilationError::InadmissibleQueryTerm)) => {
+                let err = self
+                    .machine_st
+                    .type_error(ValidType::Callable, self.machine_st.registers[3]);
 
                 Err(self.machine_st.error_form(err, stub_gen()))
             }
@@ -2126,9 +2101,9 @@ impl Machine {
     }
 
     pub(crate) fn abolish_clause(&mut self) -> CallResult {
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let key = self
             .machine_st
@@ -2140,8 +2115,8 @@ impl Machine {
         };
 
         let mut abolish_clause = || {
-            let mut loader: Loader<'_, LiveLoadAndMachineState<'_>>
-                = Loader::new(self, LiveTermStream::new(ListingSource::User));
+            let mut loader: Loader<'_, LiveLoadAndMachineState<'_>> =
+                Loader::new(self, LiveTermStream::new(ListingSource::User));
 
             loader.payload.compilation_target = compilation_target;
 
@@ -2161,9 +2136,11 @@ impl Machine {
                         .remove_predicate_skeleton(
                             &clause_clause_compilation_target,
                             &(atom!("$clause"), 2),
-                        ).unwrap();
+                        )
+                        .unwrap();
 
-                    let result = skeleton.core
+                    let result = skeleton
+                        .core
                         .clause_clause_locs
                         .iter()
                         .map(|clause_clause_loc| {
@@ -2173,11 +2150,7 @@ impl Machine {
                         })
                         .collect();
 
-                    loader.add_extensible_predicate(
-                        key,
-                        skeleton,
-                        compilation_target,
-                    );
+                    loader.add_extensible_predicate(key, skeleton, compilation_target);
 
                     loader.add_extensible_predicate(
                         (atom!("$clause"), 2),
@@ -2186,14 +2159,15 @@ impl Machine {
                     );
 
                     result
-                }).unwrap();
+                })
+                .unwrap();
 
-            loader.wam_prelude
+            loader
+                .wam_prelude
                 .indices
                 .remove_predicate_skeleton(&compilation_target, &key);
 
-            let mut code_index = loader
-                .get_or_insert_code_index(key, compilation_target);
+            let mut code_index = loader.get_or_insert_code_index(key, compilation_target);
 
             code_index.set(IndexPtr::undefined());
 
@@ -2231,9 +2205,9 @@ impl Machine {
             _ => unreachable!(),
         };
 
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[4]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[4])));
 
         let compilation_target = match module_name {
             atom!("user") => CompilationTarget::User,
@@ -2286,9 +2260,9 @@ impl Machine {
     }
 
     pub(crate) fn is_consistent_with_term_queue(&mut self) -> CallResult {
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let key = self
             .machine_st
@@ -2303,8 +2277,8 @@ impl Machine {
 
         LiveLoadAndMachineState::machine_st(&mut loader.payload).fail =
             (!loader.payload.predicates.is_empty()
-             && loader.payload.predicates.compilation_target != compilation_target)
-             || !key.is_consistent(&loader.payload.predicates);
+                && loader.payload.predicates.compilation_target != compilation_target)
+                || !key.is_consistent(&loader.payload.predicates);
 
         let result = LiveLoadAndMachineState::evacuate(loader);
         self.restore_load_state_payload(result)
@@ -2326,9 +2300,9 @@ impl Machine {
     }
 
     pub(crate) fn remove_module_exports(&mut self) -> CallResult {
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let mut loader = self.loader_from_heap_evacuable(temp_v!(2));
 
@@ -2354,9 +2328,9 @@ impl Machine {
     }
 
     pub(crate) fn meta_predicate_property(&mut self) {
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let (predicate_name, arity) = self
             .machine_st
@@ -2374,9 +2348,12 @@ impl Machine {
             Some(meta_specs) => {
                 let term_loc = self.machine_st.heap.len();
 
-                self.machine_st.heap.push(atom_as_cell!(predicate_name, arity));
-                self.machine_st.heap.extend(
-                    meta_specs.iter().map(|meta_spec| match meta_spec {
+                self.machine_st
+                    .heap
+                    .push(atom_as_cell!(predicate_name, arity));
+                self.machine_st
+                    .heap
+                    .extend(meta_specs.iter().map(|meta_spec| match meta_spec {
                         MetaSpec::Minus => atom_as_cell!(atom!("+")),
                         MetaSpec::Plus => atom_as_cell!(atom!("-")),
                         MetaSpec::Either => atom_as_cell!(atom!("?")),
@@ -2384,15 +2361,20 @@ impl Machine {
                         MetaSpec::RequiresExpansionWithArgument(ref arg_num) => {
                             fixnum_as_cell!(Fixnum::build_with(*arg_num as i64))
                         }
-                    })
-                );
+                    }));
 
                 let heap_loc = self.machine_st.heap.len();
 
-                self.machine_st.heap.push(atom_as_cell!(atom!("meta_predicate"), 1));
+                self.machine_st
+                    .heap
+                    .push(atom_as_cell!(atom!("meta_predicate"), 1));
                 self.machine_st.heap.push(str_loc_as_cell!(term_loc));
 
-                unify!(self.machine_st, str_loc_as_cell!(heap_loc), self.machine_st.registers[4]);
+                unify!(
+                    self.machine_st,
+                    str_loc_as_cell!(heap_loc),
+                    self.machine_st.registers[4]
+                );
             }
             None => {
                 self.machine_st.fail = true;
@@ -2401,9 +2383,9 @@ impl Machine {
     }
 
     pub(crate) fn dynamic_property(&mut self) {
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let key = self
             .machine_st
@@ -2428,9 +2410,9 @@ impl Machine {
     }
 
     pub(crate) fn multifile_property(&mut self) {
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let key = self
             .machine_st
@@ -2455,9 +2437,9 @@ impl Machine {
     }
 
     pub(crate) fn discontiguous_property(&mut self) {
-        let module_name = cell_as_atom!(
-            self.machine_st.store(self.machine_st.deref(self.machine_st.registers[1]))
-        );
+        let module_name = cell_as_atom!(self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[1])));
 
         let key = self
             .machine_st

--- a/src/machine/machine_errors.rs
+++ b/src/machine/machine_errors.rs
@@ -44,7 +44,8 @@ pub(crate) enum ValidType {
     InCharacter,
     Integer,
     List,
-    #[allow(unused)] Number,
+    #[allow(unused)]
+    Number,
     Pair,
     //    PredicateIndicator,
     //    Variable
@@ -254,9 +255,11 @@ pub(super) type FunctorStub = [HeapCellValue; 3];
 
 #[inline(always)]
 pub(super) fn functor_stub(name: Atom, arity: usize) -> FunctorStub {
-    [atom_as_cell!(atom!("/"), 2),
-     atom_as_cell!(name),
-     fixnum_as_cell!(Fixnum::build_with(arity as i64))]
+    [
+        atom_as_cell!(atom!("/"), 2),
+        atom_as_cell!(name),
+        fixnum_as_cell!(Fixnum::build_with(arity as i64)),
+    ]
 }
 
 impl MachineState {
@@ -440,11 +443,13 @@ impl MachineState {
     pub(super) fn session_error(&mut self, err: SessionError) -> MachineError {
         match err {
             SessionError::CannotOverwriteBuiltIn(key) => {
-            // SessionError::CannotOverwriteImport(pred_atom) => {
+                // SessionError::CannotOverwriteImport(pred_atom) => {
                 self.permission_error(
                     Permission::Modify,
                     atom!("static_procedure"),
-                    functor_stub(key.0, key.1).into_iter().collect::<MachineStub>(),
+                    functor_stub(key.0, key.1)
+                        .into_iter()
+                        .collect::<MachineStub>(),
                 )
             }
             SessionError::ExistenceError(err) => self.existence_error(err),
@@ -471,7 +476,11 @@ impl MachineState {
             }
             SessionError::NamelessEntry => {
                 let error_atom = atom!("nameless_procedure");
-                self.permission_error(Permission::Create, atom!("static_procedure"), functor!(error_atom))
+                self.permission_error(
+                    Permission::Create,
+                    atom!("static_procedure"),
+                    functor!(error_atom),
+                )
             }
             SessionError::OpIsInfixAndPostFix(op) => {
                 self.permission_error(Permission::Create, atom!("operator"), functor!(op))
@@ -541,21 +550,21 @@ impl MachineState {
 
     #[cfg(feature = "ffi")]
     pub(super) fn ffi_error(&mut self, err: FFIError) -> MachineError {
-	let error_atom = match err {
-	    FFIError::ValueCast => atom!("value_cast"),
-	    FFIError::ValueDontFit => atom!("value_dont_fit"),
-	    FFIError::InvalidFFIType => atom!("invalid_ffi_type"),
-	    FFIError::InvalidStructName => atom!("invalid_struct_name"),
-	    FFIError::FunctionNotFound => atom!("function_not_found"),
-	    FFIError::StructNotFound => atom!("struct_not_found"),
-	};
-	let stub = functor!(atom!("ffi_error"),[atom(error_atom)]);
+        let error_atom = match err {
+            FFIError::ValueCast => atom!("value_cast"),
+            FFIError::ValueDontFit => atom!("value_dont_fit"),
+            FFIError::InvalidFFIType => atom!("invalid_ffi_type"),
+            FFIError::InvalidStructName => atom!("invalid_struct_name"),
+            FFIError::FunctionNotFound => atom!("function_not_found"),
+            FFIError::StructNotFound => atom!("struct_not_found"),
+        };
+        let stub = functor!(atom!("ffi_error"), [atom(error_atom)]);
 
-	MachineError {
-	    stub,
-	    location: None,
-	    from: ErrorProvenance::Constructed,
-	}
+        MachineError {
+            stub,
+            location: None,
+            from: ErrorProvenance::Constructed,
+        }
     }
 
     pub(super) fn error_form(&mut self, err: MachineError, src: FunctorStub) -> MachineStub {
@@ -682,10 +691,12 @@ impl CompilationError {
             &CompilationError::ExpectedRel => {
                 functor!(atom!("expected_relation"))
             }
-            &CompilationError::InadmissibleFact => { // TODO: type_error(callable, _).
+            &CompilationError::InadmissibleFact => {
+                // TODO: type_error(callable, _).
                 functor!(atom!("inadmissible_fact"))
             }
-            &CompilationError::InadmissibleQueryTerm => { // TODO: type_error(callable, _).
+            &CompilationError::InadmissibleQueryTerm => {
+                // TODO: type_error(callable, _).
                 functor!(atom!("inadmissible_query_term"))
             }
             &CompilationError::InconsistentEntry => {
@@ -820,10 +831,10 @@ pub enum CycleSearchResult {
     Cyclic(usize),
     EmptyList,
     NotList(usize, HeapCellValue), // the list length until the second argument in the heap
-    PartialList(usize, Ref), // the list length (up to max), and an offset into the heap.
-    ProperList(usize),       // the list length.
+    PartialList(usize, Ref),       // the list length (up to max), and an offset into the heap.
+    ProperList(usize),             // the list length.
     PStrLocation(usize, usize, usize), // list length (up to max), the heap address of the PStr, the offset
-    UntouchedList(usize, usize),   // list length (up to max), the address of an uniterated Addr::Lis(address).
+    UntouchedList(usize, usize), // list length (up to max), the address of an uniterated Addr::Lis(address).
     UntouchedCStr(Atom, usize),
 }
 
@@ -838,7 +849,7 @@ impl MachineState {
         match BrentAlgState::detect_cycles(&self.heap, list) {
             CycleSearchResult::PartialList(..) => {
                 let err = self.instantiation_error();
-                return Err(self.error_form(err, stub_gen()))
+                return Err(self.error_form(err, stub_gen()));
             }
             CycleSearchResult::NotList(..) | CycleSearchResult::Cyclic(_) => {
                 let err = self.type_error(ValidType::List, list);

--- a/src/machine/machine_indices.rs
+++ b/src/machine/machine_indices.rs
@@ -3,15 +3,15 @@ use crate::parser::ast::*;
 use crate::arena::*;
 use crate::atom_table::*;
 use crate::forms::*;
-use crate::machine::ClauseType;
 use crate::machine::loader::*;
 use crate::machine::machine_state::*;
 use crate::machine::streams::Stream;
+use crate::machine::ClauseType;
 
 use fxhash::FxBuildHasher;
 use indexmap::{IndexMap, IndexSet};
-use modular_bitfield::{BitfieldSpecifier, bitfield};
 use modular_bitfield::specifiers::*;
+use modular_bitfield::{bitfield, BitfieldSpecifier};
 
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
@@ -86,7 +86,8 @@ pub enum IndexPtrTag {
 #[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct IndexPtr {
     pub p: B56,
-    #[allow(unused)] m: bool,
+    #[allow(unused)]
+    m: bool,
     pub tag: IndexPtrTag,
 }
 
@@ -143,10 +144,10 @@ impl IndexPtr {
 #[derive(Debug, Clone, Copy, Ord, Hash, PartialOrd, Eq, PartialEq)]
 pub struct CodeIndex(TypedArenaPtr<IndexPtr>);
 
-#[cfg(target_pointer_width="32")]
+#[cfg(target_pointer_width = "32")]
 const_assert!(std::mem::align_of::<CodeIndex>() == 4);
 
-#[cfg(target_pointer_width="64")]
+#[cfg(target_pointer_width = "64")]
 const_assert!(std::mem::align_of::<CodeIndex>() == 8);
 
 impl Deref for CodeIndex {
@@ -293,7 +294,8 @@ impl IndexStore {
         let (name, arity) = key;
 
         if !ClauseType::is_inbuilt(name, arity) {
-            self.modules.get(&(atom!("builtins")))
+            self.modules
+                .get(&(atom!("builtins")))
                 .map(|module| module.code_dir.contains_key(&(name, arity)))
                 .unwrap_or(false)
         } else {
@@ -444,11 +446,7 @@ impl IndexStore {
         }
     }
 
-    pub(crate) fn is_dynamic_predicate(
-        &self,
-        module_name: Atom,
-        key: PredicateKey,
-    ) -> bool {
+    pub(crate) fn is_dynamic_predicate(&self, module_name: Atom, key: PredicateKey) -> bool {
         match module_name {
             atom!("user") => self
                 .extensible_predicates

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -18,7 +18,6 @@ use crate::types::*;
 use crate::parser::dashu::Integer;
 
 use indexmap::IndexMap;
-use tokio::sync::RwLock;
 
 use std::convert::TryFrom;
 use std::fmt;
@@ -59,7 +58,7 @@ pub enum OnEOF {
 }
 
 pub struct MachineState {
-    pub atom_tbl: Arc<RwLock<AtomTable>>,
+    pub atom_tbl: Arc<AtomTable>,
     pub arena: Arena,
     pub(super) pdl: Vec<HeapCellValue>,
     pub(super) s: HeapPtr,
@@ -205,7 +204,7 @@ pub fn pstr_loc_and_offset(heap: &[HeapCellValue], index: usize) -> (usize, Fixn
 fn push_var_eq_functors<'a>(
     heap: &mut Heap,
     iter: impl Iterator<Item = (&'a VarKey, &'a HeapCellValue)>,
-    atom_tbl: &RwLock<AtomTable>,
+    atom_tbl: &AtomTable,
 ) -> Vec<HeapCellValue> {
     let mut list_of_var_eqs = vec![];
 

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -205,12 +205,12 @@ pub fn pstr_loc_and_offset(heap: &[HeapCellValue], index: usize) -> (usize, Fixn
 fn push_var_eq_functors<'a>(
     heap: &mut Heap,
     iter: impl Iterator<Item = (&'a VarKey, &'a HeapCellValue)>,
-    atom_tbl: &mut AtomTable,
+    atom_tbl: &RwLock<AtomTable>,
 ) -> Vec<HeapCellValue> {
     let mut list_of_var_eqs = vec![];
 
     for (var, binding) in iter {
-        let var_atom = atom_tbl.build_with(&var.to_string());
+        let var_atom = AtomTable::build_with(atom_tbl, &var.to_string());
         let h = heap.len();
 
         heap.push(atom_as_cell!(atom!("="), 2));
@@ -531,7 +531,7 @@ impl MachineState {
                     Some((var_name, var))
                 }
             }),
-            &mut self.atom_tbl.blocking_write(),
+            &self.atom_tbl,
         );
 
         let singleton_addr = self.registers[3];
@@ -617,7 +617,7 @@ impl MachineState {
                         false
                     }
                 }),
-            &mut self.atom_tbl.blocking_write(),
+            &self.atom_tbl,
         );
 
         for var in term_write_result.var_dict.values_mut() {

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -503,7 +503,7 @@ impl MachineState {
                                     } else {
                                         self.pdl.clear();
                                         return Some(
-                                            n1.chars().next().cmp(&Some(c2))
+                                            n1.as_str().chars().next().cmp(&Some(c2))
                                               .then(Ordering::Greater)
                                         );
                                     }
@@ -533,7 +533,7 @@ impl MachineState {
                                     } else {
                                         self.pdl.clear();
                                         return Some(
-                                            Some(c1).cmp(&n2.chars().next())
+                                            Some(c1).cmp(&n2.as_str().chars().next())
                                                     .then(Ordering::Less)
                                         );
                                     }
@@ -556,7 +556,7 @@ impl MachineState {
                                     } else {
                                         self.pdl.clear();
                                         return Some(
-                                            Some(c1).cmp(&n2.chars().next())
+                                            Some(c1).cmp(&n2.as_str().chars().next())
                                                     .then(Ordering::Less)
                                         );
                                     }
@@ -586,7 +586,7 @@ impl MachineState {
                                     } else {
                                         self.pdl.clear();
                                         return Some(
-                                            n1.chars().next().cmp(&Some(c2))
+                                            n1.as_str().chars().next().cmp(&Some(c2))
                                               .then(Ordering::Greater)
                                         );
                                     }
@@ -896,7 +896,7 @@ impl MachineState {
 
         let s = string.as_str();
 
-        match heap_pstr_iter.compare_pstr_to_string(s) {
+        match heap_pstr_iter.compare_pstr_to_string(&*s) {
             Some(PStrPrefixCmpResult {
                 focus,
                 offset,
@@ -1003,9 +1003,9 @@ impl MachineState {
             self.s_offset = 0;
             self.mode = MachineMode::Read;
 
-            put_partial_string(&mut self.heap, pstr, &mut self.atom_tbl)
+            put_partial_string(&mut self.heap, pstr, &mut self.atom_tbl.blocking_write())
         } else {
-            put_complete_string(&mut self.heap, pstr, &mut self.atom_tbl)
+            put_complete_string(&mut self.heap, pstr, &mut self.atom_tbl.blocking_write())
         }
     }
 
@@ -1097,7 +1097,7 @@ impl MachineState {
                 (name, 0, 0)
             }
             (HeapCellValueTag::Char, c) => {
-                (self.atom_tbl.build_with(&c.to_string()), 0, 0)
+                (self.atom_tbl.blocking_write().build_with(&c.to_string()), 0, 0)
             }
             (HeapCellValueTag::Var | HeapCellValueTag::AttrVar | HeapCellValueTag::StackVar) => {
                 let stub = functor_stub(atom!("call"), arity + 1);
@@ -1436,7 +1436,7 @@ impl MachineState {
                         }
                     }
                     (HeapCellValueTag::Char, c) => {
-                        let c = self.atom_tbl.build_with(&c.to_string());
+                        let c = self.atom_tbl.blocking_write().build_with(&c.to_string());
 
                         self.try_functor_fabricate_struct(
                             c,

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -1,6 +1,5 @@
 use crate::arena::*;
 use crate::atom_table::*;
-use crate::types::*;
 use crate::forms::*;
 use crate::heap_iter::*;
 use crate::machine::attributed_variables::*;
@@ -14,6 +13,7 @@ use crate::machine::stack::*;
 use crate::machine::unify::*;
 use crate::parser::ast::*;
 use crate::parser::dashu::{Integer, Rational};
+use crate::types::*;
 
 use indexmap::IndexSet;
 
@@ -50,7 +50,7 @@ impl MachineState {
             ball: Ball::new(),
             ball_stack: vec![],
             lifted_heap: Heap::new(),
-            interms: vec![Number::default();256],
+            interms: vec![Number::default(); 256],
             cont_pts: Vec::with_capacity(256),
             cwil: CWIL::new(),
             flags: MachineFlags::default(),
@@ -59,8 +59,8 @@ impl MachineState {
             dynamic_mode: FirstOrNext::First,
             unify_fn: MachineState::unify,
             bind_fn: MachineState::bind,
-            run_cleaners_fn: |_| { false },
-            increment_call_count_fn: |_| { Ok(()) },
+            run_cleaners_fn: |_| false,
+            increment_call_count_fn: |_| Ok(()),
         }
     }
 
@@ -160,9 +160,8 @@ impl MachineState {
                     key_atom.index as u64,
                 ));
 
-                self.trail.push(TrailEntry::from_bytes(
-                    value_cell.into_bytes(),
-                ));
+                self.trail
+                    .push(TrailEntry::from_bytes(value_cell.into_bytes()));
 
                 self.tr += 2;
             }
@@ -248,9 +247,7 @@ impl MachineState {
         r: Ref,
         value: HeapCellValue,
     ) {
-        let mut unifier = CompositeUnifierForOccursCheckWithError::from(
-            DefaultUnifier::from(self),
-        );
+        let mut unifier = CompositeUnifierForOccursCheckWithError::from(DefaultUnifier::from(self));
 
         unifier.bind(r, value);
     }
@@ -316,9 +313,7 @@ impl MachineState {
     }
 
     pub(super) fn unify_with_occurs_check_with_error(&mut self) {
-        let mut unifier = CompositeUnifierForOccursCheckWithError::from(
-            DefaultUnifier::from(self),
-        );
+        let mut unifier = CompositeUnifierForOccursCheckWithError::from(DefaultUnifier::from(self));
 
         unifier.unify_internal();
     }
@@ -380,8 +375,7 @@ impl MachineState {
                     }
                 )
             }
-            &mut HeapPtr::PStrChar(h, ref mut n) |
-            &mut HeapPtr::PStrLocation(h, ref mut n) => {
+            &mut HeapPtr::PStrChar(h, ref mut n) | &mut HeapPtr::PStrLocation(h, ref mut n) => {
                 read_heap_cell!(self.heap[h],
                     (HeapCellValueTag::PStr, pstr_atom) => {
                         let pstr = PartialString::from(pstr_atom);
@@ -639,7 +633,7 @@ impl MachineState {
                                             // iter2 is continuable, so it
                                             // has a tail in the heap at
                                             // focus+1.
-                                            pdl.push(iter2.heap[focus+1]);
+                                            pdl.push(iter2.heap[focus + 1]);
 
                                             return None;
                                         }
@@ -903,7 +897,11 @@ impl MachineState {
         let s = string.as_str();
 
         match heap_pstr_iter.compare_pstr_to_string(s) {
-            Some(PStrPrefixCmpResult { focus, offset, prefix_len }) if prefix_len == s.len() => {
+            Some(PStrPrefixCmpResult {
+                focus,
+                offset,
+                prefix_len,
+            }) if prefix_len == s.len() => {
                 let focus_addr = self.heap[focus];
 
                 read_heap_cell!(focus_addr,
@@ -950,7 +948,10 @@ impl MachineState {
 
                 return;
             }
-            Some(PStrPrefixCmpResult { prefix_len: inner_prefix_len, .. }) => {
+            Some(PStrPrefixCmpResult {
+                prefix_len: inner_prefix_len,
+                ..
+            }) => {
                 prefix_len = inner_prefix_len;
             }
             None => {
@@ -1324,7 +1325,7 @@ impl MachineState {
 
         let f_a = if name == atom!(".") && arity == 2 {
             self.heap.push(heap_loc_as_cell!(h));
-            self.heap.push(heap_loc_as_cell!(h+1));
+            self.heap.push(heap_loc_as_cell!(h + 1));
 
             list_loc_as_cell!(h)
         } else {
@@ -1571,8 +1572,7 @@ impl MachineState {
 
         while let Some(iteratee) = heap_pstr_iter.next() {
             match iteratee {
-                PStrIteratee::Char(_, c) =>
-                    chars.push(char_as_cell!(c)),
+                PStrIteratee::Char(_, c) => chars.push(char_as_cell!(c)),
                 PStrIteratee::PStrSegment(_, pstr_atom, n) => {
                     let pstr = PartialString::from(pstr_atom);
                     chars.extend(pstr.as_str_from(n).chars().map(|c| char_as_cell!(c)));
@@ -1634,10 +1634,7 @@ impl MachineState {
             let mut value = unmark_cell_bits!(value);
 
             if value.is_var() {
-                value = heap_bound_store(
-                    iter.heap,
-                    heap_bound_deref(iter.heap, value),
-                );
+                value = heap_bound_store(iter.heap, heap_bound_deref(iter.heap, value));
 
                 if value.is_var() {
                     return true;
@@ -1646,7 +1643,7 @@ impl MachineState {
 
             if value.is_compound(iter.heap) {
                 if visited.contains(&value) {
-                    for _ in stack_len .. iter.stack_len() {
+                    for _ in stack_len..iter.stack_len() {
                         iter.pop_stack();
                     }
                 } else {

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -1003,9 +1003,9 @@ impl MachineState {
             self.s_offset = 0;
             self.mode = MachineMode::Read;
 
-            put_partial_string(&mut self.heap, pstr, &mut self.atom_tbl.blocking_write())
+            put_partial_string(&mut self.heap, pstr, &self.atom_tbl)
         } else {
-            put_complete_string(&mut self.heap, pstr, &mut self.atom_tbl.blocking_write())
+            put_complete_string(&mut self.heap, pstr, &self.atom_tbl)
         }
     }
 
@@ -1097,7 +1097,7 @@ impl MachineState {
                 (name, 0, 0)
             }
             (HeapCellValueTag::Char, c) => {
-                (self.atom_tbl.blocking_write().build_with(&c.to_string()), 0, 0)
+                (AtomTable::build_with(&self.atom_tbl, &c.to_string()), 0, 0)
             }
             (HeapCellValueTag::Var | HeapCellValueTag::AttrVar | HeapCellValueTag::StackVar) => {
                 let stub = functor_stub(atom!("call"), arity + 1);
@@ -1436,7 +1436,7 @@ impl MachineState {
                         }
                     }
                     (HeapCellValueTag::Char, c) => {
-                        let c = self.atom_tbl.blocking_write().build_with(&c.to_string());
+                        let c = AtomTable::build_with(&self.atom_tbl, &c.to_string());
 
                         self.try_functor_fabricate_struct(
                             c,

--- a/src/machine/mock_wam.rs
+++ b/src/machine/mock_wam.rs
@@ -2,10 +2,10 @@ pub use crate::arena::*;
 pub use crate::atom_table::*;
 use crate::heap_print::*;
 pub use crate::machine::heap::*;
-pub use crate::machine::*;
 pub use crate::machine::machine_state::*;
 pub use crate::machine::stack::*;
 pub use crate::machine::streams::*;
+pub use crate::machine::*;
 pub use crate::macros::*;
 pub use crate::parser::ast::*;
 use crate::read::*;
@@ -71,11 +71,9 @@ impl MockWAM {
         printer.var_names = term_write_result
             .var_dict
             .into_iter()
-            .map(|(var, cell)| {
-                match var {
-                    VarKey::VarPtr(var) => (cell, var.clone()),
-                    VarKey::AnonVar(_) => (cell, VarPtr::from(var.to_string()))
-                }
+            .map(|(var, cell)| match var {
+                VarKey::VarPtr(var) => (cell, var.clone()),
+                VarKey::AnonVar(_) => (cell, VarPtr::from(var.to_string())),
             })
             .collect();
 
@@ -245,7 +243,7 @@ impl Machine {
             load_contexts: vec![],
             runtime,
             #[cfg(feature = "ffi")]
-	        foreign_function_table: Default::default(),
+            foreign_function_table: Default::default(),
         };
 
         let mut lib_path = current_dir();
@@ -266,17 +264,14 @@ impl Machine {
                 lib_path.clone(),
             ),
         )
-            .unwrap();
+        .unwrap();
 
         bootstrapping_compile(
-            Stream::from_static_string(
-                LIBRARIES.borrow()["builtins"],
-                &mut wam.machine_st.arena,
-            ),
+            Stream::from_static_string(LIBRARIES.borrow()["builtins"], &mut wam.machine_st.arena),
             &mut wam,
             ListingSource::from_file_and_path(atom!("builtins.pl"), lib_path.clone()),
         )
-            .unwrap();
+        .unwrap();
 
         if let Some(ref mut builtins) = wam.indices.modules.get_mut(&atom!("builtins")) {
             load_module(
@@ -300,7 +295,7 @@ impl Machine {
             &mut wam,
             ListingSource::from_file_and_path(atom!("loader.pl"), lib_path.clone()),
         )
-            .unwrap();
+        .unwrap();
 
         wam.configure_modules();
 
@@ -346,26 +341,11 @@ mod tests {
         let mut wam = MachineState::new();
         let mut op_dir = default_op_dir();
 
-        op_dir.insert(
-            (atom!("+"), Fixity::In),
-            OpDesc::build_with(500, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("-"), Fixity::In),
-            OpDesc::build_with(500, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("*"), Fixity::In),
-            OpDesc::build_with(500, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("/"), Fixity::In),
-            OpDesc::build_with(400, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("="), Fixity::In),
-            OpDesc::build_with(700, XFX as u8),
-        );
+        op_dir.insert((atom!("+"), Fixity::In), OpDesc::build_with(500, YFX as u8));
+        op_dir.insert((atom!("-"), Fixity::In), OpDesc::build_with(500, YFX as u8));
+        op_dir.insert((atom!("*"), Fixity::In), OpDesc::build_with(500, YFX as u8));
+        op_dir.insert((atom!("/"), Fixity::In), OpDesc::build_with(400, YFX as u8));
+        op_dir.insert((atom!("="), Fixity::In), OpDesc::build_with(700, XFX as u8));
 
         {
             parse_and_write_parsed_term_to_heap(&mut wam, "f(X,X).", &op_dir).unwrap();
@@ -582,22 +562,10 @@ mod tests {
         let mut wam = MachineState::new();
         let mut op_dir = default_op_dir();
 
-        op_dir.insert(
-            (atom!("+"), Fixity::In),
-            OpDesc::build_with(500, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("-"), Fixity::In),
-            OpDesc::build_with(500, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("*"), Fixity::In),
-            OpDesc::build_with(400, YFX as u8),
-        );
-        op_dir.insert(
-            (atom!("/"), Fixity::In),
-            OpDesc::build_with(400, YFX as u8),
-        );
+        op_dir.insert((atom!("+"), Fixity::In), OpDesc::build_with(500, YFX as u8));
+        op_dir.insert((atom!("-"), Fixity::In), OpDesc::build_with(500, YFX as u8));
+        op_dir.insert((atom!("*"), Fixity::In), OpDesc::build_with(400, YFX as u8));
+        op_dir.insert((atom!("/"), Fixity::In), OpDesc::build_with(400, YFX as u8));
 
         {
             parse_and_write_parsed_term_to_heap(&mut wam, "f(X,X).", &op_dir).unwrap();
@@ -688,20 +656,12 @@ mod tests {
         wam.heap.push(heap_loc_as_cell!(1));
 
         assert_eq!(
-            compare_term_test!(
-                wam,
-                heap_loc_as_cell!(0),
-                heap_loc_as_cell!(0)
-            ),
+            compare_term_test!(wam, heap_loc_as_cell!(0), heap_loc_as_cell!(0)),
             Some(Ordering::Equal)
         );
 
         assert_eq!(
-            compare_term_test!(
-                wam,
-                heap_loc_as_cell!(0),
-                atom_as_cell!(atom!("a"))
-            ),
+            compare_term_test!(wam, heap_loc_as_cell!(0), atom_as_cell!(atom!("a"))),
             Some(Ordering::Greater)
         );
 
@@ -724,29 +684,17 @@ mod tests {
         wam.heap.push(empty_list_as_cell!());
 
         assert_eq!(
-            compare_term_test!(
-                wam,
-                heap_loc_as_cell!(7),
-                heap_loc_as_cell!(7)
-            ),
+            compare_term_test!(wam, heap_loc_as_cell!(7), heap_loc_as_cell!(7)),
             Some(Ordering::Equal)
         );
 
         assert_eq!(
-            compare_term_test!(
-                wam,
-                heap_loc_as_cell!(0),
-                heap_loc_as_cell!(7)
-            ),
+            compare_term_test!(wam, heap_loc_as_cell!(0), heap_loc_as_cell!(7)),
             Some(Ordering::Greater)
         );
 
         assert_eq!(
-            compare_term_test!(
-                wam,
-                empty_list_as_cell!(),
-                heap_loc_as_cell!(7)
-            ),
+            compare_term_test!(wam, empty_list_as_cell!(), heap_loc_as_cell!(7)),
             Some(Ordering::Less)
         );
 
@@ -769,40 +717,24 @@ mod tests {
         );
 
         assert_eq!(
-            compare_term_test!(
-                wam,
-                empty_list_as_cell!(),
-                atom_as_cell!(atom!("atom"))
-            ),
+            compare_term_test!(wam, empty_list_as_cell!(), atom_as_cell!(atom!("atom"))),
             Some(Ordering::Less)
         );
 
         assert_eq!(
-            compare_term_test!(
-                wam,
-                atom_as_cell!(atom!("atom")),
-                empty_list_as_cell!()
-            ),
+            compare_term_test!(wam, atom_as_cell!(atom!("atom")), empty_list_as_cell!()),
             Some(Ordering::Greater)
         );
 
         let one_p_one = HeapCellValue::from(float_alloc!(1.1, &mut wam.arena));
 
         assert_eq!(
-            compare_term_test!(
-                wam,
-                one_p_one,
-                fixnum_as_cell!(Fixnum::build_with(1))
-            ),
+            compare_term_test!(wam, one_p_one, fixnum_as_cell!(Fixnum::build_with(1))),
             Some(Ordering::Less)
         );
 
         assert_eq!(
-            compare_term_test!(
-                wam,
-                fixnum_as_cell!(Fixnum::build_with(1)),
-                one_p_one
-            ),
+            compare_term_test!(wam, fixnum_as_cell!(Fixnum::build_with(1)), one_p_one),
             Some(Ordering::Greater)
         );
     }
@@ -821,7 +753,8 @@ mod tests {
         all_cells_unmarked(&wam.heap);
         wam.heap.clear();
 
-        wam.heap.extend(functor!(atom!("f"), [atom(atom!("a")), atom(atom!("b"))]));
+        wam.heap
+            .extend(functor!(atom!("f"), [atom(atom!("a")), atom(atom!("b"))]));
 
         assert!(!wam.is_cyclic_term(str_loc_as_cell!(0)));
 

--- a/src/machine/mock_wam.rs
+++ b/src/machine/mock_wam.rs
@@ -11,6 +11,8 @@ pub use crate::parser::ast::*;
 use crate::read::*;
 pub use crate::types::*;
 
+use std::sync::Arc;
+
 #[cfg(test)]
 use crate::machine::copier::CopierTarget;
 
@@ -61,7 +63,7 @@ impl MockWAM {
 
         let mut printer = HCPrinter::new(
             &mut self.machine_st.heap,
-            &mut self.machine_st.atom_tbl,
+            Arc::clone(&self.machine_st.atom_tbl),
             &mut self.machine_st.stack,
             &self.op_dir,
             PrinterOutputter::new(),

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -230,7 +230,8 @@ impl Machine {
 
     pub fn load_file(&mut self, path: &str, stream: Stream) {
         self.machine_st.registers[1] = stream_as_cell!(stream);
-        self.machine_st.registers[2] = atom_as_cell!(self.machine_st.atom_tbl.build_with(path));
+        self.machine_st.registers[2] =
+            atom_as_cell!(self.machine_st.atom_tbl.blocking_write().build_with(path));
 
         self.run_module_predicate(atom!("loader"), (atom!("file_load"), 2));
     }
@@ -295,7 +296,7 @@ impl Machine {
             arg_pstrs.push(put_complete_string(
                 &mut self.machine_st.heap,
                 &arg,
-                &mut self.machine_st.atom_tbl,
+                &mut self.machine_st.atom_tbl.blocking_write(),
             ));
         }
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -231,7 +231,7 @@ impl Machine {
     pub fn load_file(&mut self, path: &str, stream: Stream) {
         self.machine_st.registers[1] = stream_as_cell!(stream);
         self.machine_st.registers[2] =
-            atom_as_cell!(self.machine_st.atom_tbl.blocking_write().build_with(path));
+            atom_as_cell!(AtomTable::build_with(&self.machine_st.atom_tbl, path));
 
         self.run_module_predicate(atom!("loader"), (atom!("file_load"), 2));
     }
@@ -296,7 +296,7 @@ impl Machine {
             arg_pstrs.push(put_complete_string(
                 &mut self.machine_st.heap,
                 &arg,
-                &mut self.machine_st.atom_tbl.blocking_write(),
+                &self.machine_st.atom_tbl,
             ));
         }
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -6,6 +6,7 @@ pub mod code_walker;
 pub mod loader;
 pub mod compile;
 pub mod copier;
+pub mod disjuncts;
 pub mod dispatch;
 pub mod gc;
 pub mod heap;
@@ -16,7 +17,6 @@ pub mod machine_state;
 pub mod machine_state_impl;
 pub mod mock_wam;
 pub mod partial_string;
-pub mod disjuncts;
 pub mod preprocessor;
 pub mod stack;
 pub mod streams;
@@ -27,9 +27,9 @@ pub mod unify;
 use crate::arena::*;
 use crate::arithmetic::*;
 use crate::atom_table::*;
-use crate::forms::*;
 #[cfg(feature = "ffi")]
 use crate::ffi::ForeignFunctionTable;
+use crate::forms::*;
 use crate::instructions::*;
 use crate::machine::args::*;
 use crate::machine::compile::*;
@@ -163,7 +163,10 @@ pub(crate) fn import_builtin_impls(code_dir: &CodeDir, builtins: &mut Module) {
     for key in keys {
         let idx = code_dir.get(&key).unwrap();
         builtins.code_dir.insert(key, idx.clone());
-        builtins.module_decl.exports.push(ModuleExport::PredicateKey(key));
+        builtins
+            .module_decl
+            .exports
+            .push(ModuleExport::PredicateKey(key));
     }
 }
 
@@ -194,7 +197,7 @@ impl Machine {
                 code: &mut self.code,
                 load_contexts: &mut self.load_contexts,
             },
-            &mut self.machine_st
+            &mut self.machine_st,
         )
     }
 
@@ -206,7 +209,11 @@ impl Machine {
         self.machine_st.throw_exception(err);
     }
 
-    fn run_module_predicate(&mut self, module_name: Atom, key: PredicateKey) -> std::process::ExitCode {
+    fn run_module_predicate(
+        &mut self,
+        module_name: Atom,
+        key: PredicateKey,
+    ) -> std::process::ExitCode {
         if let Some(module) = self.indices.modules.get(&module_name) {
             if let Some(ref code_index) = module.code_dir.get(&key) {
                 let p = code_index.local().unwrap();
@@ -223,9 +230,7 @@ impl Machine {
 
     pub fn load_file(&mut self, path: &str, stream: Stream) {
         self.machine_st.registers[1] = stream_as_cell!(stream);
-        self.machine_st.registers[2] = atom_as_cell!(
-            self.machine_st.atom_tbl.build_with(path)
-        );
+        self.machine_st.registers[2] = atom_as_cell!(self.machine_st.atom_tbl.build_with(path));
 
         self.run_module_predicate(atom!("loader"), (atom!("file_load"), 2));
     }
@@ -236,10 +241,8 @@ impl Machine {
         path_buf.push("src/toplevel.pl");
 
         let path = path_buf.to_str().unwrap();
-        let toplevel_stream = Stream::from_static_string(
-            include_str!("../toplevel.pl"),
-            &mut self.machine_st.arena,
-        );
+        let toplevel_stream =
+            Stream::from_static_string(include_str!("../toplevel.pl"), &mut self.machine_st.arena);
 
         self.load_file(path, toplevel_stream);
 
@@ -296,15 +299,20 @@ impl Machine {
             ));
         }
 
-        self.machine_st.registers[1] = heap_loc_as_cell!(
-            iter_to_heap_list(&mut self.machine_st.heap, arg_pstrs.into_iter())
-        );
+        self.machine_st.registers[1] = heap_loc_as_cell!(iter_to_heap_list(
+            &mut self.machine_st.heap,
+            arg_pstrs.into_iter()
+        ));
 
         self.run_module_predicate(atom!("$toplevel"), (atom!("$repl"), 1))
     }
 
     pub(crate) fn configure_modules(&mut self) {
-        fn update_call_n_indices(loader: &Module, target_code_dir: &mut CodeDir, arena: &mut Arena) {
+        fn update_call_n_indices(
+            loader: &Module,
+            target_code_dir: &mut CodeDir,
+            arena: &mut Arena,
+        ) {
             for arity in 1..66 {
                 let key = (atom!("call"), arity);
 
@@ -349,10 +357,18 @@ impl Machine {
             }
 
             for (_, target_module) in self.indices.modules.iter_mut() {
-                update_call_n_indices(&loader, &mut target_module.code_dir, &mut self.machine_st.arena);
+                update_call_n_indices(
+                    &loader,
+                    &mut target_module.code_dir,
+                    &mut self.machine_st.arena,
+                );
             }
 
-            update_call_n_indices(&loader, &mut self.indices.code_dir, &mut self.machine_st.arena);
+            update_call_n_indices(
+                &loader,
+                &mut self.indices.code_dir,
+                &mut self.machine_st.arena,
+            );
 
             self.indices.modules.insert(atom!("loader"), loader);
         } else {
@@ -363,56 +379,65 @@ impl Machine {
     pub(crate) fn add_impls_to_indices(&mut self) {
         let impls_offset = self.code.len() + 3;
 
-        self.code.extend(vec![
-            Instruction::BreakFromDispatchLoop,
-            Instruction::InstallVerifyAttr,
-            Instruction::VerifyAttrInterrupt,
-            Instruction::ExecuteTermGreaterThan,
-            Instruction::ExecuteTermLessThan,
-            Instruction::ExecuteTermGreaterThanOrEqual,
-            Instruction::ExecuteTermLessThanOrEqual,
-            Instruction::ExecuteTermEqual,
-            Instruction::ExecuteTermNotEqual,
-            Instruction::ExecuteNumberGreaterThan(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
-            Instruction::ExecuteNumberLessThan(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
-            Instruction::ExecuteNumberGreaterThanOrEqual(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
-            Instruction::ExecuteNumberLessThanOrEqual(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
-            Instruction::ExecuteNumberEqual(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
-            Instruction::ExecuteNumberNotEqual(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
-            Instruction::ExecuteIs(temp_v!(1), ar_reg!(temp_v!(2))),
-            Instruction::ExecuteAcyclicTerm,
-            Instruction::ExecuteArg,
-            Instruction::ExecuteCompare,
-            Instruction::ExecuteCopyTerm,
-            Instruction::ExecuteFunctor,
-            Instruction::ExecuteGround,
-            Instruction::ExecuteKeySort,
-            Instruction::ExecuteSort,
-            Instruction::ExecuteN(1),
-            Instruction::ExecuteN(2),
-            Instruction::ExecuteN(3),
-            Instruction::ExecuteN(4),
-            Instruction::ExecuteN(5),
-            Instruction::ExecuteN(6),
-            Instruction::ExecuteN(7),
-            Instruction::ExecuteN(8),
-            Instruction::ExecuteN(9),
-            Instruction::ExecuteIsAtom(temp_v!(1)),
-            Instruction::ExecuteIsAtomic(temp_v!(1)),
-            Instruction::ExecuteIsCompound(temp_v!(1)),
-            Instruction::ExecuteIsInteger(temp_v!(1)),
-            Instruction::ExecuteIsNumber(temp_v!(1)),
-            Instruction::ExecuteIsRational(temp_v!(1)),
-            Instruction::ExecuteIsFloat(temp_v!(1)),
-            Instruction::ExecuteIsNonVar(temp_v!(1)),
-            Instruction::ExecuteIsVar(temp_v!(1))
-        ].into_iter());
+        self.code.extend(
+            vec![
+                Instruction::BreakFromDispatchLoop,
+                Instruction::InstallVerifyAttr,
+                Instruction::VerifyAttrInterrupt,
+                Instruction::ExecuteTermGreaterThan,
+                Instruction::ExecuteTermLessThan,
+                Instruction::ExecuteTermGreaterThanOrEqual,
+                Instruction::ExecuteTermLessThanOrEqual,
+                Instruction::ExecuteTermEqual,
+                Instruction::ExecuteTermNotEqual,
+                Instruction::ExecuteNumberGreaterThan(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
+                Instruction::ExecuteNumberLessThan(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
+                Instruction::ExecuteNumberGreaterThanOrEqual(
+                    ar_reg!(temp_v!(1)),
+                    ar_reg!(temp_v!(2)),
+                ),
+                Instruction::ExecuteNumberLessThanOrEqual(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
+                Instruction::ExecuteNumberEqual(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
+                Instruction::ExecuteNumberNotEqual(ar_reg!(temp_v!(1)), ar_reg!(temp_v!(2))),
+                Instruction::ExecuteIs(temp_v!(1), ar_reg!(temp_v!(2))),
+                Instruction::ExecuteAcyclicTerm,
+                Instruction::ExecuteArg,
+                Instruction::ExecuteCompare,
+                Instruction::ExecuteCopyTerm,
+                Instruction::ExecuteFunctor,
+                Instruction::ExecuteGround,
+                Instruction::ExecuteKeySort,
+                Instruction::ExecuteSort,
+                Instruction::ExecuteN(1),
+                Instruction::ExecuteN(2),
+                Instruction::ExecuteN(3),
+                Instruction::ExecuteN(4),
+                Instruction::ExecuteN(5),
+                Instruction::ExecuteN(6),
+                Instruction::ExecuteN(7),
+                Instruction::ExecuteN(8),
+                Instruction::ExecuteN(9),
+                Instruction::ExecuteIsAtom(temp_v!(1)),
+                Instruction::ExecuteIsAtomic(temp_v!(1)),
+                Instruction::ExecuteIsCompound(temp_v!(1)),
+                Instruction::ExecuteIsInteger(temp_v!(1)),
+                Instruction::ExecuteIsNumber(temp_v!(1)),
+                Instruction::ExecuteIsRational(temp_v!(1)),
+                Instruction::ExecuteIsFloat(temp_v!(1)),
+                Instruction::ExecuteIsNonVar(temp_v!(1)),
+                Instruction::ExecuteIsVar(temp_v!(1)),
+            ]
+            .into_iter(),
+        );
 
-        for (p, instr) in self.code[impls_offset ..].iter().enumerate() {
+        for (p, instr) in self.code[impls_offset..].iter().enumerate() {
             let key = instr.to_name_and_arity();
             self.indices.code_dir.insert(
                 key,
-                CodeIndex::new(IndexPtr::index(p + impls_offset), &mut self.machine_st.arena),
+                CodeIndex::new(
+                    IndexPtr::index(p + impls_offset),
+                    &mut self.machine_st.arena,
+                ),
             );
         }
     }
@@ -428,8 +453,7 @@ impl Machine {
         let user_error = Stream::stderr(&mut machine_st.arena);
 
         #[cfg(not(target_os = "wasi"))]
-        let runtime = tokio::runtime::Runtime::new()
-            .unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
         #[cfg(target_os = "wasi")]
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -446,7 +470,7 @@ impl Machine {
             load_contexts: vec![],
             runtime,
             #[cfg(feature = "ffi")]
-	        foreign_function_table: Default::default(),
+            foreign_function_table: Default::default(),
         };
 
         let mut lib_path = current_dir();
@@ -470,10 +494,7 @@ impl Machine {
         .unwrap();
 
         bootstrapping_compile(
-            Stream::from_static_string(
-                LIBRARIES.borrow()["builtins"],
-                &mut wam.machine_st.arena,
-            ),
+            Stream::from_static_string(LIBRARIES.borrow()["builtins"], &mut wam.machine_st.arena),
             &mut wam,
             ListingSource::from_file_and_path(atom!("builtins.pl"), lib_path.clone()),
         )
@@ -526,7 +547,9 @@ impl Machine {
     }
 
     pub(crate) fn configure_streams(&mut self) {
-        self.user_input.options_mut().set_alias_to_atom_opt(Some(atom!("user_input")));
+        self.user_input
+            .options_mut()
+            .set_alias_to_atom_opt(Some(atom!("user_input")));
 
         self.indices
             .stream_aliases
@@ -534,7 +557,9 @@ impl Machine {
 
         self.indices.streams.insert(self.user_input);
 
-        self.user_output.options_mut().set_alias_to_atom_opt(Some(atom!("user_output")));
+        self.user_output
+            .options_mut()
+            .set_alias_to_atom_opt(Some(atom!("user_output")));
 
         self.indices
             .stream_aliases
@@ -564,9 +589,16 @@ impl Machine {
 
                     loop {
                         let indexing_code_ptr = match &indexing_lines[oip] {
-                            &IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(arg, v, c, l, s)) => {
+                            &IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
+                                arg,
+                                v,
+                                c,
+                                l,
+                                s,
+                            )) => {
                                 cell = self.deref_register(arg);
-                                self.machine_st.select_switch_on_term_index(cell, v, c, l, s)
+                                self.machine_st
+                                    .select_switch_on_term_index(cell, v, c, l, s)
                             }
                             IndexingLine::Indexing(IndexingInstruction::SwitchOnConstant(hm)) => {
                                 let lit = self.machine_st.constant_to_literal(cell);
@@ -676,7 +708,12 @@ impl Machine {
                         }
                     );
                 }
-                &Instruction::GetPartialString(Level::Shallow, string, RegType::Temp(t), has_tail) => {
+                &Instruction::GetPartialString(
+                    Level::Shallow,
+                    string,
+                    RegType::Temp(t),
+                    has_tail,
+                ) => {
                     let cell = self.deref_register(t);
 
                     read_heap_cell!(cell,
@@ -707,17 +744,17 @@ impl Machine {
                         }
                     );
                 }
-                Instruction::GetConstant(..) |
-                Instruction::GetList(..) |
-                Instruction::GetStructure(..) |
-                Instruction::GetPartialString(..) |
-                &Instruction::UnifyVoid(..) |
-                &Instruction::UnifyConstant(..) |
-                &Instruction::GetVariable(..) |
-                &Instruction::GetValue(..) |
-                &Instruction::UnifyVariable(..) |
-                &Instruction::UnifyValue(..) |
-                &Instruction::UnifyLocalValue(..)  => {
+                Instruction::GetConstant(..)
+                | Instruction::GetList(..)
+                | Instruction::GetStructure(..)
+                | Instruction::GetPartialString(..)
+                | &Instruction::UnifyVoid(..)
+                | &Instruction::UnifyConstant(..)
+                | &Instruction::GetVariable(..)
+                | &Instruction::GetValue(..)
+                | &Instruction::UnifyVariable(..)
+                | &Instruction::UnifyValue(..)
+                | &Instruction::UnifyLocalValue(..) => {
                     offset += 1;
                 }
                 _ => {
@@ -732,9 +769,10 @@ impl Machine {
     fn next_applicable_clause(&mut self, mut offset: usize) -> Option<usize> {
         while !self.next_clause_applicable(self.machine_st.p + offset + 1) {
             match &self.code[self.machine_st.p + offset] {
-                &Instruction::DefaultRetryMeElse(o) | &Instruction::RetryMeElse(o) |
-                &Instruction::DynamicElse(.., NextOrFail::Next(o)) |
-                &Instruction::DynamicInternalElse(.., NextOrFail::Next(o)) => offset += o,
+                &Instruction::DefaultRetryMeElse(o)
+                | &Instruction::RetryMeElse(o)
+                | &Instruction::DynamicElse(.., NextOrFail::Next(o))
+                | &Instruction::DynamicInternalElse(.., NextOrFail::Next(o)) => offset += o,
                 _ => {
                     return None;
                 }
@@ -753,16 +791,16 @@ impl Machine {
                     match &indexing_lines[self.machine_st.oip as usize] {
                         IndexingLine::IndexedChoice(indexed_choice) => {
                             match &indexed_choice[(self.machine_st.iip + inner_offset) as usize] {
-                                &IndexedChoiceInstruction::Retry(o) |
-                                &IndexedChoiceInstruction::DefaultRetry(o) => {
+                                &IndexedChoiceInstruction::Retry(o)
+                                | &IndexedChoiceInstruction::DefaultRetry(o) => {
                                     if self.next_clause_applicable(self.machine_st.p + o) {
                                         return Some(inner_offset);
                                     }
 
                                     inner_offset += 1;
                                 }
-                                &IndexedChoiceInstruction::Trust(o) |
-                                &IndexedChoiceInstruction::DefaultTrust(o) => {
+                                &IndexedChoiceInstruction::Trust(o)
+                                | &IndexedChoiceInstruction::DefaultTrust(o) => {
                                     return if self.next_clause_applicable(self.machine_st.p + o) {
                                         Some(inner_offset)
                                     } else {
@@ -815,12 +853,13 @@ impl Machine {
             or_frame.prelude.tr = self.machine_st.tr;
             or_frame.prelude.h = self.machine_st.heap.len();
             or_frame.prelude.b0 = self.machine_st.b0;
-            or_frame.prelude.attr_var_queue_len = self.machine_st.attr_var_init.attr_var_queue.len();
+            or_frame.prelude.attr_var_queue_len =
+                self.machine_st.attr_var_init.attr_var_queue.len();
 
             self.machine_st.b = b;
 
             for i in 0..n {
-                or_frame[i] = self.machine_st.registers[i+1];
+                or_frame[i] = self.machine_st.registers[i + 1];
             }
 
             self.machine_st.hb = self.machine_st.heap.len();
@@ -846,12 +885,13 @@ impl Machine {
             or_frame.prelude.tr = self.machine_st.tr;
             or_frame.prelude.h = self.machine_st.heap.len();
             or_frame.prelude.b0 = self.machine_st.b0;
-            or_frame.prelude.attr_var_queue_len = self.machine_st.attr_var_init.attr_var_queue.len();
+            or_frame.prelude.attr_var_queue_len =
+                self.machine_st.attr_var_init.attr_var_queue.len();
 
             self.machine_st.b = b;
 
             for i in 0..n {
-                or_frame[i] = self.machine_st.registers[i+1];
+                or_frame[i] = self.machine_st.registers[i + 1];
             }
 
             self.machine_st.hb = self.machine_st.heap.len();
@@ -914,7 +954,7 @@ impl Machine {
         let curr_tr = self.machine_st.tr;
 
         for i in 0..n {
-            self.machine_st.registers[i+1] = or_frame[i];
+            self.machine_st.registers[i + 1] = or_frame[i];
         }
 
         self.unwind_trail(old_tr, curr_tr);
@@ -958,7 +998,7 @@ impl Machine {
         let curr_tr = self.machine_st.tr;
 
         for i in 0..n {
-            self.machine_st.registers[i+1] = or_frame[i];
+            self.machine_st.registers[i + 1] = or_frame[i];
         }
 
         self.unwind_trail(old_tr, curr_tr);
@@ -1001,7 +1041,7 @@ impl Machine {
         let n = or_frame.prelude.num_cells;
 
         for i in 0..n {
-            self.machine_st.registers[i+1] = or_frame[i];
+            self.machine_st.registers[i + 1] = or_frame[i];
         }
 
         let old_tr = or_frame.prelude.tr;
@@ -1040,15 +1080,17 @@ impl Machine {
     #[inline(always)]
     fn undefined_procedure(&mut self, name: Atom, arity: usize) -> CallResult {
         match self.machine_st.flags.unknown {
-            Unknown::Error => {
-                Err(self.machine_st.throw_undefined_error(name, arity))
-            }
+            Unknown::Error => Err(self.machine_st.throw_undefined_error(name, arity)),
             Unknown::Fail => {
                 self.machine_st.fail = true;
                 Ok(())
             }
             Unknown::Warn => {
-                println!("warning: predicate {}/{} is undefined", name.as_str(), arity);
+                println!(
+                    "warning: predicate {}/{} is undefined",
+                    name.as_str(),
+                    arity
+                );
                 self.machine_st.fail = true;
                 Ok(())
             }
@@ -1093,9 +1135,7 @@ impl Machine {
                 self.machine_st.dynamic_mode = FirstOrNext::First;
                 self.machine_st.execute_at_index(arity, compiled_tl_index);
             }
-            IndexPtrTag::Index => {
-                self.machine_st.execute_at_index(arity, compiled_tl_index)
-            }
+            IndexPtrTag::Index => self.machine_st.execute_at_index(arity, compiled_tl_index),
         }
 
         Ok(())
@@ -1120,7 +1160,9 @@ impl Machine {
                 }
             } else {
                 let stub = functor_stub(name, arity);
-                let err = self.machine_st.module_resolution_error(module_name, name, arity);
+                let err = self
+                    .machine_st
+                    .module_resolution_error(module_name, name, arity);
 
                 Err(self.machine_st.error_form(err, stub))
             }
@@ -1146,7 +1188,9 @@ impl Machine {
                 }
             } else {
                 let stub = functor_stub(name, arity);
-                let err = self.machine_st.module_resolution_error(module_name, name, arity);
+                let err = self
+                    .machine_st
+                    .module_resolution_error(module_name, name, arity);
 
                 Err(self.machine_st.error_form(err, stub))
             }
@@ -1180,12 +1224,16 @@ impl Machine {
                 let r_c_wo_h_atom = atom!("run_cleaners_without_handling");
                 let iso_ext = atom!("iso_ext");
 
-                RCWH = self.indices.get_predicate_code_index(r_c_w_h_atom, 0, iso_ext)
-                           .and_then(|item| item.local())
-                           .unwrap();
-                RCWOH = self.indices.get_predicate_code_index(r_c_wo_h_atom, 1, iso_ext)
-                            .and_then(|item| item.local())
-                            .unwrap();
+                RCWH = self
+                    .indices
+                    .get_predicate_code_index(r_c_w_h_atom, 0, iso_ext)
+                    .and_then(|item| item.local())
+                    .unwrap();
+                RCWOH = self
+                    .indices
+                    .get_predicate_code_index(r_c_wo_h_atom, 1, iso_ext)
+                    .and_then(|item| item.local())
+                    .unwrap();
             });
 
             (RCWH, RCWOH)
@@ -1196,9 +1244,8 @@ impl Machine {
                 let (idx, arity) = if self.machine_st.effective_block() > prev_block {
                     (r_c_w_h, 0)
                 } else {
-                    self.machine_st.registers[1] = fixnum_as_cell!(
-                        Fixnum::build_with(b_cutoff as i64)
-                    );
+                    self.machine_st.registers[1] =
+                        fixnum_as_cell!(Fixnum::build_with(b_cutoff as i64));
 
                     (r_c_wo_h, 1)
                 };
@@ -1265,8 +1312,7 @@ impl Machine {
                         None => unreachable!(),
                     }
                 }
-                TrailEntryTag::TrailedAttachedValue => {
-                }
+                TrailEntryTag::TrailedAttachedValue => {}
             }
         }
     }

--- a/src/machine/partial_string.rs
+++ b/src/machine/partial_string.rs
@@ -45,9 +45,9 @@ impl PartialString {
     #[inline]
     pub(super) fn new<'a>(src: &'a str, atom_tbl: &mut AtomTable) -> Option<(Self, &'a str)> {
         let terminator_idx = scan_for_terminator(src.chars());
-        let pstr = PartialString(atom_tbl.build_with(&src[.. terminator_idx]));
+        let pstr = PartialString(atom_tbl.build_with(&src[..terminator_idx]));
 
-        Some(if terminator_idx <  src.as_bytes().len() {
+        Some(if terminator_idx < src.as_bytes().len() {
             (pstr, &src[terminator_idx + 1..])
         } else {
             (pstr, "")
@@ -124,11 +124,15 @@ impl<'a> HeapPStrIter<'a> {
 
         let mut final_result = None;
 
-        while let Some(PStrIterStep { iteratee, next_hare }) = self.step(self.brent_st.hare) {
+        while let Some(PStrIterStep {
+            iteratee,
+            next_hare,
+        }) = self.step(self.brent_st.hare)
+        {
             self.brent_st.hare = next_hare;
             self.focus = self.heap[iteratee.focus()];
 
-            result.focus  = iteratee.focus();
+            result.focus = iteratee.focus();
             result.offset = iteratee.offset();
 
             match iteratee {
@@ -202,7 +206,7 @@ impl<'a> HeapPStrIter<'a> {
         self.brent_st.hare = self.orig_focus;
         self.brent_st.tortoise = self.orig_focus;
 
-        for _ in 0 .. self.brent_st.lam {
+        for _ in 0..self.brent_st.lam {
             self.brent_st.hare = self.step(self.brent_st.hare).unwrap().next_hare;
         }
 
@@ -238,43 +242,43 @@ impl<'a> HeapPStrIter<'a> {
         let mut focus = self.focus;
 
         loop {
-           read_heap_cell!(focus,
-               (HeapCellValueTag::CStr | HeapCellValueTag::PStrLoc) => {
-                   return true;
-               }
-               (HeapCellValueTag::Atom, (name, arity)) => { // TODO: use Str here?
-                   return name == atom!(".") && arity == 2;
-               }
-               (HeapCellValueTag::Lis, h) => {
-                   let value = self.heap[h];
-                   let value = heap_bound_store(
-                       self.heap,
-                       heap_bound_deref(self.heap, value),
-                   );
+            read_heap_cell!(focus,
+                (HeapCellValueTag::CStr | HeapCellValueTag::PStrLoc) => {
+                    return true;
+                }
+                (HeapCellValueTag::Atom, (name, arity)) => { // TODO: use Str here?
+                    return name == atom!(".") && arity == 2;
+                }
+                (HeapCellValueTag::Lis, h) => {
+                    let value = self.heap[h];
+                    let value = heap_bound_store(
+                        self.heap,
+                        heap_bound_deref(self.heap, value),
+                    );
 
-                   return read_heap_cell!(value,
-                       (HeapCellValueTag::Atom, (name, arity)) => {
-                           arity == 0 && name.as_char().is_some()
-                       }
-                       (HeapCellValueTag::Char) => {
-                           true
-                       }
-                       _ => {
-                           false
-                       }
-                   );
-               }
-               (HeapCellValueTag::AttrVar | HeapCellValueTag::Var, h) => {
-                   if focus == self.heap[h] {
-                       return false;
-                   }
+                    return read_heap_cell!(value,
+                        (HeapCellValueTag::Atom, (name, arity)) => {
+                            arity == 0 && name.as_char().is_some()
+                        }
+                        (HeapCellValueTag::Char) => {
+                            true
+                        }
+                        _ => {
+                            false
+                        }
+                    );
+                }
+                (HeapCellValueTag::AttrVar | HeapCellValueTag::Var, h) => {
+                    if focus == self.heap[h] {
+                        return false;
+                    }
 
-                   focus = self.heap[h];
-               }
-               _ => {
-                   return false;
-               }
-           );
+                    focus = self.heap[h];
+                }
+                _ => {
+                    return false;
+                }
+            );
         }
     }
 
@@ -381,13 +385,15 @@ impl<'a> HeapPStrIter<'a> {
     }
 
     fn pre_cycle_discovery_stepper(&mut self) -> Option<PStrIteratee> {
-        let PStrIterStep { iteratee, next_hare } =
-            match self.step(self.brent_st.hare) {
-                Some(results) => results,
-                None => {
-                    return None;
-                }
-            };
+        let PStrIterStep {
+            iteratee,
+            next_hare,
+        } = match self.step(self.brent_st.hare) {
+            Some(results) => results,
+            None => {
+                return None;
+            }
+        };
 
         self.focus = self.heap[iteratee.focus()];
 
@@ -421,13 +427,15 @@ impl<'a> HeapPStrIter<'a> {
             return None;
         }
 
-        let PStrIterStep { iteratee, next_hare } =
-            match self.step(self.brent_st.hare) {
-                Some(results) => results,
-                None => {
-                    return None;
-                }
-            };
+        let PStrIterStep {
+            iteratee,
+            next_hare,
+        } = match self.step(self.brent_st.hare) {
+            Some(results) => results,
+            None => {
+                return None;
+            }
+        };
 
         self.focus = self.heap[next_hare];
         self.brent_st.hare = next_hare;
@@ -515,11 +523,8 @@ impl<'a> Iterator for PStrCharsIter<'a> {
 
                     match pstr.as_str_from(n).chars().next() {
                         Some(c) => {
-                            self.item = Some(PStrIteratee::PStrSegment(
-                                f1,
-                                pstr_atom,
-                                n + c.len_utf8(),
-                            ));
+                            self.item =
+                                Some(PStrIteratee::PStrSegment(f1, pstr_atom, n + c.len_utf8()));
 
                             return Some(c);
                         }
@@ -684,8 +689,10 @@ pub fn compare_pstr_prefixes<'a>(
                             }
                         }
                     }
-                    (PStrIteratee::PStrSegment(f1, pstr1_atom, n1),
-                     PStrIteratee::PStrSegment(f2, pstr2_atom, n2)) => {
+                    (
+                        PStrIteratee::PStrSegment(f1, pstr1_atom, n1),
+                        PStrIteratee::PStrSegment(f2, pstr2_atom, n2),
+                    ) => {
                         if pstr1_atom == pstr2_atom && n1 == n2 {
                             cycle_detection_step(i1, i2, &step_1);
                             let both_cyclic = cycle_detection_step(i2, i1, &step_2);
@@ -719,7 +726,8 @@ pub fn compare_pstr_prefixes<'a>(
                                 }
                             }
                             Ordering::Less if str2.starts_with(str1) => {
-                                step_2.iteratee = PStrIteratee::PStrSegment(f2, pstr2_atom, n2 + str1.len());
+                                step_2.iteratee =
+                                    PStrIteratee::PStrSegment(f2, pstr2_atom, n2 + str1.len());
                                 let c1_result = cycle_detection_step(i1, i2, &step_1);
                                 r1 = step(i1, i1.brent_st.hare);
 
@@ -728,7 +736,8 @@ pub fn compare_pstr_prefixes<'a>(
                                 }
                             }
                             Ordering::Greater if str1.starts_with(str2) => {
-                                step_1.iteratee = PStrIteratee::PStrSegment(f1, pstr1_atom, n1 + str2.len());
+                                step_1.iteratee =
+                                    PStrIteratee::PStrSegment(f1, pstr1_atom, n1 + str2.len());
                                 let c2_result = cycle_detection_step(i2, i1, &step_2);
                                 r2 = step(i2, i2.brent_st.hare);
 
@@ -836,7 +845,11 @@ mod test {
             );
             assert_eq!(
                 iter.next(),
-                Some(PStrIteratee::PStrSegment(2, cell_as_atom!(pstr_second_cell), 0))
+                Some(PStrIteratee::PStrSegment(
+                    2,
+                    cell_as_atom!(pstr_second_cell),
+                    0
+                ))
             );
 
             assert_eq!(iter.next(), None);
@@ -855,7 +868,11 @@ mod test {
             );
             assert_eq!(
                 iter.next(),
-                Some(PStrIteratee::PStrSegment(2, cell_as_atom!(pstr_second_cell), 0))
+                Some(PStrIteratee::PStrSegment(
+                    2,
+                    cell_as_atom!(pstr_second_cell),
+                    0
+                ))
             );
 
             assert_eq!(iter.next(), None);
@@ -863,10 +880,14 @@ mod test {
         }
 
         wam.machine_st.heap.pop();
-        wam.machine_st.heap.push(pstr_loc_as_cell!(wam.machine_st.heap.len() + 1));
+        wam.machine_st
+            .heap
+            .push(pstr_loc_as_cell!(wam.machine_st.heap.len() + 1));
 
         wam.machine_st.heap.push(pstr_offset_as_cell!(0));
-        wam.machine_st.heap.push(fixnum_as_cell!(Fixnum::build_with(0)));
+        wam.machine_st
+            .heap
+            .push(fixnum_as_cell!(Fixnum::build_with(0)));
 
         {
             let mut iter = HeapPStrIter::new(&wam.machine_st.heap, 0);
@@ -892,31 +913,25 @@ mod test {
             // construct a structurally similar but different cyclic partial string
             // matching the one beginning at wam.machine_st.heap[0].
 
-            put_partial_string(
-                &mut wam.machine_st.heap,
-                "ab",
-                &mut wam.machine_st.atom_tbl,
-            );
+            put_partial_string(&mut wam.machine_st.heap, "ab", &mut wam.machine_st.atom_tbl);
 
             wam.machine_st.heap.pop();
 
-            wam.machine_st.heap.push(pstr_loc_as_cell!(second_h+2));
+            wam.machine_st.heap.push(pstr_loc_as_cell!(second_h + 2));
 
-            put_partial_string(
-                &mut wam.machine_st.heap,
-                "c ",
-                &mut wam.machine_st.atom_tbl,
-            );
+            put_partial_string(&mut wam.machine_st.heap, "c ", &mut wam.machine_st.atom_tbl);
 
             wam.machine_st.heap.pop();
 
-            wam.machine_st.heap.push(pstr_loc_as_cell!(second_h+4));
+            wam.machine_st.heap.push(pstr_loc_as_cell!(second_h + 4));
 
             wam.machine_st.heap.push(pstr_second_cell);
-            wam.machine_st.heap.push(pstr_loc_as_cell!(second_h+6));
+            wam.machine_st.heap.push(pstr_loc_as_cell!(second_h + 6));
 
             wam.machine_st.heap.push(pstr_offset_as_cell!(second_h));
-            wam.machine_st.heap.push(fixnum_as_cell!(Fixnum::build_with(0)));
+            wam.machine_st
+                .heap
+                .push(fixnum_as_cell!(Fixnum::build_with(0)));
 
             let mut iter1 = HeapPStrIter::new(&wam.machine_st.heap, 0);
             let mut iter2 = HeapPStrIter::new(&wam.machine_st.heap, second_h);
@@ -982,20 +997,11 @@ mod test {
 
         unify!(wam.machine_st, cstr_var_cell, heap_loc_as_cell!(1));
 
-        assert_eq!(
-            wam.machine_st.heap[2],
-            char_as_cell!('a'),
-        );
+        assert_eq!(wam.machine_st.heap[2], char_as_cell!('a'),);
 
-        assert_eq!(
-            wam.machine_st.heap[4],
-            char_as_cell!('b'),
-        );
+        assert_eq!(wam.machine_st.heap[4], char_as_cell!('b'),);
 
-        assert_eq!(
-            wam.machine_st.heap[6],
-            char_as_cell!('c'),
-        );
+        assert_eq!(wam.machine_st.heap[6], char_as_cell!('c'),);
 
         // test "abc" = [X,Y,Z|D].
 
@@ -1022,35 +1028,20 @@ mod test {
 
         assert_eq!(wam.machine_st.fail, false);
 
-        assert_eq!(
-            wam.machine_st.heap[2],
-            char_as_cell!('a'),
-        );
+        assert_eq!(wam.machine_st.heap[2], char_as_cell!('a'),);
 
-        assert_eq!(
-            wam.machine_st.heap[4],
-            char_as_cell!('b'),
-        );
+        assert_eq!(wam.machine_st.heap[4], char_as_cell!('b'),);
 
-        assert_eq!(
-            wam.machine_st.heap[6],
-            char_as_cell!('c'),
-        );
+        assert_eq!(wam.machine_st.heap[6], char_as_cell!('c'),);
 
-        assert_eq!(
-            wam.machine_st.heap[7],
-            empty_list_as_cell!(),
-        );
+        assert_eq!(wam.machine_st.heap[7], empty_list_as_cell!(),);
 
         // test "d" = [d].
 
         wam.machine_st.heap.clear();
 
-        let cstr_var_cell = put_complete_string(
-            &mut wam.machine_st.heap,
-            "d",
-            &mut wam.machine_st.atom_tbl,
-        );
+        let cstr_var_cell =
+            put_complete_string(&mut wam.machine_st.heap, "d", &mut wam.machine_st.atom_tbl);
 
         wam.machine_st.heap.push(list_loc_as_cell!(2));
         wam.machine_st.heap.push(char_as_cell!('d'));
@@ -1085,20 +1076,11 @@ mod test {
 
         assert_eq!(wam.machine_st.fail, false);
 
-        assert_eq!(
-            wam.machine_st.heap[2],
-            char_as_cell!('a'),
-        );
+        assert_eq!(wam.machine_st.heap[2], char_as_cell!('a'),);
 
-        assert_eq!(
-            wam.machine_st.heap[4],
-            char_as_cell!('b'),
-        );
+        assert_eq!(wam.machine_st.heap[4], char_as_cell!('b'),);
 
-        assert_eq!(
-            wam.machine_st.heap[6],
-            char_as_cell!('c'),
-        );
+        assert_eq!(wam.machine_st.heap[6], char_as_cell!('c'),);
 
         // test "abcdef" = [a,b,c|X].
 
@@ -1123,7 +1105,10 @@ mod test {
         assert_eq!(wam.machine_st.heap[3], pstr_loc_as_cell!(1));
         assert_eq!(wam.machine_st.heap[4], atom_as_cstr_cell!(atom!("abcdef")));
         assert_eq!(wam.machine_st.heap[5], pstr_offset_as_cell!(4));
-        assert_eq!(wam.machine_st.heap[6], fixnum_as_cell!(Fixnum::build_with("abc".len() as i64)));
+        assert_eq!(
+            wam.machine_st.heap[6],
+            fixnum_as_cell!(Fixnum::build_with("abc".len() as i64))
+        );
 
         // test iteration on X = [b,c,b,c,b,c,b,c|...] as an offset.
 
@@ -1132,7 +1117,9 @@ mod test {
         wam.machine_st.heap.push(pstr_as_cell!(atom!("abc")));
         wam.machine_st.heap.push(pstr_loc_as_cell!(2));
         wam.machine_st.heap.push(pstr_offset_as_cell!(0));
-        wam.machine_st.heap.push(fixnum_as_cell!(Fixnum::build_with(1)));
+        wam.machine_st
+            .heap
+            .push(fixnum_as_cell!(Fixnum::build_with(1)));
 
         {
             let mut iter = HeapPStrIter::new(&wam.machine_st.heap, 2);

--- a/src/machine/partial_string.rs
+++ b/src/machine/partial_string.rs
@@ -1,5 +1,3 @@
-use tokio::sync::RwLock;
-
 use crate::atom_table::*;
 use crate::parser::ast::*;
 
@@ -45,7 +43,7 @@ impl Into<Atom> for PartialString {
 
 impl PartialString {
     #[inline]
-    pub(super) fn new<'a>(src: &'a str, atom_tbl: &RwLock<AtomTable>) -> Option<(Self, &'a str)> {
+    pub(super) fn new<'a>(src: &'a str, atom_tbl: &AtomTable) -> Option<(Self, &'a str)> {
         let terminator_idx = scan_for_terminator(src.chars());
         let pstr = PartialString(AtomTable::build_with(&atom_tbl, &src[..terminator_idx]));
         Some(if terminator_idx < src.as_bytes().len() {

--- a/src/machine/preprocessor.rs
+++ b/src/machine/preprocessor.rs
@@ -8,7 +8,6 @@ use crate::machine::machine_errors::*;
 use crate::parser::ast::*;
 
 use indexmap::IndexSet;
-use tokio::sync::RwLock;
 
 use std::cell::Cell;
 use std::convert::TryFrom;
@@ -26,10 +25,7 @@ pub(crate) fn to_op_decl(prec: u16, spec: Atom, name: Atom) -> Result<OpDecl, Co
     }
 }
 
-fn setup_op_decl(
-    mut terms: Vec<Term>,
-    atom_tbl: &RwLock<AtomTable>,
-) -> Result<OpDecl, CompilationError> {
+fn setup_op_decl(mut terms: Vec<Term>, atom_tbl: &AtomTable) -> Result<OpDecl, CompilationError> {
     let name = match terms.pop().unwrap() {
         Term::Literal(_, Literal::Atom(name)) => name,
         Term::Literal(_, Literal::Char(c)) => AtomTable::build_with(atom_tbl, &c.to_string()),
@@ -86,7 +82,7 @@ fn setup_predicate_indicator(term: &mut Term) -> Result<PredicateKey, Compilatio
 
 fn setup_module_export(
     mut term: Term,
-    atom_tbl: &RwLock<AtomTable>,
+    atom_tbl: &AtomTable,
 ) -> Result<ModuleExport, CompilationError> {
     setup_predicate_indicator(&mut term)
         .map(ModuleExport::PredicateKey)
@@ -112,7 +108,7 @@ pub(crate) fn build_rule_body(vars: &[Term], body_term: Term) -> Term {
 
 pub(super) fn setup_module_export_list(
     mut export_list: Term,
-    atom_tbl: &RwLock<AtomTable>,
+    atom_tbl: &AtomTable,
 ) -> Result<Vec<ModuleExport>, CompilationError> {
     let mut exports = vec![];
 
@@ -132,7 +128,7 @@ pub(super) fn setup_module_export_list(
 
 fn setup_module_decl(
     mut terms: Vec<Term>,
-    atom_tbl: &RwLock<AtomTable>,
+    atom_tbl: &AtomTable,
 ) -> Result<ModuleDecl, CompilationError> {
     let export_list = terms.pop().unwrap();
     let name = terms.pop().unwrap();
@@ -165,7 +161,7 @@ type UseModuleExport = (ModuleSource, IndexSet<ModuleExport>);
 
 fn setup_qualified_import(
     mut terms: Vec<Term>,
-    atom_tbl: &RwLock<AtomTable>,
+    atom_tbl: &AtomTable,
 ) -> Result<UseModuleExport, CompilationError> {
     let mut export_list = terms.pop().unwrap();
     let module_src = match terms.pop().unwrap() {

--- a/src/machine/preprocessor.rs
+++ b/src/machine/preprocessor.rs
@@ -313,11 +313,17 @@ pub(super) fn setup_declaration<'a, LS: LoadState<'a>>(
             }
             (atom!("module"), 2) => {
                 let atom_tbl = &mut LS::machine_st(&mut loader.payload).atom_tbl;
-                Ok(Declaration::Module(setup_module_decl(terms, atom_tbl)?))
+                Ok(Declaration::Module(setup_module_decl(
+                    terms,
+                    &mut atom_tbl.blocking_write(),
+                )?))
             }
             (atom!("op"), 3) => {
                 let atom_tbl = &mut LS::machine_st(&mut loader.payload).atom_tbl;
-                Ok(Declaration::Op(setup_op_decl(terms, atom_tbl)?))
+                Ok(Declaration::Op(setup_op_decl(
+                    terms,
+                    &mut atom_tbl.blocking_write(),
+                )?))
             }
             (atom!("non_counted_backtracking"), 1) => {
                 let (name, arity) = setup_predicate_indicator(&mut terms.pop().unwrap())?;
@@ -326,7 +332,8 @@ pub(super) fn setup_declaration<'a, LS: LoadState<'a>>(
             (atom!("use_module"), 1) => Ok(Declaration::UseModule(setup_use_module_decl(terms)?)),
             (atom!("use_module"), 2) => {
                 let atom_tbl = &mut LS::machine_st(&mut loader.payload).atom_tbl;
-                let (name, exports) = setup_qualified_import(terms, atom_tbl)?;
+                let (name, exports) =
+                    setup_qualified_import(terms, &mut atom_tbl.blocking_write())?;
 
                 Ok(Declaration::UseQualifiedModule(name, exports))
             }

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -290,7 +290,7 @@ mod tests {
 
         assert_eq!(
             e,
-            0// 10 * mem::size_of::<HeapCellValue>() + prelude_size::<AndFrame>()
+            0 // 10 * mem::size_of::<HeapCellValue>() + prelude_size::<AndFrame>()
         );
 
         assert_eq!(and_frame.prelude.num_cells, 10);
@@ -315,7 +315,10 @@ mod tests {
         let and_frame = wam.machine_st.stack.index_and_frame_mut(next_e);
 
         for idx in 0..9 {
-            assert_eq!(and_frame[idx + 1], stack_loc_as_cell!(AndFrame, next_e, idx + 1));
+            assert_eq!(
+                and_frame[idx + 1],
+                stack_loc_as_cell!(AndFrame, next_e, idx + 1)
+            );
         }
 
         let and_frame = wam.machine_st.stack.index_and_frame(e);

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -30,12 +30,6 @@ pub struct Stack {
     _marker: PhantomData<HeapCellValue>,
 }
 
-impl Drop for Stack {
-    fn drop(&mut self) {
-        self.buf.deallocate();
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct AndFramePrelude {
     pub(crate) num_cells: usize,
@@ -189,7 +183,7 @@ impl Stack {
         let frame_size = AndFrame::size_of(num_cells);
 
         unsafe {
-            let e = self.buf.ptr as usize - self.buf.base as usize;
+            let e = (*self.buf.ptr.get_mut()) as usize - self.buf.base as usize;
             let new_ptr = self.alloc(frame_size);
             let mut offset = prelude_size::<AndFramePrelude>();
 
@@ -213,7 +207,7 @@ impl Stack {
         let frame_size = OrFrame::size_of(num_cells);
 
         unsafe {
-            let b = self.buf.ptr as usize - self.buf.base as usize;
+            let b = (*self.buf.ptr.get_mut()) as usize - self.buf.base as usize;
             let new_ptr = self.alloc(frame_size);
             let mut offset = prelude_size::<OrFramePrelude>();
 
@@ -269,8 +263,8 @@ impl Stack {
     pub(crate) fn truncate(&mut self, b: usize) {
         let base = self.buf.base as usize + b;
 
-        if base < self.buf.ptr as usize {
-            self.buf.ptr = base as *mut _;
+        if base < (*self.buf.ptr.get_mut()) as usize {
+            *self.buf.ptr.get_mut() = base as *mut _;
         }
     }
 }

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -4,13 +4,13 @@ use crate::parser::ast::*;
 use crate::parser::char_reader::*;
 use crate::read::*;
 
+#[cfg(feature = "http")]
+use crate::http::HttpResponse;
 use crate::machine::heap::*;
 use crate::machine::machine_errors::*;
 use crate::machine::machine_indices::*;
 use crate::machine::machine_state::*;
 use crate::types::*;
-#[cfg(feature = "http")]
-use crate::http::HttpResponse;
 
 pub use modular_bitfield::prelude::*;
 
@@ -19,11 +19,11 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::Debug;
 use std::fs::{File, OpenOptions};
-use std::hash::{Hash};
+use std::hash::Hash;
 use std::io;
 use std::io::{BufRead, Cursor, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::mem;
-use std::net::{TcpStream, Shutdown};
+use std::net::{Shutdown, TcpStream};
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
@@ -154,8 +154,10 @@ impl StreamLayout<CharReader<InputFileStream>> {
     fn position(&mut self) -> Option<u64> {
         // stream is the internal CharReader. subtract
         // its pending buffer length from position.
-        self.get_mut().file.seek(SeekFrom::Current(0))
-            .map(|pos| pos  - self.stream.rem_buf_len() as u64)
+        self.get_mut()
+            .file
+            .seek(SeekFrom::Current(0))
+            .map(|pos| pos - self.stream.rem_buf_len() as u64)
             .ok()
     }
 }
@@ -195,7 +197,7 @@ impl CharRead for StaticStringStream {
     #[inline(always)]
     fn peek_char(&mut self) -> Option<std::io::Result<char>> {
         let pos = self.stream.position() as usize;
-        self.stream.get_ref()[pos ..].chars().next().map(Ok)
+        self.stream.get_ref()[pos..].chars().next().map(Ok)
     }
 
     #[inline(always)]
@@ -205,7 +207,9 @@ impl CharRead for StaticStringStream {
 
     #[inline(always)]
     fn put_back_char(&mut self, c: char) {
-        self.stream.seek(SeekFrom::Current(- (c.len_utf8() as i64))).unwrap();
+        self.stream
+            .seek(SeekFrom::Current(-(c.len_utf8() as i64)))
+            .unwrap();
     }
 }
 
@@ -294,7 +298,7 @@ pub struct HttpWriteStream {
 #[cfg(feature = "http")]
 impl Debug for HttpWriteStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-	    write!(f, "Http Write Stream")
+        write!(f, "Http Write Stream")
     }
 }
 
@@ -302,28 +306,27 @@ impl Debug for HttpWriteStream {
 impl Write for HttpWriteStream {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-	self.buffer.extend_from_slice(buf);
-	Ok(buf.len())
+        self.buffer.extend_from_slice(buf);
+        Ok(buf.len())
     }
 
     #[inline]
     fn flush(&mut self) -> std::io::Result<()> {
-	let (ready, response, cvar) = &**self.response;
+        let (ready, response, cvar) = &**self.response;
 
-	let mut ready = ready.lock().unwrap();
-	{
-	    let mut response = response.lock().unwrap();
-	
-	    let bytes = bytes::Bytes::copy_from_slice(&self.buffer);
-	    let mut response_ = hyper::Response::builder()
-	        .status(self.status_code);
-	    *response_.headers_mut().unwrap() = self.headers.clone();
-	    *response = Some(response_.body(http_body_util::Full::new(bytes)).unwrap());
-	}
-	*ready = true;
-	cvar.notify_one();
+        let mut ready = ready.lock().unwrap();
+        {
+            let mut response = response.lock().unwrap();
 
-	Ok(())
+            let bytes = bytes::Bytes::copy_from_slice(&self.buffer);
+            let mut response_ = hyper::Response::builder().status(self.status_code);
+            *response_.headers_mut().unwrap() = self.headers.clone();
+            *response = Some(response_.body(http_body_util::Full::new(bytes)).unwrap());
+        }
+        *ready = true;
+        cvar.notify_one();
+
+        Ok(())
     }
 }
 
@@ -510,7 +513,9 @@ impl Stream {
     #[inline]
     pub fn from_owned_string(string: String, arena: &mut Arena) -> Stream {
         Stream::Byte(arena_alloc!(
-            StreamLayout::new(CharReader::new(ByteStream(Cursor::new(string.into_bytes())))),
+            StreamLayout::new(CharReader::new(ByteStream(Cursor::new(
+                string.into_bytes()
+            )))),
             arena
         ))
     }
@@ -546,7 +551,7 @@ impl Stream {
             #[cfg(feature = "http")]
             ArenaHeaderTag::HttpReadStream => Stream::HttpRead(TypedArenaPtr::new(ptr as *mut _)),
             #[cfg(feature = "http")]
-	        ArenaHeaderTag::HttpWriteStream => Stream::HttpWrite(TypedArenaPtr::new(ptr as *mut _)),
+            ArenaHeaderTag::HttpWriteStream => Stream::HttpWrite(TypedArenaPtr::new(ptr as *mut _)),
             ArenaHeaderTag::ReadlineStream => Stream::Readline(TypedArenaPtr::new(ptr as *mut _)),
             ArenaHeaderTag::StaticStringStream => {
                 Stream::StaticString(TypedArenaPtr::new(ptr as *mut _))
@@ -603,7 +608,7 @@ impl Stream {
             #[cfg(feature = "http")]
             Stream::HttpRead(ptr) => ptr.header_ptr(),
             #[cfg(feature = "http")]
-	        Stream::HttpWrite(ptr) => ptr.header_ptr(),
+            Stream::HttpWrite(ptr) => ptr.header_ptr(),
             Stream::Null(_) => ptr::null(),
             Stream::Readline(ptr) => ptr.header_ptr(),
             Stream::StandardOutput(ptr) => ptr.header_ptr(),
@@ -728,14 +733,14 @@ impl CharRead for Stream {
             Stream::StaticString(src) => (*src).peek_char(),
             Stream::Byte(cursor) => (*cursor).peek_char(),
             #[cfg(feature = "http")]
-	        Stream::HttpWrite(_) => Some(Err(std::io::Error::new(
+            Stream::HttpWrite(_) => Some(Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::ReadFromOutputStream,
             ))),
-            Stream::OutputFile(_) |
-            Stream::StandardError(_) |
-            Stream::StandardOutput(_) |
-            Stream::Null(_) => Some(Err(std::io::Error::new(
+            Stream::OutputFile(_)
+            | Stream::StandardError(_)
+            | Stream::StandardOutput(_)
+            | Stream::Null(_) => Some(Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::ReadFromOutputStream,
             ))),
@@ -754,14 +759,14 @@ impl CharRead for Stream {
             Stream::StaticString(src) => (*src).read_char(),
             Stream::Byte(cursor) => (*cursor).read_char(),
             #[cfg(feature = "http")]
-	        Stream::HttpWrite(_) => Some(Err(std::io::Error::new(
+            Stream::HttpWrite(_) => Some(Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::ReadFromOutputStream,
             ))),
-            Stream::OutputFile(_) |
-            Stream::StandardError(_) |
-            Stream::StandardOutput(_) |
-            Stream::Null(_) => Some(Err(std::io::Error::new(
+            Stream::OutputFile(_)
+            | Stream::StandardError(_)
+            | Stream::StandardOutput(_)
+            | Stream::Null(_) => Some(Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::ReadFromOutputStream,
             ))),
@@ -780,11 +785,11 @@ impl CharRead for Stream {
             Stream::StaticString(src) => src.put_back_char(c),
             Stream::Byte(cursor) => cursor.put_back_char(c),
             #[cfg(feature = "http")]
-	        Stream::HttpWrite(_) => {}
-            Stream::OutputFile(_) |
-            Stream::StandardError(_) |
-            Stream::StandardOutput(_) |
-            Stream::Null(_) => {}
+            Stream::HttpWrite(_) => {}
+            Stream::OutputFile(_)
+            | Stream::StandardError(_)
+            | Stream::StandardOutput(_)
+            | Stream::Null(_) => {}
         }
     }
 
@@ -800,11 +805,11 @@ impl CharRead for Stream {
             Stream::StaticString(ref mut src) => src.consume(nread),
             Stream::Byte(ref mut cursor) => cursor.consume(nread),
             #[cfg(feature = "http")]
-	        Stream::HttpWrite(_) => {}
-            Stream::OutputFile(_) |
-            Stream::StandardError(_) |
-            Stream::StandardOutput(_) |
-            Stream::Null(_) => {}
+            Stream::HttpWrite(_) => {}
+            Stream::OutputFile(_)
+            | Stream::StandardError(_)
+            | Stream::StandardOutput(_)
+            | Stream::Null(_) => {}
         }
     }
 }
@@ -823,17 +828,17 @@ impl Read for Stream {
             Stream::StaticString(src) => (*src).read(buf),
             Stream::Byte(cursor) => (*cursor).read(buf),
             #[cfg(feature = "http")]
-	        Stream::HttpWrite(_) => Err(std::io::Error::new(
+            Stream::HttpWrite(_) => Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::ReadFromOutputStream,
             )),
             Stream::OutputFile(_)
-                | Stream::StandardError(_)
-	            | Stream::StandardOutput(_)
-                | Stream::Null(_) => Err(std::io::Error::new(
-                    ErrorKind::PermissionDenied,
-                    StreamError::ReadFromOutputStream,
-                )),
+            | Stream::StandardError(_)
+            | Stream::StandardOutput(_)
+            | Stream::Null(_) => Err(std::io::Error::new(
+                ErrorKind::PermissionDenied,
+                StreamError::ReadFromOutputStream,
+            )),
         };
 
         bytes_read
@@ -851,16 +856,16 @@ impl Write for Stream {
             Stream::StandardOutput(stream) => stream.write(buf),
             Stream::StandardError(stream) => stream.write(buf),
             #[cfg(feature = "http")]
-	        Stream::HttpWrite(ref mut stream) => stream.get_mut().write(buf),
+            Stream::HttpWrite(ref mut stream) => stream.get_mut().write(buf),
             #[cfg(feature = "http")]
             Stream::HttpRead(_) => Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::WriteToInputStream,
             )),
-            Stream::StaticString(_) |
-            Stream::Readline(_) |
-            Stream::InputFile(..) |
-            Stream::Null(_) => Err(std::io::Error::new(
+            Stream::StaticString(_)
+            | Stream::Readline(_)
+            | Stream::InputFile(..)
+            | Stream::Null(_) => Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::WriteToInputStream,
             )),
@@ -877,16 +882,16 @@ impl Write for Stream {
             Stream::StandardError(stream) => stream.stream.flush(),
             Stream::StandardOutput(stream) => stream.stream.flush(),
             #[cfg(feature = "http")]
-	        Stream::HttpWrite(ref mut stream) => stream.stream.get_mut().flush(),
-            #[cfg(feature = "http")] 
+            Stream::HttpWrite(ref mut stream) => stream.stream.get_mut().flush(),
+            #[cfg(feature = "http")]
             Stream::HttpRead(_) => Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::FlushToInputStream,
             )),
-            Stream::StaticString(_) |
-            Stream::Readline(_) |
-            Stream::InputFile(_) |
-            Stream::Null(_) => Err(std::io::Error::new(
+            Stream::StaticString(_)
+            | Stream::Readline(_)
+            | Stream::InputFile(_)
+            | Stream::Null(_) => Err(std::io::Error::new(
                 ErrorKind::PermissionDenied,
                 StreamError::FlushToInputStream,
             )),
@@ -898,8 +903,10 @@ impl Write for Stream {
 enum StreamError {
     PeekByteFailed,
     PeekByteFromNonPeekableStream,
-    #[allow(unused)] PeekCharFailed,
-    #[allow(unused)] PeekCharFromNonPeekableStream,
+    #[allow(unused)]
+    PeekCharFailed,
+    #[allow(unused)]
+    PeekCharFromNonPeekableStream,
     ReadFromOutputStream,
     WriteToInputStream,
     FlushToInputStream,
@@ -958,7 +965,11 @@ impl PartialEq for Stream {
 
 impl Eq for Stream {}
 
-fn cursor_position<T>(past_end_of_stream: &mut bool, cursor: &Cursor<T>, cursor_len: u64) -> AtEndOfStream {
+fn cursor_position<T>(
+    past_end_of_stream: &mut bool,
+    cursor: &Cursor<T>,
+    cursor_len: u64,
+) -> AtEndOfStream {
     let position = cursor.position();
 
     let at_end_of_stream = match position.cmp(&cursor_len) {
@@ -984,17 +995,10 @@ impl Stream {
             Stream::StaticString(string_stream_layout) => {
                 Some(string_stream_layout.stream.stream.position())
             }
-            Stream::InputFile(file_stream) => {
-                file_stream.position()
-            }
+            Stream::InputFile(file_stream) => file_stream.position(),
             #[cfg(feature = "tls")]
-            Stream::NamedTls(..) => {
-                Some(0)
-            }
-            Stream::NamedTcp(..) 
-            | Stream::Readline(..) => {
-                Some(0)
-            }
+            Stream::NamedTls(..) => Some(0),
+            Stream::NamedTcp(..) | Stream::Readline(..) => Some(0),
             _ => None,
         };
 
@@ -1011,7 +1015,11 @@ impl Stream {
                     ..
                 } = &mut **stream_layout;
 
-                stream.get_mut().file.seek(SeekFrom::Start(position)).unwrap();
+                stream
+                    .get_mut()
+                    .file
+                    .seek(SeekFrom::Start(position))
+                    .unwrap();
                 stream.reset_buffer(); // flush the internal buffer.
 
                 if let Ok(metadata) = stream.get_ref().file.metadata() {
@@ -1127,9 +1135,7 @@ impl Stream {
                     }
                 }
             }
-            _ => {
-                AtEndOfStream::Not
-            }
+            _ => AtEndOfStream::Not,
         }
     }
 
@@ -1153,14 +1159,16 @@ impl Stream {
             #[cfg(feature = "tls")]
             Stream::NamedTls(..) => atom!("read_append"),
             Stream::Byte(_)
-                | Stream::Readline(_)
-                | Stream::StaticString(_)
-                | Stream::InputFile(..) => atom!("read"),
+            | Stream::Readline(_)
+            | Stream::StaticString(_)
+            | Stream::InputFile(..) => atom!("read"),
             Stream::NamedTcp(..) => atom!("read_append"),
             Stream::OutputFile(file) if file.is_append => atom!("append"),
             #[cfg(feature = "http")]
             Stream::HttpWrite(_) => atom!("write"),
-            Stream::OutputFile(_) | Stream::StandardError(_) | Stream::StandardOutput(_) => atom!("write"),
+            Stream::OutputFile(_) | Stream::StandardError(_) | Stream::StandardOutput(_) => {
+                atom!("write")
+            }
             Stream::Null(_) => atom!(""),
         }
     }
@@ -1182,11 +1190,7 @@ impl Stream {
     }
 
     #[inline]
-    pub(crate) fn from_tcp_stream(
-        address: Atom,
-        tcp_stream: TcpStream,
-        arena: &mut Arena,
-    ) -> Self {
+    pub(crate) fn from_tcp_stream(address: Atom, tcp_stream: TcpStream, arena: &mut Arena) -> Self {
         tcp_stream.set_read_timeout(None).unwrap();
         tcp_stream.set_write_timeout(None).unwrap();
 
@@ -1234,20 +1238,20 @@ impl Stream {
     #[cfg(feature = "http")]
     #[inline]
     pub(crate) fn from_http_sender(
-	response: TypedArenaPtr<HttpResponse>,
-	status_code: u16,
-	headers: hyper::HeaderMap,
-	arena: &mut Arena,
+        response: TypedArenaPtr<HttpResponse>,
+        status_code: u16,
+        headers: hyper::HeaderMap,
+        arena: &mut Arena,
     ) -> Self {
-	Stream::HttpWrite(arena_alloc!(
-	    StreamLayout::new(CharReader::new(HttpWriteStream {
-		response,
-		status_code,
-		headers,
-		buffer: Vec::new(),
-	    })),
-	    arena
-	))
+        Stream::HttpWrite(arena_alloc!(
+            StreamLayout::new(CharReader::new(HttpWriteStream {
+                response,
+                status_code,
+                headers,
+                buffer: Vec::new(),
+            })),
+            arena
+        ))
     }
 
     #[inline]
@@ -1282,11 +1286,9 @@ impl Stream {
         match stream {
             Stream::NamedTcp(ref mut tcp_stream) => {
                 tcp_stream.inner_mut().tcp_stream.shutdown(Shutdown::Both)
-            },
-            #[cfg(feature = "tls")]
-            Stream::NamedTls(ref mut tls_stream) => {
-                tls_stream.inner_mut().tls_stream.shutdown()
             }
+            #[cfg(feature = "tls")]
+            Stream::NamedTls(ref mut tls_stream) => tls_stream.inner_mut().tls_stream.shutdown(),
             #[cfg(feature = "http")]
             Stream::HttpRead(ref mut http_stream) => {
                 unsafe {
@@ -1297,14 +1299,14 @@ impl Stream {
                 Ok(())
             }
             #[cfg(feature = "http")]
-	        Stream::HttpWrite(ref mut http_stream) => {
+            Stream::HttpWrite(ref mut http_stream) => {
                 unsafe {
                     http_stream.set_tag(ArenaHeaderTag::Dropped);
                     std::ptr::drop_in_place(&mut http_stream.inner_mut().buffer as *mut _);
                 }
 
                 Ok(())
-	        }
+            }
             Stream::InputFile(mut file_stream) => {
                 // close the stream by dropping the inner File.
                 unsafe {
@@ -1323,7 +1325,7 @@ impl Stream {
 
                 Ok(())
             }
-            _ => Ok(())
+            _ => Ok(()),
         }
     }
 
@@ -1344,10 +1346,10 @@ impl Stream {
             #[cfg(feature = "http")]
             Stream::HttpRead(..) => true,
             Stream::NamedTcp(..)
-                | Stream::Byte(_)
-                | Stream::Readline(_)
-                | Stream::StaticString(_)
-                | Stream::InputFile(..) => true,
+            | Stream::Byte(_)
+            | Stream::Readline(_)
+            | Stream::StaticString(_)
+            | Stream::InputFile(..) => true,
             _ => false,
         }
     }
@@ -1360,10 +1362,10 @@ impl Stream {
             #[cfg(feature = "http")]
             Stream::HttpWrite(..) => true,
             Stream::StandardError(_)
-                | Stream::StandardOutput(_)
-                | Stream::NamedTcp(..)
-                | Stream::Byte(_)
-                | Stream::OutputFile(..) => true,
+            | Stream::StandardOutput(_)
+            | Stream::NamedTcp(..)
+            | Stream::Byte(_)
+            | Stream::OutputFile(..) => true,
             _ => false,
         }
     }
@@ -1381,7 +1383,12 @@ impl Stream {
                     return true;
                 }
                 Stream::InputFile(ref mut file_stream) => {
-                    file_stream.stream.get_mut().file.seek(SeekFrom::Start(0)).unwrap();
+                    file_stream
+                        .stream
+                        .get_mut()
+                        .file
+                        .seek(SeekFrom::Start(0))
+                        .unwrap();
                     return true;
                 }
                 Stream::Readline(ref mut readline_stream) => {
@@ -1410,17 +1417,13 @@ impl Stream {
                     _ => Err(std::io::Error::new(ErrorKind::UnexpectedEof, "end of file")),
                 }
             }
-            Stream::InputFile(ref mut file) => {
-                match file.peek_byte() {
-                    Some(result) => {
-                        Ok(result?)
-                    }
-                    _ => Err(std::io::Error::new(
-                        ErrorKind::UnexpectedEof,
-                        StreamError::PeekByteFailed,
-                    )),
-                }
-            }
+            Stream::InputFile(ref mut file) => match file.peek_byte() {
+                Some(result) => Ok(result?),
+                _ => Err(std::io::Error::new(
+                    ErrorKind::UnexpectedEof,
+                    StreamError::PeekByteFailed,
+                )),
+            },
             Stream::Readline(ref mut stream) => stream.stream.peek_byte(),
             Stream::NamedTcp(ref mut stream) => {
                 let mut b = [0u8; 1];
@@ -1663,7 +1666,10 @@ impl MachineState {
         }
     }
 
-    pub(crate) fn open_parsing_stream(&mut self, mut stream: Stream) -> Result<Stream, ParserError> {
+    pub(crate) fn open_parsing_stream(
+        &mut self,
+        mut stream: Stream,
+    ) -> Result<Stream, ParserError> {
         match stream.peek_char() {
             None => Ok(stream), // empty stream is handled gracefully by Lexer::eof
             Some(Err(e)) => Err(ParserError::IO(e)),
@@ -1687,7 +1693,7 @@ impl MachineState {
         arity: usize,
     ) -> MachineStub {
         let stub = functor_stub(caller, arity);
-        let err  = self.permission_error(
+        let err = self.permission_error(
             perm,
             err_atom,
             if let Some(alias) = stream.options().get_alias() {
@@ -1723,7 +1729,7 @@ impl MachineState {
         stub_arity: usize,
     ) -> MachineStub {
         let stub = functor_stub(stub_name, stub_arity);
-        let err  = self.permission_error(Permission::Open, atom!("source_sink"), culprit);
+        let err = self.permission_error(Permission::Open, atom!("source_sink"), culprit);
 
         self.error_form(err, stub)
     }
@@ -1855,15 +1861,18 @@ impl MachineState {
                         // 8.11.5.3j)
                         let stub = functor_stub(atom!("open"), 4);
 
-                        let err = self.existence_error(
-                            ExistenceError::SourceSink(self[temp_v!(1)]),
-                        );
+                        let err =
+                            self.existence_error(ExistenceError::SourceSink(self[temp_v!(1)]));
 
                         return Err(self.error_form(err, stub));
                     }
                     ErrorKind::PermissionDenied => {
                         // 8.11.5.3k)
-                        return Err(self.open_permission_error(self.registers[1], atom!("open"), 4));
+                        return Err(self.open_permission_error(
+                            self.registers[1],
+                            atom!("open"),
+                            4,
+                        ));
                     }
                     _ => {
                         let stub = functor_stub(atom!("open"), 4);

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -1853,7 +1853,7 @@ impl MachineState {
             }
         };
 
-        let file = match open_options.open(file_spec.as_str()) {
+        let file = match open_options.open(&*file_spec.as_str()) {
             Ok(file) => file,
             Err(err) => {
                 match err.kind() {

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -7846,7 +7846,9 @@ impl Machine {
 
         use crate::machine::LIBRARIES;
 
-        match LIBRARIES.borrow().get(&*library_name.as_str()) {
+        let lib_ref = LIBRARIES.borrow();
+        let lib = lib_ref.get(&*library_name.as_str());
+        match lib {
             Some(library) => {
                 let lib_stream = Stream::from_static_string(library, &mut self.machine_st.arena);
                 unify!(

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -6,16 +6,15 @@ use lazy_static::lazy_static;
 
 use crate::arena::*;
 use crate::atom_table::*;
-use crate::forms::*;
 #[cfg(feature = "ffi")]
 use crate::ffi::*;
+use crate::forms::*;
 use crate::heap_iter::*;
 use crate::heap_print::*;
 #[cfg(feature = "http")]
-use crate::http::{HttpService, HttpListener, HttpResponse};
+use crate::http::{HttpListener, HttpResponse, HttpService};
 use crate::instructions::*;
 use crate::machine;
-use crate::machine::{Machine, VERIFY_ATTR_INTERRUPT_LOC, get_structure_index};
 use crate::machine::code_walker::*;
 use crate::machine::copier::*;
 use crate::machine::heap::*;
@@ -26,12 +25,13 @@ use crate::machine::partial_string::*;
 use crate::machine::preprocessor::to_op_decl;
 use crate::machine::stack::*;
 use crate::machine::streams::*;
+use crate::machine::{get_structure_index, Machine, VERIFY_ATTR_INTERRUPT_LOC};
 use crate::parser::char_reader::*;
 use crate::parser::dashu::Integer;
 use crate::read::*;
 use crate::types::*;
-use rand::{Rng, SeedableRng};
 use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 use ordered_float::OrderedFloat;
 
@@ -53,7 +53,7 @@ use std::hash::{BuildHasher, BuildHasherDefault};
 use std::io::{ErrorKind, Read, Write};
 use std::iter::{once, FromIterator};
 use std::mem;
-use std::net::{TcpListener, TcpStream, SocketAddr, ToSocketAddrs};
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::num::NonZeroU32;
 use std::ops::Sub;
 use std::process;
@@ -81,20 +81,20 @@ use sha3::{Sha3_224, Sha3_256, Sha3_384, Sha3_512};
 use crrl::{secp256k1, x25519};
 
 #[cfg(feature = "tls")]
-use native_tls::{TlsConnector,TlsAcceptor,Identity};
+use native_tls::{Identity, TlsAcceptor, TlsConnector};
 
 use base64;
 use roxmltree;
 use select;
 
+use bytes::Buf;
+use http_body_util::BodyExt;
+#[cfg(feature = "http")]
+use hyper::header::{HeaderName, HeaderValue};
 #[cfg(feature = "http")]
 use hyper::server::conn::http1;
 #[cfg(feature = "http")]
-use hyper::header::{HeaderValue, HeaderName};
-#[cfg(feature = "http")]
 use hyper::{HeaderMap, Method};
-use http_body_util::BodyExt;
-use bytes::Buf;
 #[cfg(feature = "http")]
 use reqwest::Url;
 
@@ -233,7 +233,12 @@ impl BrentAlgState {
         }
     }
 
-    fn add_pstr_offset_chars(&mut self, heap: &[HeapCellValue], h: usize, offset: usize) -> Option<CycleSearchResult> {
+    fn add_pstr_offset_chars(
+        &mut self,
+        heap: &[HeapCellValue],
+        h: usize,
+        offset: usize,
+    ) -> Option<CycleSearchResult> {
         read_heap_cell!(heap[h],
             (HeapCellValueTag::CStr, cstr_atom) => {
                 let cstr = PartialString::from(cstr_atom);
@@ -267,7 +272,11 @@ impl BrentAlgState {
         )
     }
 
-    fn add_pstr_chars_and_step(&mut self, heap: &[HeapCellValue], h: usize) -> Option<CycleSearchResult> {
+    fn add_pstr_chars_and_step(
+        &mut self,
+        heap: &[HeapCellValue],
+        h: usize,
+    ) -> Option<CycleSearchResult> {
         read_heap_cell!(heap[h],
             (HeapCellValueTag::PStrOffset, l) => {
                 let (pstr_loc, offset) = pstr_loc_and_offset(heap, l);
@@ -505,7 +514,7 @@ impl BrentAlgState {
 #[derive(Debug)]
 enum MatchSite {
     NoMatchVarTail(usize), // no match, we refer to the location of the uninstantiated tail instead.
-    Match(usize), // a match
+    Match(usize),          // a match
 }
 
 #[derive(Debug)]
@@ -624,7 +633,7 @@ impl MachineState {
         let mut hare = h;
         let mut tortoise = hare;
 
-        for _ in 0 .. lam {
+        for _ in 0..lam {
             hare = step(&self.heap, self.heap[hare]);
         }
 
@@ -670,10 +679,7 @@ impl MachineState {
 
     fn skip_max_list_result(&mut self, max_steps: i64) {
         let search_result = if max_steps == -1 {
-            BrentAlgState::detect_cycles(
-                &self.heap,
-                self.store(self.deref(self.registers[3])),
-            )
+            BrentAlgState::detect_cycles(&self.heap, self.store(self.deref(self.registers[3])))
         } else {
             BrentAlgState::detect_cycles_with_max(
                 &self.heap,
@@ -684,7 +690,7 @@ impl MachineState {
 
         match search_result {
             CycleSearchResult::PStrLocation(steps, pstr_loc, offset) => {
-                let steps = if max_steps > - 1 {
+                let steps = if max_steps > -1 {
                     std::cmp::min(max_steps, steps as i64)
                 } else {
                     steps as i64
@@ -694,7 +700,8 @@ impl MachineState {
                     let h = self.heap.len();
 
                     self.heap.push(pstr_offset_as_cell!(pstr_loc));
-                    self.heap.push(fixnum_as_cell!(Fixnum::build_with(offset as i64)));
+                    self.heap
+                        .push(fixnum_as_cell!(Fixnum::build_with(offset as i64)));
 
                     pstr_loc_as_cell!(h)
                 } else {
@@ -712,9 +719,10 @@ impl MachineState {
 
                     self.heap.push(string_as_cstr_cell!(cstr_atom));
                     self.heap.push(pstr_offset_as_cell!(h));
-                    self.heap.push(fixnum_as_cell!(Fixnum::build_with(n as i64)));
+                    self.heap
+                        .push(fixnum_as_cell!(Fixnum::build_with(n as i64)));
 
-                    pstr_loc_as_cell!(h+1)
+                    pstr_loc_as_cell!(h + 1)
                 } else {
                     string_as_cstr_cell!(cstr_atom)
                 };
@@ -799,12 +807,7 @@ impl MachineState {
             }
         }
 
-        let outcome = heap_loc_as_cell!(
-            iter_to_heap_list(
-                &mut self.heap,
-                seen_set.into_iter(),
-            )
-        );
+        let outcome = heap_loc_as_cell!(iter_to_heap_list(&mut self.heap, seen_set.into_iter(),));
 
         unify_fn!(*self, list_of_vars, outcome);
     }
@@ -819,7 +822,11 @@ impl MachineState {
         self.block
     }
 
-    pub(crate) fn copy_findall_solution(&mut self, lh_offset: usize, copy_target: HeapCellValue) -> usize {
+    pub(crate) fn copy_findall_solution(
+        &mut self,
+        lh_offset: usize,
+        copy_target: HeapCellValue,
+    ) -> usize {
         let threshold = self.lifted_heap.len() - lh_offset;
 
         let mut copy_ball_term =
@@ -862,7 +869,7 @@ impl MachineState {
                 let key = (*name, *arity);
 
                 if let Some((last_idx, _, _)) = indices.code_dir.get_full(&key) {
-                    for idx in last_idx + 1 .. indices.code_dir.len() {
+                    for idx in last_idx + 1..indices.code_dir.len() {
                         let ((name, arity), idx) = indices.code_dir.get_index(idx).unwrap();
 
                         if idx.is_undefined() {
@@ -877,7 +884,7 @@ impl MachineState {
                 let key = (*name, *fixity);
 
                 if let Some((last_idx, _, _)) = op_dir.get_full(&key) {
-                    if let Some(((name, fixity), _)) = op_dir.get_index(last_idx+1) {
+                    if let Some(((name, fixity), _)) = op_dir.get_index(last_idx + 1) {
                         return Some(DBRef::Op(*name, *fixity, *op_dir));
                     }
                 }
@@ -899,18 +906,15 @@ impl MachineState {
         let add_dot = !string.ends_with(".");
         let cursor = std::io::Cursor::new(string);
 
-        let iter = std::io::Read::chain(
-            cursor,
-            {
-                let mut dot_buf: [u8; '.'.len_utf8()] = [0u8];
+        let iter = std::io::Read::chain(cursor, {
+            let mut dot_buf: [u8; '.'.len_utf8()] = [0u8];
 
-                if add_dot {
-                    '.'.encode_utf8(&mut dot_buf);
-                }
+            if add_dot {
+                '.'.encode_utf8(&mut dot_buf);
+            }
 
-                std::io::Cursor::new(dot_buf)
-            },
-        );
+            std::io::Cursor::new(dot_buf)
+        });
 
         let mut lexer = Lexer::new(CharReader::new(iter), self);
         let mut tokens = vec![];
@@ -985,7 +989,11 @@ impl MachineState {
         Ok(())
     }
 
-    pub(crate) fn call_continuation_chunk(&mut self, chunk: HeapCellValue, return_p: usize) -> usize {
+    pub(crate) fn call_continuation_chunk(
+        &mut self,
+        chunk: HeapCellValue,
+        return_p: usize,
+    ) -> usize {
         let chunk = self.store(self.deref(chunk));
 
         let s = chunk.get_value() as usize;
@@ -1098,17 +1106,15 @@ impl MachineState {
             let addr = self.store(self.deref(addr));
 
             match Number::try_from(addr) {
-                Ok(Number::Fixnum(n)) => {
-                    match u32::try_from(n.get_num()) {
-                        Ok(n) => {
-                            if let Some(c) = std::char::from_u32(n) {
-                                string.push(c);
-                                continue;
-                            }
+                Ok(Number::Fixnum(n)) => match u32::try_from(n.get_num()) {
+                    Ok(n) => {
+                        if let Some(c) = std::char::from_u32(n) {
+                            string.push(c);
+                            continue;
                         }
-                        _ => {}
                     }
-                }
+                    _ => {}
+                },
                 Ok(Number::Integer(n)) => {
                     if let Some(c) = n.to_u32().and_then(std::char::from_u32) {
                         string.push(c);
@@ -1171,7 +1177,8 @@ impl Machine {
         if let HeapCellValueTag::AttrVar = attr_var.get_tag() {
             let attr_var_loc = attr_var.get_value() as usize;
             self.machine_st.heap[attr_var_loc] = heap_loc_as_cell!(attr_var_loc);
-            self.machine_st.trail(TrailRef::Ref(Ref::attr_var(attr_var_loc)));
+            self.machine_st
+                .trail(TrailRef::Ref(Ref::attr_var(attr_var_loc)));
         }
     }
 
@@ -1188,10 +1195,10 @@ impl Machine {
             CompilationTarget::Module(module_name)
         };
 
-        let skeleton = self.indices.get_predicate_skeleton(
-            &compilation_target,
-            &key,
-        ).unwrap();
+        let skeleton = self
+            .indices
+            .get_predicate_skeleton(&compilation_target, &key)
+            .unwrap();
 
         if self.machine_st.b > self.machine_st.e {
             let or_frame = self.machine_st.stack.index_or_frame(self.machine_st.b);
@@ -1204,14 +1211,14 @@ impl Machine {
                             let p = or_frame.prelude.biip as usize - 1;
 
                             match &indexed_choice[p] {
-                                &IndexedChoiceInstruction::Try(offset) |
-                                &IndexedChoiceInstruction::Retry(offset) |
-                                &IndexedChoiceInstruction::DefaultRetry(offset) => {
+                                &IndexedChoiceInstruction::Try(offset)
+                                | &IndexedChoiceInstruction::Retry(offset)
+                                | &IndexedChoiceInstruction::DefaultRetry(offset) => {
                                     let clause_clause_loc = skeleton.core.clause_clause_locs[p];
                                     (clause_clause_loc, bp + offset)
                                 }
-                                &IndexedChoiceInstruction::Trust(_) |
-                                &IndexedChoiceInstruction::DefaultTrust(_) => {
+                                &IndexedChoiceInstruction::Trust(_)
+                                | &IndexedChoiceInstruction::DefaultTrust(_) => {
                                     unreachable!()
                                 }
                             }
@@ -1221,7 +1228,7 @@ impl Machine {
                         }
                     }
                 }
-                _ => unreachable!()
+                _ => unreachable!(),
             }
         } else {
             let module_name = match compilation_target {
@@ -1229,7 +1236,8 @@ impl Machine {
                 CompilationTarget::Module(target) => target,
             };
 
-            let bp = self.indices
+            let bp = self
+                .indices
                 .get_predicate_code_index(atom!("$clause"), 2, module_name)
                 .and_then(|idx| idx.local())
                 .unwrap();
@@ -1237,10 +1245,12 @@ impl Machine {
             macro_rules! extract_ptr {
                 ($ptr: expr) => {
                     match $ptr {
-                        IndexingCodePtr::External(p) => return (
-                            skeleton.core.clause_clause_locs.back().cloned().unwrap(),
-                            bp + p,
-                        ),
+                        IndexingCodePtr::External(p) => {
+                            return (
+                                skeleton.core.clause_clause_locs.back().cloned().unwrap(),
+                                bp + p,
+                            )
+                        }
                         IndexingCodePtr::Internal(boip) => boip,
                         _ => unreachable!(),
                     }
@@ -1250,8 +1260,18 @@ impl Machine {
             match &self.code[bp] {
                 &Instruction::IndexingCode(ref indexing_code) => {
                     let indexing_code_ptr = match &indexing_code[0] {
-                        &IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(_, _, c, _, s)) => {
-                            if key.1 > 0 { s } else { c }
+                        &IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
+                            _,
+                            _,
+                            c,
+                            _,
+                            s,
+                        )) => {
+                            if key.1 > 0 {
+                                s
+                            } else {
+                                c
+                            }
                         }
                         _ => {
                             unreachable!()
@@ -1281,7 +1301,10 @@ impl Machine {
                     }
                 }
                 _ => {
-                    return (skeleton.core.clause_clause_locs.back().cloned().unwrap(), bp);
+                    return (
+                        skeleton.core.clause_clause_locs.back().cloned().unwrap(),
+                        bp,
+                    );
                 }
             }
         }
@@ -1289,7 +1312,8 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn deref_register(&self, i: usize) -> HeapCellValue {
-	    self.machine_st.store(self.machine_st.deref(self.machine_st.registers[i]))
+        self.machine_st
+            .store(self.machine_st.deref(self.machine_st.registers[i]))
     }
 
     #[inline(always)]
@@ -1299,12 +1323,13 @@ impl Machine {
         call_at_index: impl Fn(&mut Machine, Atom, usize, IndexPtr) -> CallResult,
     ) -> CallResult {
         let arity = arity - 1;
-        let (mut module_name, mut goal) = self.machine_st.strip_module(
-            self.machine_st.registers[1],
-            heap_loc_as_cell!(0),
-        );
+        let (mut module_name, mut goal) = self
+            .machine_st
+            .strip_module(self.machine_st.registers[1], heap_loc_as_cell!(0));
 
-        let load_registers = |machine_st: &mut MachineState, goal: HeapCellValue, goal_arity: usize| {
+        let load_registers = |machine_st: &mut MachineState,
+                              goal: HeapCellValue,
+                              goal_arity: usize| {
             read_heap_cell!(goal,
                 (HeapCellValueTag::Str | HeapCellValueTag::Atom, s) => {
                     if goal_arity > 1 {
@@ -1357,10 +1382,12 @@ impl Machine {
             } else {
                 if is_internal_call {
                     debug_assert_eq!(goal.get_tag(), HeapCellValueTag::Str);
-                    goal = self.machine_st.heap[goal.get_value() as usize+1];
+                    goal = self.machine_st.heap[goal.get_value() as usize + 1];
                     (module_name, goal) = self.machine_st.strip_module(goal, module_name);
 
-                    if let Some((inner_name, inner_arity)) = self.machine_st.name_and_arity_from_heap(goal) {
+                    if let Some((inner_name, inner_arity)) =
+                        self.machine_st.name_and_arity_from_heap(goal)
+                    {
                         arity -= goal_arity;
                         (name, goal_arity) = (inner_name, inner_arity);
                         arity += goal_arity;
@@ -1379,7 +1406,8 @@ impl Machine {
                     cell_as_atom!(module_name)
                 };
 
-                self.indices.get_predicate_code_index(name, arity, module_name)
+                self.indices
+                    .get_predicate_code_index(name, arity, module_name)
             }
         });
 
@@ -1404,7 +1432,8 @@ impl Machine {
         // complete_partial_goal prior to goal_expansion.
         let mut supp_vars = IndexSet::with_hasher(FxBuildHasher::default());
 
-        self.machine_st.variable_set(&mut supp_vars, self.machine_st.registers[2]);
+        self.machine_st
+            .variable_set(&mut supp_vars, self.machine_st.registers[2]);
 
         struct GoalAnalysisResult {
             is_simple_goal: bool,
@@ -1526,12 +1555,14 @@ impl Machine {
 
         let expanded_term = if result.is_simple_goal {
             let idx = self.get_or_insert_qualified_code_index(module_name, result.key);
-            self.machine_st.heap.push(untyped_arena_ptr_as_cell!(UntypedArenaPtr::from(idx)));
+            self.machine_st
+                .heap
+                .push(untyped_arena_ptr_as_cell!(UntypedArenaPtr::from(idx)));
             result.goal
         } else {
             // all supp_vars must appear later!
             let vars = IndexSet::<HeapCellValue, BuildHasherDefault<FxHasher>>::from_iter(
-                result.expanded_vars.difference(&result.supp_vars).cloned()
+                result.expanded_vars.difference(&result.supp_vars).cloned(),
             );
 
             let vars: Vec<_> = vars
@@ -1566,7 +1597,9 @@ impl Machine {
                         &mut self.machine_st.arena,
                     );
 
-                    self.machine_st.heap.push(untyped_arena_ptr_as_cell!(UntypedArenaPtr::from(idx)));
+                    self.machine_st
+                        .heap
+                        .push(untyped_arena_ptr_as_cell!(UntypedArenaPtr::from(idx)));
 
                     str_loc_as_cell!(h)
                 }
@@ -1581,15 +1614,13 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn is_expanded_or_inlined(&self) -> bool {
-        let (_module_loc, qualified_goal) = self.machine_st.strip_module(
-            self.machine_st.registers[1],
-            empty_list_as_cell!(),
-        );
+        let (_module_loc, qualified_goal) = self
+            .machine_st
+            .strip_module(self.machine_st.registers[1], empty_list_as_cell!());
 
         if HeapCellValueTag::Str == qualified_goal.get_tag() {
             let s = qualified_goal.get_value() as usize;
-            let (name, arity) = cell_as_atom_cell!(self.machine_st.heap[s])
-                .get_name_and_arity();
+            let (name, arity) = cell_as_atom_cell!(self.machine_st.heap[s]).get_name_and_arity();
 
             if name == atom!("$call") {
                 return false;
@@ -1615,26 +1646,17 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn strip_module(&mut self) {
-        let (module_loc, qualified_goal) = self.machine_st.strip_module(
-            self.machine_st.registers[1],
-            self.machine_st.registers[2],
-        );
+        let (module_loc, qualified_goal) = self
+            .machine_st
+            .strip_module(self.machine_st.registers[1], self.machine_st.registers[2]);
 
         let target_module_loc = self.machine_st.registers[2];
 
-        unify_fn!(
-            &mut self.machine_st,
-            module_loc,
-            target_module_loc
-        );
+        unify_fn!(&mut self.machine_st, module_loc, target_module_loc);
 
         let target_qualified_goal = self.machine_st.registers[3];
 
-        unify_fn!(
-            &mut self.machine_st,
-            qualified_goal,
-            target_qualified_goal
-        );
+        unify_fn!(&mut self.machine_st, qualified_goal, target_qualified_goal);
     }
 
     #[inline(always)]
@@ -1644,26 +1666,30 @@ impl Machine {
         // the first two arguments don't belong to the containing call/N.
         let arity = arity - 2;
 
-        let (name, narity, s) = self.machine_st.setup_call_n_init_goal_info(
-            qualified_goal,
-            arity,
-        )?;
+        let (name, narity, s) = self
+            .machine_st
+            .setup_call_n_init_goal_info(qualified_goal, arity)?;
 
         // assemble goal from pre-loaded (narity) and supplementary
         // (arity) arguments.
 
         let target_goal = if arity == 0 {
             qualified_goal
-        } else { // if narity + arity > 0 {
+        } else {
+            // if narity + arity > 0 {
             let h = self.machine_st.heap.len();
-            self.machine_st.heap.push(atom_as_cell!(name, narity + arity));
+            self.machine_st
+                .heap
+                .push(atom_as_cell!(name, narity + arity));
 
-            for idx in 1 .. narity + 1 {
+            for idx in 1..narity + 1 {
                 self.machine_st.heap.push(self.machine_st.heap[s + idx]);
             }
 
-            for idx in 1 .. arity + 1 {
-                self.machine_st.heap.push(self.machine_st.registers[2 + idx]);
+            for idx in 1..arity + 1 {
+                self.machine_st
+                    .heap
+                    .push(self.machine_st.registers[2 + idx]);
             }
 
             if narity + arity > 0 {
@@ -1675,11 +1701,7 @@ impl Machine {
 
         let target_qualified_goal = self.machine_st.registers[1];
 
-        unify_fn!(
-            &mut self.machine_st,
-            target_goal,
-            target_qualified_goal
-        );
+        unify_fn!(&mut self.machine_st, target_goal, target_qualified_goal);
 
         Ok(())
     }
@@ -1746,9 +1768,9 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn is_reset_cont_marker(&self, p: usize) -> bool {
         match &self.code[p] {
-            &Instruction::CallResetContinuationMarker |
-            &Instruction::ExecuteResetContinuationMarker => true,
-            _ => false
+            &Instruction::CallResetContinuationMarker
+            | &Instruction::ExecuteResetContinuationMarker => true,
+            _ => false,
         }
     }
 
@@ -1785,10 +1807,7 @@ impl Machine {
                     let hostname = self.machine_st.atom_tbl.build_with(host);
 
                     let a1 = self.deref_register(1);
-                    self.machine_st.unify_atom(
-                        hostname,
-                        a1
-                    );
+                    self.machine_st.unify_atom(hostname, a1);
 
                     return;
                 }
@@ -1872,7 +1891,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn directory_files(&mut self) -> CallResult {
-        if let Some(dir) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(dir) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             let path = std::path::Path::new(dir.as_str());
             let mut files = Vec::new();
 
@@ -1894,9 +1916,10 @@ impl Machine {
                     return Err(err);
                 }
 
-                let files_list = heap_loc_as_cell!(
-                    iter_to_heap_list(&mut self.machine_st.heap, files.into_iter())
-                );
+                let files_list = heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    files.into_iter()
+                ));
 
                 unify!(self.machine_st, self.machine_st.registers[2], files_list);
                 return Ok(());
@@ -1909,15 +1932,22 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn file_size(&mut self) {
-        if let Some(file) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(file) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             let len = Number::arena_from(
                 fs::metadata(file.as_str()).unwrap().len(),
                 &mut self.machine_st.arena,
             );
 
             match len {
-                Number::Fixnum(n) => self.machine_st.unify_fixnum(n, self.machine_st.registers[2]),
-                Number::Integer(n) => self.machine_st.unify_big_int(n, self.machine_st.registers[2]),
+                Number::Fixnum(n) => self
+                    .machine_st
+                    .unify_fixnum(n, self.machine_st.registers[2]),
+                Number::Integer(n) => self
+                    .machine_st
+                    .unify_big_int(n, self.machine_st.registers[2]),
                 _ => unreachable!(),
             }
         } else {
@@ -1927,10 +1957,15 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn file_exists(&mut self) {
-        if let Some(file) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(file) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             let file_str = file.as_str();
 
-            if !std::path::Path::new(file_str).exists() || !fs::metadata(file_str).unwrap().is_file() {
+            if !std::path::Path::new(file_str).exists()
+                || !fs::metadata(file_str).unwrap().is_file()
+            {
                 self.machine_st.fail = true;
             }
         } else {
@@ -1940,7 +1975,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn directory_exists(&mut self) {
-        if let Some(dir) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(dir) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             let dir_str = dir.as_str();
 
             if !std::path::Path::new(dir_str).exists() || !fs::metadata(dir_str).unwrap().is_dir() {
@@ -1953,7 +1991,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn file_time(&mut self) {
-        if let Some(file) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(file) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             let which = cell_as_atom!(self.deref_register(2));
 
             if let Ok(md) = fs::metadata(file.as_str()) {
@@ -1967,10 +2008,8 @@ impl Machine {
                 } {
                     let chars_atom = self.systemtime_to_timestamp(time);
 
-                    self.machine_st.unify_complete_string(
-                        chars_atom,
-                        self.machine_st.registers[3],
-                    );
+                    self.machine_st
+                        .unify_complete_string(chars_atom, self.machine_st.registers[3]);
 
                     return;
                 }
@@ -1982,12 +2021,16 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn directory_separator(&mut self) {
-        self.machine_st.unify_char(std::path::MAIN_SEPARATOR, self.machine_st.registers[1]);
+        self.machine_st
+            .unify_char(std::path::MAIN_SEPARATOR, self.machine_st.registers[1]);
     }
 
     #[inline(always)]
     pub(crate) fn make_directory(&mut self) {
-        if let Some(dir) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(dir) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             match fs::create_dir(dir.as_str()) {
                 Ok(_) => {}
                 _ => {
@@ -2001,8 +2044,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn make_directory_path(&mut self) {
-        if let Some(dir) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
-
+        if let Some(dir) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             match fs::create_dir_all(dir.as_str()) {
                 Ok(_) => {}
                 _ => {
@@ -2016,7 +2061,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn delete_file(&mut self) {
-        if let Some(file) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(file) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             match fs::remove_file(file.as_str()) {
                 Ok(_) => {}
                 _ => {
@@ -2028,8 +2076,14 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn rename_file(&mut self) {
-        if let Some(file) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
-            if let Some(renamed) = self.machine_st.value_to_str_like(self.machine_st.registers[2]) {
+        if let Some(file) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
+            if let Some(renamed) = self
+                .machine_st
+                .value_to_str_like(self.machine_st.registers[2])
+            {
                 if fs::rename(file.as_str(), renamed.as_str()).is_ok() {
                     return;
                 }
@@ -2041,20 +2095,29 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn file_copy(&mut self) {
-	if let Some(file) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
-	    if let Some(copied) = self.machine_st.value_to_str_like(self.machine_st.registers[2]) {
-		if fs::copy(file.as_str(), copied.as_str()).is_ok() {
-		    return;
-		}
-	    }
-	}
+        if let Some(file) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
+            if let Some(copied) = self
+                .machine_st
+                .value_to_str_like(self.machine_st.registers[2])
+            {
+                if fs::copy(file.as_str(), copied.as_str()).is_ok() {
+                    return;
+                }
+            }
+        }
 
-	self.machine_st.fail = true;
+        self.machine_st.fail = true;
     }
 
     #[inline(always)]
     pub(crate) fn delete_directory(&mut self) {
-        if let Some(dir) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(dir) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             match fs::remove_dir(dir.as_str()) {
                 Ok(_) => {}
                 _ => {
@@ -2081,10 +2144,7 @@ impl Machine {
             let current_atom = self.machine_st.atom_tbl.build_with(&current);
 
             let a1 = self.deref_register(1);
-            self.machine_st.unify_complete_string(
-                current_atom,
-                a1
-            );
+            self.machine_st.unify_complete_string(current_atom, a1);
 
             if self.machine_st.fail {
                 return Ok(());
@@ -2105,7 +2165,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn path_canonical(&mut self) -> CallResult {
-        if let Some(path) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(path) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             match fs::canonicalize(path.as_str()) {
                 Ok(canonical) => {
                     let cs = match canonical.to_str() {
@@ -2122,15 +2185,11 @@ impl Machine {
                     let canonical_atom = self.machine_st.atom_tbl.build_with(cs);
 
                     let a2 = self.deref_register(2);
-                    self.machine_st.unify_complete_string(
-                        canonical_atom,
-                        a2
-                    );
+                    self.machine_st.unify_complete_string(canonical_atom, a2);
 
                     return Ok(());
                 }
-                _ => {
-                }
+                _ => {}
             }
         }
 
@@ -2298,10 +2357,7 @@ impl Machine {
         );
 
         let a2 = self.deref_register(2);
-        self.machine_st.unify_fixnum(
-            Fixnum::build_with(len),
-            a2,
-        );
+        self.machine_st.unify_fixnum(Fixnum::build_with(len), a2);
     }
 
     #[inline(always)]
@@ -2335,18 +2391,13 @@ impl Machine {
         let a1 = self.deref_register(1);
         let atom_or_string = self.machine_st.value_to_str_like(a1).unwrap();
 
-        self.machine_st.parse_number_from_string(
-            atom_or_string.as_str(),
-            &self.indices,
-            stub_gen,
-        )
+        self.machine_st
+            .parse_number_from_string(atom_or_string.as_str(), &self.indices, stub_gen)
     }
 
     #[inline(always)]
     pub(crate) fn create_partial_string(&mut self) {
-        let atom = cell_as_atom!(
-            self.deref_register(1)
-        );
+        let atom = cell_as_atom!(self.deref_register(1));
 
         if atom == atom!("") {
             self.machine_st.fail = true;
@@ -2356,13 +2407,17 @@ impl Machine {
         let pstr_h = self.machine_st.heap.len();
 
         self.machine_st.heap.push(pstr_as_cell!(atom));
-        self.machine_st.heap.push(heap_loc_as_cell!(pstr_h+1));
+        self.machine_st.heap.push(heap_loc_as_cell!(pstr_h + 1));
 
-        unify!(self.machine_st, self.machine_st.registers[2], pstr_loc_as_cell!(pstr_h));
+        unify!(
+            self.machine_st,
+            self.machine_st.registers[2],
+            pstr_loc_as_cell!(pstr_h)
+        );
 
         if !self.machine_st.fail {
             let tail = self.machine_st.registers[3];
-            unify!(self.machine_st, tail, heap_loc_as_cell!(pstr_h+1));
+            unify!(self.machine_st, tail, heap_loc_as_cell!(pstr_h + 1));
         }
     }
 
@@ -2454,10 +2509,7 @@ impl Machine {
         let addr = self.deref_register(2);
 
         if stream.at_end_of_stream() {
-            self.machine_st.unify_fixnum(
-                Fixnum::build_with(-1),
-                addr,
-            );
+            self.machine_st.unify_fixnum(Fixnum::build_with(-1), addr);
 
             if self.machine_st.fail {
                 self.machine_st.fail = false;
@@ -2495,7 +2547,8 @@ impl Machine {
         loop {
             match stream.peek_byte().map_err(|e| e.kind()) {
                 Ok(b) => {
-                    self.machine_st.unify_fixnum(Fixnum::build_with(b as i64), addr);
+                    self.machine_st
+                        .unify_fixnum(Fixnum::build_with(b as i64), addr);
                     break;
                 }
                 Err(ErrorKind::PermissionDenied) => {
@@ -2554,10 +2607,7 @@ impl Machine {
         if stream.at_end_of_stream() {
             let end_of_file = atom!("end_of_file");
 
-            self.machine_st.unify_atom(
-                end_of_file,
-                a2,
-            );
+            self.machine_st.unify_atom(end_of_file, a2);
 
             return Ok(());
         }
@@ -2589,7 +2639,10 @@ impl Machine {
         );
 
         loop {
-            match stream.peek_char().map(|result| result.map_err(|e| e.kind())) {
+            match stream
+                .peek_char()
+                .map(|result| result.map_err(|e| e.kind()))
+            {
                 Some(Ok(d)) => {
                     self.machine_st.unify_char(d, a2);
                     break;
@@ -2648,10 +2701,7 @@ impl Machine {
         let a2 = self.deref_register(2);
 
         if stream.at_end_of_stream() {
-            self.machine_st.unify_fixnum(
-                Fixnum::build_with(-1),
-                a2,
-            );
+            self.machine_st.unify_fixnum(Fixnum::build_with(-1), a2);
 
             if self.machine_st.fail {
                 self.machine_st.fail = false;
@@ -2703,7 +2753,8 @@ impl Machine {
 
             match result.map(|result| result.map_err(|e| e.kind())) {
                 Some(Ok(c)) => {
-                    self.machine_st.unify_fixnum(Fixnum::build_with(c as i64), addr);
+                    self.machine_st
+                        .unify_fixnum(Fixnum::build_with(c as i64), addr);
                     break;
                 }
                 Some(Err(ErrorKind::PermissionDenied)) => {
@@ -2736,9 +2787,7 @@ impl Machine {
         let chs = self.deref_register(2);
 
         let string = match Number::try_from(n) {
-            Ok(Number::Float(OrderedFloat(n))) => {
-                fmt_float(n)
-            }
+            Ok(Number::Float(OrderedFloat(n))) => fmt_float(n),
             Ok(Number::Fixnum(n)) => n.get_num().to_string(),
             Ok(Number::Integer(n)) => n.to_string(),
             Ok(Number::Rational(r)) => {
@@ -2753,10 +2802,7 @@ impl Machine {
         };
 
         let chars_atom = self.machine_st.atom_tbl.build_with(&string.trim());
-        self.machine_st.unify_complete_string(
-            chars_atom,
-            chs,
-        );
+        self.machine_st.unify_complete_string(chars_atom, chs);
     }
 
     #[inline(always)]
@@ -2781,9 +2827,10 @@ impl Machine {
             }
         };
 
-        let codes = string.trim().chars().map(|c| {
-            fixnum_as_cell!(Fixnum::build_with(c as i64))
-        });
+        let codes = string
+            .trim()
+            .chars()
+            .map(|c| fixnum_as_cell!(Fixnum::build_with(c as i64)));
 
         let h = iter_to_heap_list(&mut self.machine_st.heap, codes);
         unify!(self.machine_st, heap_loc_as_cell!(h), chs);
@@ -2793,13 +2840,22 @@ impl Machine {
     pub(crate) fn codes_to_number(&mut self) -> CallResult {
         let stub_gen = || functor_stub(atom!("number_codes"), 2);
 
-        match self.machine_st.try_from_list(self.machine_st.registers[1], stub_gen) {
+        match self
+            .machine_st
+            .try_from_list(self.machine_st.registers[1], stub_gen)
+        {
             Err(e) => {
                 return Err(e);
             }
             Ok(addrs) => {
-                let string = self.machine_st.codes_to_string(addrs.into_iter(), stub_gen)?;
-                self.machine_st.parse_number_from_string(string.as_str(), &self.indices, stub_gen)?;
+                let string = self
+                    .machine_st
+                    .codes_to_string(addrs.into_iter(), stub_gen)?;
+                self.machine_st.parse_number_from_string(
+                    string.as_str(),
+                    &self.indices,
+                    stub_gen,
+                )?;
             }
         }
 
@@ -2870,10 +2926,8 @@ impl Machine {
             }
         );
 
-        self.machine_st.unify_fixnum(
-            Fixnum::build_with(c as i64),
-            a2,
-        );
+        self.machine_st
+            .unify_fixnum(Fixnum::build_with(c as i64), a2);
 
         Ok(())
     }
@@ -2905,98 +2959,95 @@ impl Machine {
         self.machine_st.fail = true; // This predicate fails by default.
 
         read_heap_cell!(a2,
-	    (HeapCellValueTag::Atom, (chars, _arity)) => {
-                macro_rules! macro_check {
-		    ($id:ident, $name:expr) => {
-			if $id!(c) && chars == $name {
-			    self.machine_st.fail = false;
-			    return;
-			}
-		    };
-		}
+            (HeapCellValueTag::Atom, (chars, _arity)) => {
+                    macro_rules! macro_check {
+                ($id:ident, $name:expr) => {
+                if $id!(c) && chars == $name {
+                    self.machine_st.fail = false;
+                    return;
+                }
+                };
+            }
 
-		macro_rules! method_check {
-		    ($id:ident, $name:expr) => {
-			if c.$id() && chars == $name {
-			    self.machine_st.fail = false;
-			    return;
-			}
-		    };
-		}
+            macro_rules! method_check {
+                ($id:ident, $name:expr) => {
+                if c.$id() && chars == $name {
+                    self.machine_st.fail = false;
+                    return;
+                }
+                };
+            }
 
-		macro_check!(alpha_char, atom!("alpha"));
-		method_check!(is_alphabetic, atom!("alphabetic"));
-		method_check!(is_alphanumeric, atom!("alphanumeric"));
-		macro_check!(alpha_numeric_char, atom!("alnum"));
-		method_check!(is_ascii, atom!("ascii"));
-		method_check!(is_ascii_punctuation, atom!("ascii_punctuation"));
-		method_check!(is_ascii_graphic, atom!("ascii_graphic"));
-		// macro_check!(backslash_char, atom!("backslash"));
-		// macro_check!(back_quote_char, atom!("back_quote"));
-		macro_check!(binary_digit_char, atom!("binary_digit"));
-		// macro_check!(capital_letter_char, atom!("upper"));
-		// macro_check!(comment_1_char, "comment_1");
-		// macro_check!(comment_2_char, "comment_2");
-		method_check!(is_control, atom!("control"));
-		// macro_check!(cut_char, atom!("cut"));
-		macro_check!(decimal_digit_char, atom!("decimal_digit"));
-		// macro_check!(decimal_point_char, atom!("decimal_point"));
-		// macro_check!(double_quote_char, atom!("double_quote"));
-		macro_check!(exponent_char, atom!("exponent"));
-		macro_check!(graphic_char, atom!("graphic"));
-		macro_check!(graphic_token_char, atom!("graphic_token"));
-		macro_check!(hexadecimal_digit_char, atom!("hexadecimal_digit"));
-		macro_check!(layout_char, atom!("layout"));
-		method_check!(is_lowercase, atom!("lower"));
-		macro_check!(meta_char, atom!("meta"));
-		// macro_check!(new_line_char, atom!("new_line"));
-		method_check!(is_numeric, atom!("numeric"));
-		macro_check!(octal_digit_char, atom!("octal_digit"));
-		macro_check!(octet_char, atom!("octet"));
-		macro_check!(prolog_char, atom!("prolog"));
-		// macro_check!(semicolon_char, atom!("semicolon"));
-		macro_check!(sign_char, atom!("sign"));
-		// macro_check!(single_quote_char, atom!("single_quote"));
-		// macro_check!(small_letter_char, atom!("lower"));
-		macro_check!(solo_char, atom!("solo"));
-		// macro_check!(space_char, atom!("space"));
-		macro_check!(symbolic_hexadecimal_char, atom!("symbolic_hexadecimal"));
-		macro_check!(symbolic_control_char, atom!("symbolic_control"));
-		method_check!(is_uppercase, atom!("upper"));
-		// macro_check!(variable_indicator_char, atom!("variable_indicator"));
-		method_check!(is_whitespace, atom!("whitespace"));
-	    }
-            (HeapCellValueTag::Str, s) => {
-	        let (name, arity) = cell_as_atom_cell!(self.machine_st.heap[s])
-		    .get_name_and_arity();
+            macro_check!(alpha_char, atom!("alpha"));
+            method_check!(is_alphabetic, atom!("alphabetic"));
+            method_check!(is_alphanumeric, atom!("alphanumeric"));
+            macro_check!(alpha_numeric_char, atom!("alnum"));
+            method_check!(is_ascii, atom!("ascii"));
+            method_check!(is_ascii_punctuation, atom!("ascii_punctuation"));
+            method_check!(is_ascii_graphic, atom!("ascii_graphic"));
+            // macro_check!(backslash_char, atom!("backslash"));
+            // macro_check!(back_quote_char, atom!("back_quote"));
+            macro_check!(binary_digit_char, atom!("binary_digit"));
+            // macro_check!(capital_letter_char, atom!("upper"));
+            // macro_check!(comment_1_char, "comment_1");
+            // macro_check!(comment_2_char, "comment_2");
+            method_check!(is_control, atom!("control"));
+            // macro_check!(cut_char, atom!("cut"));
+            macro_check!(decimal_digit_char, atom!("decimal_digit"));
+            // macro_check!(decimal_point_char, atom!("decimal_point"));
+            // macro_check!(double_quote_char, atom!("double_quote"));
+            macro_check!(exponent_char, atom!("exponent"));
+            macro_check!(graphic_char, atom!("graphic"));
+            macro_check!(graphic_token_char, atom!("graphic_token"));
+            macro_check!(hexadecimal_digit_char, atom!("hexadecimal_digit"));
+            macro_check!(layout_char, atom!("layout"));
+            method_check!(is_lowercase, atom!("lower"));
+            macro_check!(meta_char, atom!("meta"));
+            // macro_check!(new_line_char, atom!("new_line"));
+            method_check!(is_numeric, atom!("numeric"));
+            macro_check!(octal_digit_char, atom!("octal_digit"));
+            macro_check!(octet_char, atom!("octet"));
+            macro_check!(prolog_char, atom!("prolog"));
+            // macro_check!(semicolon_char, atom!("semicolon"));
+            macro_check!(sign_char, atom!("sign"));
+            // macro_check!(single_quote_char, atom!("single_quote"));
+            // macro_check!(small_letter_char, atom!("lower"));
+            macro_check!(solo_char, atom!("solo"));
+            // macro_check!(space_char, atom!("space"));
+            macro_check!(symbolic_hexadecimal_char, atom!("symbolic_hexadecimal"));
+            macro_check!(symbolic_control_char, atom!("symbolic_control"));
+            method_check!(is_uppercase, atom!("upper"));
+            // macro_check!(variable_indicator_char, atom!("variable_indicator"));
+            method_check!(is_whitespace, atom!("whitespace"));
+            }
+                (HeapCellValueTag::Str, s) => {
+                let (name, arity) = cell_as_atom_cell!(self.machine_st.heap[s])
+                .get_name_and_arity();
 
-		match (name, arity) {
-		    (atom!("to_upper"), 1) => {
-			let reg = self.machine_st.deref(self.machine_st.heap[s+1]);
-			let atom = self.machine_st.atom_tbl.build_with(&c.to_uppercase().to_string());
-			let upper_str = string_as_cstr_cell!(atom);
-			unify!(self.machine_st, reg, upper_str);
-			self.machine_st.fail = false;
-		    }
-		    (atom!("to_lower"), 1) => {
-			let reg = self.machine_st.deref(self.machine_st.heap[s+1]);
-			let atom = self.machine_st.atom_tbl.build_with(&c.to_lowercase().to_string());
-			let lower_str = string_as_cstr_cell!(atom);
-			unify!(self.machine_st, reg, lower_str);
-			self.machine_st.fail = false;
-		    }
-		    _ => {
-			unreachable!()
-		    }
-		};
-	    }
-            _ => {
-	        unreachable!()
-	    }
-	);
-
-
-
+            match (name, arity) {
+                (atom!("to_upper"), 1) => {
+                let reg = self.machine_st.deref(self.machine_st.heap[s+1]);
+                let atom = self.machine_st.atom_tbl.build_with(&c.to_uppercase().to_string());
+                let upper_str = string_as_cstr_cell!(atom);
+                unify!(self.machine_st, reg, upper_str);
+                self.machine_st.fail = false;
+                }
+                (atom!("to_lower"), 1) => {
+                let reg = self.machine_st.deref(self.machine_st.heap[s+1]);
+                let atom = self.machine_st.atom_tbl.build_with(&c.to_lowercase().to_string());
+                let lower_str = string_as_cstr_cell!(atom);
+                unify!(self.machine_st, reg, lower_str);
+                self.machine_st.fail = false;
+                }
+                _ => {
+                unreachable!()
+                }
+            };
+            }
+                _ => {
+                unreachable!()
+            }
+        );
     }
 
     #[inline(always)]
@@ -3004,7 +3055,12 @@ impl Machine {
         let addr = self.deref_register(1);
         let old_b = cell_as_fixnum!(addr).get_num() as usize;
 
-        let prev_b = self.machine_st.stack.index_or_frame(self.machine_st.b).prelude.b;
+        let prev_b = self
+            .machine_st
+            .stack
+            .index_or_frame(self.machine_st.b)
+            .prelude
+            .b;
         let prev_b = self.machine_st.stack.index_or_frame(prev_b).prelude.b;
 
         if prev_b > old_b {
@@ -3152,26 +3208,32 @@ impl Machine {
         let mut bytes = Vec::new();
         let stub_gen = || functor_stub(atom!("$put_chars"), 2);
 
-        if let Some(string) = self.machine_st.value_to_str_like(self.machine_st.registers[2]) {
+        if let Some(string) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[2])
+        {
             if stream.options().stream_type() == StreamType::Binary {
                 for c in string.as_str().chars() {
                     if c as u32 > 255 {
-                        let err = self.machine_st.type_error(ValidType::Byte, char_as_cell!(c));
+                        let err = self
+                            .machine_st
+                            .type_error(ValidType::Byte, char_as_cell!(c));
                         return Err(self.machine_st.error_form(err, stub_gen()));
                     }
 
                     bytes.push(c as u8);
-            }
+                }
             } else {
                 bytes = string.as_str().bytes().collect();
             }
 
             match stream.write_all(&bytes) {
-                Ok(_) => {
-                }
+                Ok(_) => {}
                 _ => {
                     let addr = stream_as_cell!(stream);
-                    let err = self.machine_st.existence_error(ExistenceError::Stream(addr));
+                    let err = self
+                        .machine_st
+                        .existence_error(ExistenceError::Stream(addr));
 
                     return Err(self.machine_st.error_form(err, stub_gen()));
                 }
@@ -3215,9 +3277,9 @@ impl Machine {
                                 return Ok(());
                             }
                             _ => {
-                                let err = self.machine_st.existence_error(
-                                    ExistenceError::Stream(stream_as_cell!(stream))
-                                );
+                                let err = self.machine_st.existence_error(ExistenceError::Stream(
+                                    stream_as_cell!(stream),
+                                ));
 
                                 return Err(self.machine_st.error_form(err, stub_gen()));
                             }
@@ -3231,21 +3293,22 @@ impl Machine {
                                 return Ok(());
                             }
                             _ => {
-                                let err = self.machine_st.existence_error(
-                                    ExistenceError::Stream(stream_as_cell!(stream))
-                                );
+                                let err = self.machine_st.existence_error(ExistenceError::Stream(
+                                    stream_as_cell!(stream),
+                                ));
 
                                 return Err(self.machine_st.error_form(err, stub_gen()));
                             }
                         }
                     }
                 }
-                _ => {
-                }
+                _ => {}
             }
         }
 
-        let err = self.machine_st.type_error(ValidType::Byte, self.machine_st.registers[2]);
+        let err = self
+            .machine_st
+            .type_error(ValidType::Byte, self.machine_st.registers[2]);
         Err(self.machine_st.error_form(err, stub_gen()))
     }
 
@@ -3267,7 +3330,12 @@ impl Machine {
         )?;
 
         if stream.past_end_of_stream() {
-            self.machine_st.eof_action(self.machine_st.registers[2], stream, atom!("get_byte"), 2)?;
+            self.machine_st.eof_action(
+                self.machine_st.registers[2],
+                stream,
+                atom!("get_byte"),
+                2,
+            )?;
 
             if EOFAction::Reset != stream.options().eof_action() {
                 return Ok(());
@@ -3317,12 +3385,14 @@ impl Machine {
 
             match stream.read(&mut b) {
                 Ok(1) => {
-                    self.machine_st.unify_fixnum(Fixnum::build_with(b[0] as i64), addr);
+                    self.machine_st
+                        .unify_fixnum(Fixnum::build_with(b[0] as i64), addr);
                     break;
                 }
                 _ => {
                     stream.set_past_end_of_stream(true);
-                    self.machine_st.unify_fixnum(Fixnum::build_with(-1), self.machine_st.registers[2]);
+                    self.machine_st
+                        .unify_fixnum(Fixnum::build_with(-1), self.machine_st.registers[2]);
                     break;
                 }
             }
@@ -3362,10 +3432,7 @@ impl Machine {
             let end_of_file = atom!("end_of_file");
             stream.set_past_end_of_stream(true);
 
-            self.machine_st.unify_atom(
-                end_of_file,
-                addr
-            );
+            self.machine_st.unify_atom(end_of_file, addr);
 
             return Ok(());
         }
@@ -3468,13 +3535,12 @@ impl Machine {
                 string.push(c as char);
             }
         } else {
-            let mut iter = self.machine_st.open_parsing_stream(stream)
-                .map_err(|e| {
-                    let err = self.machine_st.session_error(SessionError::from(e));
-                    let stub = functor_stub(atom!("get_n_chars"), 2);
+            let mut iter = self.machine_st.open_parsing_stream(stream).map_err(|e| {
+                let err = self.machine_st.session_error(SessionError::from(e));
+                let stub = functor_stub(atom!("get_n_chars"), 2);
 
-                    self.machine_st.error_form(err, stub)
-                })?;
+                self.machine_st.error_form(err, stub)
+            })?;
 
             for _ in 0..num {
                 let result = iter.read_char();
@@ -3527,10 +3593,7 @@ impl Machine {
         if stream.at_end_of_stream() {
             stream.set_past_end_of_stream(true);
 
-            self.machine_st.unify_fixnum(
-                Fixnum::build_with(-1),
-                addr,
-            );
+            self.machine_st.unify_fixnum(Fixnum::build_with(-1), addr);
 
             return Ok(());
         }
@@ -3542,14 +3605,14 @@ impl Machine {
         } else {
             match Number::try_from(addr) {
                 Ok(Number::Integer(n)) => {
-                    let n = n
-                        .to_u32()
-                        .and_then(|n| std::char::from_u32(n));
+                    let n = n.to_u32().and_then(|n| std::char::from_u32(n));
 
                     if let Some(n) = n {
                         fixnum_as_cell!(Fixnum::build_with(n as i64))
                     } else {
-                        let err = self.machine_st.representation_error(RepFlag::InCharacterCode);
+                        let err = self
+                            .machine_st
+                            .representation_error(RepFlag::InCharacterCode);
                         return Err(self.machine_st.error_form(err, stub_gen()));
                     }
                 }
@@ -3561,31 +3624,35 @@ impl Machine {
                     if nf.is_some() {
                         fixnum_as_cell!(n)
                     } else {
-                        let err = self.machine_st.representation_error(RepFlag::InCharacterCode);
+                        let err = self
+                            .machine_st
+                            .representation_error(RepFlag::InCharacterCode);
                         return Err(self.machine_st.error_form(err, stub_gen()));
                     }
                 }
                 _ => {
-                    let err = self.machine_st.type_error(ValidType::Integer, self.machine_st.registers[2]);
+                    let err = self
+                        .machine_st
+                        .type_error(ValidType::Integer, self.machine_st.registers[2]);
                     return Err(self.machine_st.error_form(err, stub_gen()));
                 }
             }
         };
 
-        let mut iter = self.machine_st.open_parsing_stream(stream)
-            .map_err(|e| {
-                let err = self.machine_st.session_error(SessionError::from(e));
-                let stub = functor_stub(atom!("get_code"), 2);
+        let mut iter = self.machine_st.open_parsing_stream(stream).map_err(|e| {
+            let err = self.machine_st.session_error(SessionError::from(e));
+            let stub = functor_stub(atom!("get_code"), 2);
 
-                self.machine_st.error_form(err, stub)
-            })?;
+            self.machine_st.error_form(err, stub)
+        })?;
 
         loop {
             let result = iter.read_char();
 
             match result {
                 Some(Ok(c)) => {
-                    self.machine_st.unify_fixnum(Fixnum::build_with(c as i64), addr);
+                    self.machine_st
+                        .unify_fixnum(Fixnum::build_with(c as i64), addr);
                     break;
                 }
                 _ => {
@@ -3642,12 +3709,7 @@ impl Machine {
         let mut next_stream = None;
         let mut null_streams = BTreeSet::new();
 
-        for stream in self.indices
-            .streams
-            .range(prev_stream..)
-            .skip(1)
-            .cloned()
-        {
+        for stream in self.indices.streams.range(prev_stream..).skip(1).cloned() {
             if !stream.is_null_stream() {
                 next_stream = Some(stream);
                 break;
@@ -3681,11 +3743,9 @@ impl Machine {
             let stub = functor_stub(atom!("flush_output"), 1);
             let addr = stream_as_cell!(stream);
 
-            let err = self.machine_st.permission_error(
-                Permission::OutputStream,
-                atom!("stream"),
-                addr,
-            );
+            let err =
+                self.machine_st
+                    .permission_error(Permission::OutputStream, atom!("stream"), addr);
 
             return Err(self.machine_st.error_form(err, stub));
         }
@@ -3719,10 +3779,7 @@ impl Machine {
             _ => unreachable!(),
         };
         let a1 = self.deref_register(1);
-        self.machine_st.unify_char(
-            c,
-            a1,
-        );
+        self.machine_st.unify_char(c, a1);
 
         Ok(())
     }
@@ -3741,10 +3798,7 @@ impl Machine {
         }
         let c = buffer[0] as char;
         let a1 = self.deref_register(1);
-        self.machine_st.unify_char(
-            c,
-            a1,
-        );
+        self.machine_st.unify_char(c, a1);
 
         Ok(())
     }
@@ -3753,9 +3807,14 @@ impl Machine {
     pub(crate) fn head_is_dynamic(&mut self) {
         let module_name = cell_as_atom!(self.deref_register(1));
 
-        match self.machine_st.name_and_arity_from_heap(self.machine_st.registers[2]) {
+        match self
+            .machine_st
+            .name_and_arity_from_heap(self.machine_st.registers[2])
+        {
             Some((name, arity)) => {
-                self.machine_st.fail = !self.indices.is_dynamic_predicate(module_name, (name, arity));
+                self.machine_st.fail = !self
+                    .indices
+                    .is_dynamic_predicate(module_name, (name, arity));
             }
             None => {
                 self.machine_st.fail = true;
@@ -3779,7 +3838,8 @@ impl Machine {
         self.indices.streams.remove(&stream);
 
         if stream == self.user_input {
-            self.user_input = self.indices
+            self.user_input = self
+                .indices
                 .stream_aliases
                 .get(&atom!("user_input"))
                 .cloned()
@@ -3787,7 +3847,8 @@ impl Machine {
 
             self.indices.streams.insert(self.user_input);
         } else if stream == self.user_output {
-            self.user_output = self.indices
+            self.user_output = self
+                .indices
                 .stream_aliases
                 .get(&atom!("user_output"))
                 .cloned()
@@ -3806,7 +3867,9 @@ impl Machine {
             if let Err(_) = close_result {
                 let stub = functor_stub(atom!("close"), 1);
                 let addr = stream_as_cell!(stream);
-                let err  = self.machine_st.existence_error(ExistenceError::Stream(addr));
+                let err = self
+                    .machine_st
+                    .existence_error(ExistenceError::Stream(addr));
 
                 return Err(self.machine_st.error_form(err, stub));
             }
@@ -3817,18 +3880,18 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn copy_to_lifted_heap(&mut self) {
-        let lh_offset = cell_as_fixnum!(
-            self.deref_register(1)
-        ).get_num() as usize;
+        let lh_offset = cell_as_fixnum!(self.deref_register(1)).get_num() as usize;
 
         let copy_target = self.machine_st.registers[2];
 
-        let old_threshold = self.machine_st.copy_findall_solution(lh_offset, copy_target);
+        let old_threshold = self
+            .machine_st
+            .copy_findall_solution(lh_offset, copy_target);
         let new_threshold = self.machine_st.lifted_heap.len() - lh_offset;
 
         self.machine_st.lifted_heap[old_threshold] = heap_loc_as_cell!(new_threshold);
 
-        for addr in self.machine_st.lifted_heap[old_threshold + 1 ..].iter_mut() {
+        for addr in self.machine_st.lifted_heap[old_threshold + 1..].iter_mut() {
             *addr -= self.machine_st.heap.len() + lh_offset;
         }
     }
@@ -3851,7 +3914,8 @@ impl Machine {
             }
         );
 
-        self.machine_st.fail = self.indices
+        self.machine_st.fail = self
+            .indices
             .get_predicate_code_index(name, arity, module_name)
             .is_none();
     }
@@ -3911,7 +3975,12 @@ impl Machine {
         let code_dir = if module_name == atom!("user") {
             &self.indices.code_dir
         } else {
-            match self.indices.modules.get(&module_name).map(|module| &module.code_dir) {
+            match self
+                .indices
+                .modules
+                .get(&module_name)
+                .map(|module| &module.code_dir)
+            {
                 Some(code_dir) => code_dir,
                 None => {
                     self.machine_st.fail = true;
@@ -3922,9 +3991,10 @@ impl Machine {
 
         for (name, arity) in code_dir.keys() {
             if name_match(pred_atom, *name) && arity_match(pred_arity, *arity) {
-                self.machine_st.heap.extend(
-                    functor!(atom!("/"), [cell(atom_as_cell!(name)), fixnum(*arity)]),
-                );
+                self.machine_st.heap.extend(functor!(
+                    atom!("/"),
+                    [cell(atom_as_cell!(name)), fixnum(*arity)]
+                ));
 
                 num_functors += 1;
             }
@@ -3933,12 +4003,20 @@ impl Machine {
         if num_functors > 0 {
             let h = iter_to_heap_list(
                 &mut self.machine_st.heap,
-                (0 .. num_functors).map(|i| str_loc_as_cell!(h + 3 * i)),
+                (0..num_functors).map(|i| str_loc_as_cell!(h + 3 * i)),
             );
 
-            unify!(self.machine_st, heap_loc_as_cell!(h), self.machine_st.registers[4]);
+            unify!(
+                self.machine_st,
+                heap_loc_as_cell!(h),
+                self.machine_st.registers[4]
+            );
         } else {
-            unify!(self.machine_st, empty_list_as_cell!(), self.machine_st.registers[4]);
+            unify!(
+                self.machine_st,
+                empty_list_as_cell!(),
+                self.machine_st.registers[4]
+            );
         }
     }
 
@@ -3987,9 +4065,9 @@ impl Machine {
                     self.indices.op_dir.get_key_value(&(orig_op, Fixity::Post)),
                 ];
 
-                let number_of_keys = op_descs[0].is_some() as usize +
-                    op_descs[1].is_some() as usize +
-                    op_descs[2].is_some() as usize;
+                let number_of_keys = op_descs[0].is_some() as usize
+                    + op_descs[1].is_some() as usize
+                    + op_descs[2].is_some() as usize;
 
                 match number_of_keys {
                     0 => {
@@ -3999,8 +4077,7 @@ impl Machine {
                     1 => {
                         for op_desc in op_descs {
                             if let Some((_, op_desc)) = op_desc {
-                                let (op_prec, op_spec) =
-                                    (op_desc.get_prec(), op_desc.get_spec());
+                                let (op_prec, op_spec) = (op_desc.get_prec(), op_desc.get_spec());
 
                                 if op_prec == 0 {
                                     // 8.14.4, note 2
@@ -4060,13 +4137,14 @@ impl Machine {
                             return None;
                         }
 
-                        if (!orig_op.is_var() && atom_as_cell!(name) != orig_op) ||
-                            (!spec.is_var() && other_spec != spec_num) {
-                                return None;
-                            }
+                        if (!orig_op.is_var() && atom_as_cell!(name) != orig_op)
+                            || (!spec.is_var() && other_spec != spec_num)
+                        {
+                            return None;
+                        }
 
                         Some((*key, (other_prec as usize, other_spec as Specifier)))
-                    }
+                    },
                 ));
 
                 unossified_op_dir
@@ -4095,10 +4173,16 @@ impl Machine {
                     let spec_var = spec.as_var().unwrap();
                     let op_var = op.as_var().unwrap();
 
-                    self.machine_st.bind(prec_var, fixnum_as_cell!(Fixnum::build_with(*op_prec as i64)));
+                    self.machine_st.bind(
+                        prec_var,
+                        fixnum_as_cell!(Fixnum::build_with(*op_prec as i64)),
+                    );
                     self.machine_st.bind(spec_var, atom_as_cell!(spec_atom));
                     self.machine_st.bind(op_var, atom_as_cell!(op_atom));
-                    self.machine_st.bind(ossified_op_dir_var, typed_arena_ptr_as_cell!(ossified_op_dir));
+                    self.machine_st.bind(
+                        ossified_op_dir_var,
+                        typed_arena_ptr_as_cell!(ossified_op_dir),
+                    );
                 }
                 None => {
                     self.machine_st.fail = true;
@@ -4115,9 +4199,7 @@ impl Machine {
                 return;
             }
 
-            let ossified_op_dir = cell_as_ossified_op_dir!(
-                ossified_op_dir_cell
-            );
+            let ossified_op_dir = cell_as_ossified_op_dir!(ossified_op_dir_cell);
 
             let fixity = match spec {
                 atom!("xfy") | atom!("yfx") | atom!("xfx") => Fixity::In,
@@ -4129,21 +4211,30 @@ impl Machine {
                 }
             };
 
-            match self.machine_st.get_next_db_ref(
-                &self.indices,
-                &DBRef::Op(op_atom, fixity, ossified_op_dir),
-            ) {
+            match self
+                .machine_st
+                .get_next_db_ref(&self.indices, &DBRef::Op(op_atom, fixity, ossified_op_dir))
+            {
                 Some(DBRef::Op(op_atom, fixity, ossified_op_dir)) => {
                     let (prec, spec) = ossified_op_dir.get(&(op_atom, fixity)).unwrap();
 
-                    let prec_var = self.machine_st.deref(self.machine_st.registers[5])
-                        .as_var().unwrap();
+                    let prec_var = self
+                        .machine_st
+                        .deref(self.machine_st.registers[5])
+                        .as_var()
+                        .unwrap();
 
-                    let spec_var = self.machine_st.deref(self.machine_st.registers[6])
-                        .as_var().unwrap();
+                    let spec_var = self
+                        .machine_st
+                        .deref(self.machine_st.registers[6])
+                        .as_var()
+                        .unwrap();
 
-                    let op_var = self.machine_st.deref(self.machine_st.registers[7])
-                        .as_var().unwrap();
+                    let op_var = self
+                        .machine_st
+                        .deref(self.machine_st.registers[7])
+                        .as_var()
+                        .unwrap();
 
                     let spec_atom = match *spec {
                         FX => atom!("fx"),
@@ -4159,7 +4250,8 @@ impl Machine {
                         }
                     };
 
-                    self.machine_st.bind(prec_var, fixnum_as_cell!(Fixnum::build_with(*prec as i64)));
+                    self.machine_st
+                        .bind(prec_var, fixnum_as_cell!(Fixnum::build_with(*prec as i64)));
                     self.machine_st.bind(spec_var, atom_as_cell!(spec_atom));
                     self.machine_st.bind(op_var, atom_as_cell!(op_atom));
                 }
@@ -4188,9 +4280,7 @@ impl Machine {
             random_bits
         }
 
-        let result = {
-            generate_random_bits(1) == 0
-        };
+        let result = { generate_random_bits(1) == 0 };
 
         self.machine_st.fail = result;
     }
@@ -4201,7 +4291,8 @@ impl Machine {
         let secs = ProcessTime::now().as_duration().as_secs_f64();
         let secs = float_alloc!(secs, self.machine_st.arena);
 
-        self.machine_st.unify_f64(secs, self.machine_st.registers[1]);
+        self.machine_st
+            .unify_f64(secs, self.machine_st.registers[1]);
     }
 
     #[cfg(target_os = "wasi")]
@@ -4223,7 +4314,7 @@ impl Machine {
                     let err = self.machine_st.resource_error(len);
                     return Err(self.machine_st.error_form(err, stub_gen()));
                 }
-            }
+            },
             _ => {
                 unreachable!()
             }
@@ -4233,11 +4324,12 @@ impl Machine {
 
         iter_to_heap_list(
             &mut self.machine_st.heap,
-            (0 .. n).map(|i| heap_loc_as_cell!(h + 2 * i + 1)),
+            (0..n).map(|i| heap_loc_as_cell!(h + 2 * i + 1)),
         );
 
         let tail = self.deref_register(1);
-        self.machine_st.bind(tail.as_var().unwrap(), heap_loc_as_cell!(h));
+        self.machine_st
+            .bind(tail.as_var().unwrap(), heap_loc_as_cell!(h));
 
         Ok(())
     }
@@ -4246,7 +4338,7 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn http_open(&mut self) -> CallResult {
         let address_sink = self.deref_register(1);
-        let method =  read_heap_cell!(self.deref_register(3),
+        let method = read_heap_cell!(self.deref_register(3),
             (HeapCellValueTag::Atom, (name, arity)) => {
                 debug_assert_eq!(arity, 0);
                 match name {
@@ -4271,88 +4363,104 @@ impl Machine {
         }
         let stub_gen = || functor_stub(atom!("http_open"), 3);
 
-        let headers = match self.machine_st.try_from_list(self.machine_st.registers[7], stub_gen) {
+        let headers = match self
+            .machine_st
+            .try_from_list(self.machine_st.registers[7], stub_gen)
+        {
             Ok(addrs) => {
                 let mut header_map = HeaderMap::new();
-                for heap_cell in addrs{
-                   read_heap_cell!(heap_cell,
-                       (HeapCellValueTag::Str, s) => {
-                           let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
-                           let value = self.machine_st.value_to_str_like(self.machine_st.heap[s + 1]).unwrap();
-                           header_map.insert(HeaderName::from_str(name.as_str()).unwrap(), HeaderValue::from_str(value.as_str()).unwrap());
-                       }
-                       _ => {
-                           unreachable!()
-                       }
-                   )
+                for heap_cell in addrs {
+                    read_heap_cell!(heap_cell,
+                        (HeapCellValueTag::Str, s) => {
+                            let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
+                            let value = self.machine_st.value_to_str_like(self.machine_st.heap[s + 1]).unwrap();
+                            header_map.insert(HeaderName::from_str(name.as_str()).unwrap(), HeaderValue::from_str(value.as_str()).unwrap());
+                        }
+                        _ => {
+                            unreachable!()
+                        }
+                    )
                 }
                 header_map
-            },
-            Err(e) => return Err(e)
+            }
+            Err(e) => return Err(e),
         };
         if let Some(address_sink) = self.machine_st.value_to_str_like(address_sink) {
             let address_string = address_sink.as_str(); //to_string();
             let address: Url = address_string.parse().unwrap();
 
-	    let client = reqwest::blocking::Client::builder()
-		.build()
-		.unwrap();
+            let client = reqwest::blocking::Client::builder().build().unwrap();
 
-	    // request
-	    let mut req = reqwest::blocking::Request::new(method, address);
+            // request
+            let mut req = reqwest::blocking::Request::new(method, address);
 
-	    *req.headers_mut() = headers;
-	    if bytes.len() > 0 {
-		*req.body_mut() = Some(reqwest::blocking::Body::from(bytes));
-	    }
+            *req.headers_mut() = headers;
+            if bytes.len() > 0 {
+                *req.body_mut() = Some(reqwest::blocking::Body::from(bytes));
+            }
 
-	    // do it!
-	    match client.execute(req) {
-		Ok(resp) => {
-		    // status code
-		    let status = resp.status().as_u16();
-		    self.machine_st.unify_fixnum(Fixnum::build_with(status as i64), address_status);
-		    // headers
-		    let headers: Vec<HeapCellValue> = resp.headers().iter().map(|(header_name, header_value)| {
-			let h = self.machine_st.heap.len();
+            // do it!
+            match client.execute(req) {
+                Ok(resp) => {
+                    // status code
+                    let status = resp.status().as_u16();
+                    self.machine_st
+                        .unify_fixnum(Fixnum::build_with(status as i64), address_status);
+                    // headers
+                    let headers: Vec<HeapCellValue> = resp
+                        .headers()
+                        .iter()
+                        .map(|(header_name, header_value)| {
+                            let h = self.machine_st.heap.len();
 
-			let header_term = functor!(
-			    self.machine_st.atom_tbl.build_with(header_name.as_str()),
-			    [cell(string_as_cstr_cell!(self.machine_st.atom_tbl.build_with(header_value.to_str().unwrap())))]
-			);
+                            let header_term = functor!(
+                                self.machine_st.atom_tbl.build_with(header_name.as_str()),
+                                [cell(string_as_cstr_cell!(self
+                                    .machine_st
+                                    .atom_tbl
+                                    .build_with(header_value.to_str().unwrap())))]
+                            );
 
-			self.machine_st.heap.extend(header_term.into_iter());
-			str_loc_as_cell!(h)
-		    }).collect();
+                            self.machine_st.heap.extend(header_term.into_iter());
+                            str_loc_as_cell!(h)
+                        })
+                        .collect();
 
-		    let headers_list = iter_to_heap_list(&mut self.machine_st.heap, headers.into_iter());
-		    unify!(self.machine_st, heap_loc_as_cell!(headers_list), self.machine_st.registers[6]);
-		    // body
-		    let reader = resp.bytes().unwrap().reader();
+                    let headers_list =
+                        iter_to_heap_list(&mut self.machine_st.heap, headers.into_iter());
+                    unify!(
+                        self.machine_st,
+                        heap_loc_as_cell!(headers_list),
+                        self.machine_st.registers[6]
+                    );
+                    // body
+                    let reader = resp.bytes().unwrap().reader();
 
-		    let mut stream = Stream::from_http_stream(
-			self.machine_st.atom_tbl.build_with(&address_string),
-			Box::new(reader),
-			&mut self.machine_st.arena
-		    );
-		    *stream.options_mut() = StreamOptions::default();
-		    if let Some(alias) = stream.options().get_alias() {
-			self.indices.stream_aliases.insert(alias, stream);
-		    }
+                    let mut stream = Stream::from_http_stream(
+                        self.machine_st.atom_tbl.build_with(&address_string),
+                        Box::new(reader),
+                        &mut self.machine_st.arena,
+                    );
+                    *stream.options_mut() = StreamOptions::default();
+                    if let Some(alias) = stream.options().get_alias() {
+                        self.indices.stream_aliases.insert(alias, stream);
+                    }
 
-		    self.indices.streams.insert(stream);
+                    self.indices.streams.insert(stream);
 
-		    let stream = stream_as_cell!(stream);
+                    let stream = stream_as_cell!(stream);
 
-		    let stream_addr = self.deref_register(2);
-		    self.machine_st.bind(stream_addr.as_var().unwrap(), stream);
-		},
-		Err(_) => {
-		    self.machine_st.fail = true;
-		}
-	    }
+                    let stream_addr = self.deref_register(2);
+                    self.machine_st.bind(stream_addr.as_var().unwrap(), stream);
+                }
+                Err(_) => {
+                    self.machine_st.fail = true;
+                }
+            }
         } else {
-            let err = self.machine_st.domain_error(DomainErrorType::SourceSink, address_sink);
+            let err = self
+                .machine_st
+                .domain_error(DomainErrorType::SourceSink, address_sink);
             let stub = functor_stub(atom!("http_open"), 3);
 
             return Err(self.machine_st.error_form(err, stub));
@@ -4365,374 +4473,408 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn http_listen(&mut self) -> CallResult {
         let address_sink = self.deref_register(1);
-	if let Some(address_str) = self.machine_st.value_to_str_like(address_sink) {
-	    let address_string = address_str.as_str();
-	    let addr: SocketAddr = match address_string.to_socket_addrs().ok().and_then(|mut s| s.next()) {
-		Some(addr) => addr,
+        if let Some(address_str) = self.machine_st.value_to_str_like(address_sink) {
+            let address_string = address_str.as_str();
+            let addr: SocketAddr = match address_string
+                .to_socket_addrs()
+                .ok()
+                .and_then(|mut s| s.next())
+            {
+                Some(addr) => addr,
                 _ => {
                     self.machine_st.fail = true;
                     return Ok(());
                 }
-	    };
+            };
 
-	    let (tx, rx) = std::sync::mpsc::sync_channel(1024);
+            let (tx, rx) = std::sync::mpsc::sync_channel(1024);
 
-	    let _guard = self.runtime.enter();
-	    let listener = match self.runtime.block_on(async { tokio::net::TcpListener::bind(addr).await }) {
-		Ok(listener) => listener,
-		Err(_) => {
-		    return Err(self.machine_st.open_permission_error(address_sink, atom!("http_listen"), 2));
-		}
-	    };
+            let _guard = self.runtime.enter();
+            let listener = match self
+                .runtime
+                .block_on(async { tokio::net::TcpListener::bind(addr).await })
+            {
+                Ok(listener) => listener,
+                Err(_) => {
+                    return Err(self.machine_st.open_permission_error(
+                        address_sink,
+                        atom!("http_listen"),
+                        2,
+                    ));
+                }
+            };
 
-	    self.runtime.spawn(async move {
-		loop {
-		    let tx = tx.clone();
-		    let (stream, _) = listener.accept().await.unwrap();
+            self.runtime.spawn(async move {
+                loop {
+                    let tx = tx.clone();
+                    let (stream, _) = listener.accept().await.unwrap();
 
-		    tokio::task::spawn(async move {
-			if let Err(err) = http1::Builder::new()
-			    .serve_connection(stream, HttpService {
-				tx
-			    })
-			    .await
-			{
-			    eprintln!("Error serving connection: {:?}", err);
-			}
-		    });
-		}
-	    });
-	    let http_listener = HttpListener { incoming: rx };
-	    let http_listener = arena_alloc!(http_listener, &mut self.machine_st.arena);
+                    tokio::task::spawn(async move {
+                        if let Err(err) = http1::Builder::new()
+                            .serve_connection(stream, HttpService { tx })
+                            .await
+                        {
+                            eprintln!("Error serving connection: {:?}", err);
+                        }
+                    });
+                }
+            });
+            let http_listener = HttpListener { incoming: rx };
+            let http_listener = arena_alloc!(http_listener, &mut self.machine_st.arena);
             let addr = self.deref_register(2);
-	    self.machine_st.bind(addr.as_var().unwrap(), typed_arena_ptr_as_cell!(http_listener));
-	}
-	Ok(())
+            self.machine_st.bind(
+                addr.as_var().unwrap(),
+                typed_arena_ptr_as_cell!(http_listener),
+            );
+        }
+        Ok(())
     }
 
     #[cfg(feature = "http")]
     #[inline(always)]
     pub(crate) fn http_accept(&mut self) -> CallResult {
-	let culprit = self.deref_register(1);
-	let method = self.deref_register(2);
-	let path = self.deref_register(3);
-	let query = self.deref_register(5);
-	let stream_addr = self.deref_register(6);
-	let handle_addr = self.deref_register(7);
-	read_heap_cell!(culprit,
-	    (HeapCellValueTag::Cons, cons_ptr) => {
-		match_untyped_arena_ptr!(cons_ptr,
-		    (ArenaHeaderTag::HttpListener, http_listener) => {
-		        match http_listener.incoming.recv() {
-			    Ok(request) => {
-			        let method_atom = match *request.request.method() {
-				    Method::GET => atom!("get"),
-				    Method::POST => atom!("post"),
-				    Method::PUT => atom!("put"),
-				    Method::DELETE => atom!("delete"),
-				    Method::PATCH => atom!("patch"),
-				    Method::HEAD => atom!("head"),
-				    _ => unreachable!(),
-				};
-				let path_atom = self.machine_st.atom_tbl.build_with(request.request.uri().path());
-				let path_cell = atom_as_cstr_cell!(path_atom);
-				let headers: Vec<HeapCellValue> = request.request.headers().iter().map(|(header_name, header_value)| {
-				    let h = self.machine_st.heap.len();
+        let culprit = self.deref_register(1);
+        let method = self.deref_register(2);
+        let path = self.deref_register(3);
+        let query = self.deref_register(5);
+        let stream_addr = self.deref_register(6);
+        let handle_addr = self.deref_register(7);
+        read_heap_cell!(culprit,
+            (HeapCellValueTag::Cons, cons_ptr) => {
+            match_untyped_arena_ptr!(cons_ptr,
+                (ArenaHeaderTag::HttpListener, http_listener) => {
+                    match http_listener.incoming.recv() {
+                    Ok(request) => {
+                        let method_atom = match *request.request.method() {
+                        Method::GET => atom!("get"),
+                        Method::POST => atom!("post"),
+                        Method::PUT => atom!("put"),
+                        Method::DELETE => atom!("delete"),
+                        Method::PATCH => atom!("patch"),
+                        Method::HEAD => atom!("head"),
+                        _ => unreachable!(),
+                    };
+                    let path_atom = self.machine_st.atom_tbl.build_with(request.request.uri().path());
+                    let path_cell = atom_as_cstr_cell!(path_atom);
+                    let headers: Vec<HeapCellValue> = request.request.headers().iter().map(|(header_name, header_value)| {
+                        let h = self.machine_st.heap.len();
 
-				    let header_term = functor!(
-				        self.machine_st.atom_tbl.build_with(header_name.as_str()),
-					[cell(string_as_cstr_cell!(self.machine_st.atom_tbl.build_with(header_value.to_str().unwrap())))]
-				    );
+                        let header_term = functor!(
+                            self.machine_st.atom_tbl.build_with(header_name.as_str()),
+                        [cell(string_as_cstr_cell!(self.machine_st.atom_tbl.build_with(header_value.to_str().unwrap())))]
+                        );
 
-				    self.machine_st.heap.extend(header_term.into_iter());
-				    str_loc_as_cell!(h)
-				}).collect();
+                        self.machine_st.heap.extend(header_term.into_iter());
+                        str_loc_as_cell!(h)
+                    }).collect();
 
-				let headers_list = iter_to_heap_list(&mut self.machine_st.heap, headers.into_iter());
+                    let headers_list = iter_to_heap_list(&mut self.machine_st.heap, headers.into_iter());
 
-				let query_str = request.request.uri().query().unwrap_or("");
-				let query_atom = self.machine_st.atom_tbl.build_with(query_str);
-				let query_cell = string_as_cstr_cell!(query_atom);
+                    let query_str = request.request.uri().query().unwrap_or("");
+                    let query_atom = self.machine_st.atom_tbl.build_with(query_str);
+                    let query_cell = string_as_cstr_cell!(query_atom);
 
-				let hyper_req = request.request;
-				let buf = self.runtime.block_on(async {hyper_req.collect().await.unwrap().aggregate()});
-				let reader = buf.reader();
+                    let hyper_req = request.request;
+                    let buf = self.runtime.block_on(async {hyper_req.collect().await.unwrap().aggregate()});
+                    let reader = buf.reader();
 
-				let mut stream = Stream::from_http_stream(
-				    path_atom,
-				    Box::new(reader),
-				    &mut self.machine_st.arena
-				);
-				*stream.options_mut() = StreamOptions::default();
-				stream.options_mut().set_stream_type(StreamType::Binary);
-				self.indices.streams.insert(stream);
-				let stream = stream_as_cell!(stream);
+                    let mut stream = Stream::from_http_stream(
+                        path_atom,
+                        Box::new(reader),
+                        &mut self.machine_st.arena
+                    );
+                    *stream.options_mut() = StreamOptions::default();
+                    stream.options_mut().set_stream_type(StreamType::Binary);
+                    self.indices.streams.insert(stream);
+                    let stream = stream_as_cell!(stream);
 
-				let handle = arena_alloc!(request.response, &mut self.machine_st.arena);
+                    let handle = arena_alloc!(request.response, &mut self.machine_st.arena);
 
-				self.machine_st.bind(method.as_var().unwrap(), atom_as_cell!(method_atom));
-				self.machine_st.bind(path.as_var().unwrap(), path_cell);
-				unify!(self.machine_st, heap_loc_as_cell!(headers_list), self.machine_st.registers[4]);
-				self.machine_st.bind(query.as_var().unwrap(), query_cell);
-				self.machine_st.bind(stream_addr.as_var().unwrap(), stream);
-				self.machine_st.bind(handle_addr.as_var().unwrap(), typed_arena_ptr_as_cell!(handle));
-				}
-			    Err(_) => {
-			        self.machine_st.fail = true;
-			    }
-			}
-		    }
-		    _ => {
-		        unreachable!();
-		    }
-		);
-	    }
-	    _ => {
-	        unreachable!();
-	    }
-	);
-	Ok(())
+                    self.machine_st.bind(method.as_var().unwrap(), atom_as_cell!(method_atom));
+                    self.machine_st.bind(path.as_var().unwrap(), path_cell);
+                    unify!(self.machine_st, heap_loc_as_cell!(headers_list), self.machine_st.registers[4]);
+                    self.machine_st.bind(query.as_var().unwrap(), query_cell);
+                    self.machine_st.bind(stream_addr.as_var().unwrap(), stream);
+                    self.machine_st.bind(handle_addr.as_var().unwrap(), typed_arena_ptr_as_cell!(handle));
+                    }
+                    Err(_) => {
+                        self.machine_st.fail = true;
+                    }
+                }
+                }
+                _ => {
+                    unreachable!();
+                }
+            );
+            }
+            _ => {
+                unreachable!();
+            }
+        );
+        Ok(())
     }
 
     #[cfg(feature = "http")]
     #[inline(always)]
     pub(crate) fn http_answer(&mut self) -> CallResult {
-	let culprit = self.deref_register(1);
-	let status_code = self.deref_register(2);
-	let status_code: u16 = match Number::try_from(status_code) {
-	    Ok(Number::Fixnum(n)) => n.get_num() as u16,
-	    Ok(Number::Integer(n)) => match n.to_u16() {
-		Some(u) => u,
-		_ => {
-		    self.machine_st.fail = true;
-		    return Ok(());
-		}
-	    }
-	    _ => unreachable!()
-	};
-	let stub_gen = || functor_stub(atom!("http_listen"), 2);
-	let headers = match self.machine_st.try_from_list(self.machine_st.registers[3], stub_gen) {
+        let culprit = self.deref_register(1);
+        let status_code = self.deref_register(2);
+        let status_code: u16 = match Number::try_from(status_code) {
+            Ok(Number::Fixnum(n)) => n.get_num() as u16,
+            Ok(Number::Integer(n)) => match n.to_u16() {
+                Some(u) => u,
+                _ => {
+                    self.machine_st.fail = true;
+                    return Ok(());
+                }
+            },
+            _ => unreachable!(),
+        };
+        let stub_gen = || functor_stub(atom!("http_listen"), 2);
+        let headers = match self
+            .machine_st
+            .try_from_list(self.machine_st.registers[3], stub_gen)
+        {
             Ok(addrs) => {
                 let mut header_map = HeaderMap::new();
-                for heap_cell in addrs{
-                   read_heap_cell!(heap_cell,
-                       (HeapCellValueTag::Str, s) => {
-                           let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
-                           let value = self.machine_st.value_to_str_like(self.machine_st.heap[s + 1]).unwrap();
-                           header_map.insert(HeaderName::from_str(name.as_str()).unwrap(), HeaderValue::from_str(value.as_str()).unwrap());
-                       }
-                       _ => {
-                           unreachable!()
-                       }
-                   )
+                for heap_cell in addrs {
+                    read_heap_cell!(heap_cell,
+                        (HeapCellValueTag::Str, s) => {
+                            let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
+                            let value = self.machine_st.value_to_str_like(self.machine_st.heap[s + 1]).unwrap();
+                            header_map.insert(HeaderName::from_str(name.as_str()).unwrap(), HeaderValue::from_str(value.as_str()).unwrap());
+                        }
+                        _ => {
+                            unreachable!()
+                        }
+                    )
                 }
                 header_map
-            },
-            Err(e) => return Err(e)
+            }
+            Err(e) => return Err(e),
         };
-	let stream_addr = self.deref_register(4);
+        let stream_addr = self.deref_register(4);
 
-	read_heap_cell!(culprit,
-	    (HeapCellValueTag::Cons, cons_ptr) => {
-		match_untyped_arena_ptr!(cons_ptr,
-		    (ArenaHeaderTag::HttpResponse, http_response) => {
-			let mut stream = Stream::from_http_sender(
-			    http_response,
-			    status_code,
-			    headers,
-			    &mut self.machine_st.arena
-			);
-			*stream.options_mut() = StreamOptions::default();
-			stream.options_mut().set_stream_type(StreamType::Binary);
-			self.indices.streams.insert(stream);
-			let stream = stream_as_cell!(stream);
-			self.machine_st.bind(stream_addr.as_var().unwrap(), stream);
-		    }
-		    _ => {
-			unreachable!();
-		    }
-		);
-	    }
-	    _ => {
-		unreachable!();
-	    }
-	);
+        read_heap_cell!(culprit,
+            (HeapCellValueTag::Cons, cons_ptr) => {
+            match_untyped_arena_ptr!(cons_ptr,
+                (ArenaHeaderTag::HttpResponse, http_response) => {
+                let mut stream = Stream::from_http_sender(
+                    http_response,
+                    status_code,
+                    headers,
+                    &mut self.machine_st.arena
+                );
+                *stream.options_mut() = StreamOptions::default();
+                stream.options_mut().set_stream_type(StreamType::Binary);
+                self.indices.streams.insert(stream);
+                let stream = stream_as_cell!(stream);
+                self.machine_st.bind(stream_addr.as_var().unwrap(), stream);
+                }
+                _ => {
+                unreachable!();
+                }
+            );
+            }
+            _ => {
+            unreachable!();
+            }
+        );
 
-	Ok(())
+        Ok(())
     }
 
     #[cfg(feature = "ffi")]
     #[inline(always)]
     pub(crate) fn load_foreign_lib(&mut self) -> CallResult {
-	let library_name = self.deref_register(1);
-	let args_reg = self.deref_register(2);
-	if let Some(library_name) = self.machine_st.value_to_str_like(library_name) {
-	    let stub_gen = || functor_stub(atom!("use_foreign_module"), 2);
-	    match self.machine_st.try_from_list(args_reg, stub_gen) {
-		Ok(addrs) => {
-		    let mut functions = Vec::new();
-		    for heap_cell in addrs {
-			read_heap_cell!(heap_cell,
-			    (HeapCellValueTag::Str, s) => {
-			        let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
-				let args: Vec<Atom> = match self.machine_st.try_from_list(self.machine_st.heap[s + 1], stub_gen) {
-				    Ok(addrs) => {
-					let mut args = Vec::new();
-					for heap_cell in addrs {
-					    args.push(cell_as_atom_cell!(heap_cell).get_name());
-					}
-					args
-				    }
-				    Err(e) => return Err(e)
-				};
-				let return_value = cell_as_atom_cell!(self.machine_st.heap[s + 2]);
-				functions.push(FunctionDefinition {
-				    name: name.as_str().to_string(),
-				    args,
-				    return_value: return_value.get_name(),
-				});
-			    }
-			    _ => {
-			        unreachable!()
-		            }
-			)
-		    }
-		    if let Ok(_) = self.foreign_function_table.load_library(library_name.as_str(), &functions) {
-		        return Ok(());
-	            }
-		}
-		Err(e) => return Err(e)
-	    };
-	}
-	self.machine_st.fail = true;
-	Ok(())
+        let library_name = self.deref_register(1);
+        let args_reg = self.deref_register(2);
+        if let Some(library_name) = self.machine_st.value_to_str_like(library_name) {
+            let stub_gen = || functor_stub(atom!("use_foreign_module"), 2);
+            match self.machine_st.try_from_list(args_reg, stub_gen) {
+                Ok(addrs) => {
+                    let mut functions = Vec::new();
+                    for heap_cell in addrs {
+                        read_heap_cell!(heap_cell,
+                            (HeapCellValueTag::Str, s) => {
+                                let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
+                            let args: Vec<Atom> = match self.machine_st.try_from_list(self.machine_st.heap[s + 1], stub_gen) {
+                                Ok(addrs) => {
+                                let mut args = Vec::new();
+                                for heap_cell in addrs {
+                                    args.push(cell_as_atom_cell!(heap_cell).get_name());
+                                }
+                                args
+                                }
+                                Err(e) => return Err(e)
+                            };
+                            let return_value = cell_as_atom_cell!(self.machine_st.heap[s + 2]);
+                            functions.push(FunctionDefinition {
+                                name: name.as_str().to_string(),
+                                args,
+                                return_value: return_value.get_name(),
+                            });
+                            }
+                            _ => {
+                                unreachable!()
+                                }
+                        )
+                    }
+                    if let Ok(_) = self
+                        .foreign_function_table
+                        .load_library(library_name.as_str(), &functions)
+                    {
+                        return Ok(());
+                    }
+                }
+                Err(e) => return Err(e),
+            };
+        }
+        self.machine_st.fail = true;
+        Ok(())
     }
 
     #[cfg(feature = "ffi")]
     #[inline(always)]
     pub(crate) fn foreign_call(&mut self) -> CallResult {
-	let function_name = self.deref_register(1);
-	let args_reg = self.deref_register(2);
-	let return_value = self.deref_register(3);
-	if let Some(function_name) = self.machine_st.value_to_str_like(function_name) {
-   	    let stub_gen = || functor_stub(atom!("foreign_call"), 3);
-	    fn map_arg(mut machine_st: &mut MachineState, source: HeapCellValue) -> crate::ffi::Value {
-		match Number::try_from(source) {
-		    Ok(Number::Fixnum(n)) => {
-			Value::Int(n.get_num())
-		    },
-		    Ok(Number::Float(n)) => {
-			Value::Float(n.into_inner())
-		    },
-		    _ => {
-			let stub_gen = || functor_stub(atom!("foreign_call"), 3);
-			if let Some(string) = machine_st.value_to_str_like(source) {
-			    Value::CString(CString::new(string.as_str()).unwrap())
-			} else {
-			    match machine_st.try_from_list(source, stub_gen) {
-				Ok(args) => {
-				    let mut iter = args.into_iter();
-				    if let Some(struct_name) = machine_st.value_to_str_like(iter.next().unwrap()) {
-					Value::Struct(struct_name.as_str().to_string(), iter.map(|x| map_arg(&mut machine_st, x)).collect())
-				    } else {
-					unreachable!()
-				    }
-				}
-				_ => {
-				    unreachable!()
-				}
-			    }
-			}
-		    }
-		}
-	    }
+        let function_name = self.deref_register(1);
+        let args_reg = self.deref_register(2);
+        let return_value = self.deref_register(3);
+        if let Some(function_name) = self.machine_st.value_to_str_like(function_name) {
+            let stub_gen = || functor_stub(atom!("foreign_call"), 3);
+            fn map_arg(
+                mut machine_st: &mut MachineState,
+                source: HeapCellValue,
+            ) -> crate::ffi::Value {
+                match Number::try_from(source) {
+                    Ok(Number::Fixnum(n)) => Value::Int(n.get_num()),
+                    Ok(Number::Float(n)) => Value::Float(n.into_inner()),
+                    _ => {
+                        let stub_gen = || functor_stub(atom!("foreign_call"), 3);
+                        if let Some(string) = machine_st.value_to_str_like(source) {
+                            Value::CString(CString::new(string.as_str()).unwrap())
+                        } else {
+                            match machine_st.try_from_list(source, stub_gen) {
+                                Ok(args) => {
+                                    let mut iter = args.into_iter();
+                                    if let Some(struct_name) =
+                                        machine_st.value_to_str_like(iter.next().unwrap())
+                                    {
+                                        Value::Struct(
+                                            struct_name.as_str().to_string(),
+                                            iter.map(|x| map_arg(&mut machine_st, x)).collect(),
+                                        )
+                                    } else {
+                                        unreachable!()
+                                    }
+                                }
+                                _ => {
+                                    unreachable!()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-	    match self.machine_st.try_from_list(args_reg, stub_gen) {
-		Ok(args) => {
-		    let args: Vec<_> = args.into_iter().map(|x| map_arg(&mut self.machine_st, x)).collect();
-	    	    match self.foreign_function_table.exec(function_name.as_str(), args) {
-			Ok(result) => {
-			    match result {
-				Value::Int(n) => self.machine_st.unify_fixnum(Fixnum::build_with(n), return_value),
-				Value::Float(n) => {
-				    let n = float_alloc!(n, self.machine_st.arena);
-				    self.machine_st.unify_f64(n, return_value)
-				},
-				Value::Struct(name, args) => {
-				    let struct_value = self.build_struct(&name, args);
-				    unify!(self.machine_st, return_value, struct_value);
-				}
-				Value::CString(cstr) => {
-				    let cstr = self.machine_st.atom_tbl.build_with(cstr.to_str().unwrap());
-				    self.machine_st.unify_complete_string(cstr, return_value);
-				}
-			    }
-			    return Ok(());
-			},
-			Err(e) => {
-			    let stub = functor_stub(atom!("current_input"), 1);
-			    let err = self.machine_st.ffi_error(e);
+            match self.machine_st.try_from_list(args_reg, stub_gen) {
+                Ok(args) => {
+                    let args: Vec<_> = args
+                        .into_iter()
+                        .map(|x| map_arg(&mut self.machine_st, x))
+                        .collect();
+                    match self
+                        .foreign_function_table
+                        .exec(function_name.as_str(), args)
+                    {
+                        Ok(result) => {
+                            match result {
+                                Value::Int(n) => self
+                                    .machine_st
+                                    .unify_fixnum(Fixnum::build_with(n), return_value),
+                                Value::Float(n) => {
+                                    let n = float_alloc!(n, self.machine_st.arena);
+                                    self.machine_st.unify_f64(n, return_value)
+                                }
+                                Value::Struct(name, args) => {
+                                    let struct_value = self.build_struct(&name, args);
+                                    unify!(self.machine_st, return_value, struct_value);
+                                }
+                                Value::CString(cstr) => {
+                                    let cstr =
+                                        self.machine_st.atom_tbl.build_with(cstr.to_str().unwrap());
+                                    self.machine_st.unify_complete_string(cstr, return_value);
+                                }
+                            }
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            let stub = functor_stub(atom!("current_input"), 1);
+                            let err = self.machine_st.ffi_error(e);
 
                             return Err(self.machine_st.error_form(err, stub));
-			}
-		    }
-		}
-		Err(e) => return Err(e)
-	    }
-	}
-	self.machine_st.fail = true;
-	Ok(())
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        self.machine_st.fail = true;
+        Ok(())
     }
 
     #[cfg(feature = "ffi")]
     fn build_struct(&mut self, name: &str, mut args: Vec<Value>) -> HeapCellValue {
-	args.insert(0, Value::CString(CString::new(name).unwrap()));
-	let cells: Vec<_> = args.into_iter()
-	    .map(|val| {
-		match val {
-		    Value::Int(n) => fixnum_as_cell!(Fixnum::build_with(n)),
-		    Value::Float(n) => HeapCellValue::from(float_alloc!(n, self.machine_st.arena)),
-		    Value::CString(cstr) => atom_as_cell!(self.machine_st.atom_tbl.build_with(&cstr.into_string().unwrap())),
-		    Value::Struct(name, struct_args) => self.build_struct(&name, struct_args),
-		}
-	    }).collect();
+        args.insert(0, Value::CString(CString::new(name).unwrap()));
+        let cells: Vec<_> = args
+            .into_iter()
+            .map(|val| match val {
+                Value::Int(n) => fixnum_as_cell!(Fixnum::build_with(n)),
+                Value::Float(n) => HeapCellValue::from(float_alloc!(n, self.machine_st.arena)),
+                Value::CString(cstr) => atom_as_cell!(self
+                    .machine_st
+                    .atom_tbl
+                    .build_with(&cstr.into_string().unwrap())),
+                Value::Struct(name, struct_args) => self.build_struct(&name, struct_args),
+            })
+            .collect();
 
-	heap_loc_as_cell!(
-	    iter_to_heap_list(
-		&mut self.machine_st.heap,
-		cells.into_iter()
-	    )
-        )
+        heap_loc_as_cell!(iter_to_heap_list(
+            &mut self.machine_st.heap,
+            cells.into_iter()
+        ))
     }
 
     #[cfg(feature = "ffi")]
     #[inline(always)]
     pub(crate) fn define_foreign_struct(&mut self) -> CallResult {
-	let struct_name = self.deref_register(1);
-	let fields_reg = self.deref_register(2);
-	if let Some(struct_name) = self.machine_st.value_to_str_like(struct_name) {
-	    let stub_gen = || functor_stub(atom!("define_foreign_struct"), 2);
-	    let fields: Vec<Atom> = match self.machine_st.try_from_list(fields_reg, stub_gen) {
-		Ok(addrs) => {
-		    let mut args = Vec::new();
-		    for heap_cell in addrs {
-			args.push(cell_as_atom_cell!(heap_cell).get_name());
-		    }
-		    args
-		}
-		Err(e) => return Err(e)
-	    };
-	    self.foreign_function_table.define_struct(struct_name.as_str(), fields);
-	    return Ok(())
-	}
-	self.machine_st.fail = true;
-	Ok(())
+        let struct_name = self.deref_register(1);
+        let fields_reg = self.deref_register(2);
+        if let Some(struct_name) = self.machine_st.value_to_str_like(struct_name) {
+            let stub_gen = || functor_stub(atom!("define_foreign_struct"), 2);
+            let fields: Vec<Atom> = match self.machine_st.try_from_list(fields_reg, stub_gen) {
+                Ok(addrs) => {
+                    let mut args = Vec::new();
+                    for heap_cell in addrs {
+                        args.push(cell_as_atom_cell!(heap_cell).get_name());
+                    }
+                    args
+                }
+                Err(e) => return Err(e),
+            };
+            self.foreign_function_table
+                .define_struct(struct_name.as_str(), fields);
+            return Ok(());
+        }
+        self.machine_st.fail = true;
+        Ok(())
     }
 
     #[inline(always)]
     pub(crate) fn current_time(&mut self) {
         let timestamp = self.systemtime_to_timestamp(SystemTime::now());
-        self.machine_st.unify_complete_string(timestamp, self.machine_st.registers[1]);
+        self.machine_st
+            .unify_complete_string(timestamp, self.machine_st.registers[1]);
     }
 
     #[inline(always)]
@@ -4742,17 +4884,17 @@ impl Machine {
         let reposition = self.machine_st.registers[6];
         let stream_type = self.machine_st.registers[7];
 
-        let options  = self.machine_st.to_stream_options(alias, eof_action, reposition, stream_type);
+        let options = self
+            .machine_st
+            .to_stream_options(alias, eof_action, reposition, stream_type);
         let src_sink = self.deref_register(1);
 
         if let Some(file_spec) = self.machine_st.value_to_str_like(src_sink) {
             let file_spec = file_spec.as_atom(&mut self.machine_st.atom_tbl);
 
-            let mut stream = self.machine_st.stream_from_file_spec(
-                file_spec,
-                &mut self.indices,
-                &options,
-            )?;
+            let mut stream =
+                self.machine_st
+                    .stream_from_file_spec(file_spec, &mut self.indices, &options)?;
 
             *stream.options_mut() = options;
             self.indices.streams.insert(stream);
@@ -4762,9 +4904,12 @@ impl Machine {
             }
 
             let stream_var = self.deref_register(3);
-            self.machine_st.bind(stream_var.as_var().unwrap(), stream_as_cell!(stream));
+            self.machine_st
+                .bind(stream_var.as_var().unwrap(), stream_as_cell!(stream));
         } else {
-            let err = self.machine_st.domain_error(DomainErrorType::SourceSink, src_sink);
+            let err = self
+                .machine_st
+                .domain_error(DomainErrorType::SourceSink, src_sink);
             let stub = functor_stub(atom!("open"), 4);
 
             return Err(self.machine_st.error_form(err, stub));
@@ -4842,7 +4987,9 @@ impl Machine {
         let reposition = self.machine_st.registers[4];
         let stream_type = self.machine_st.registers[5];
 
-        let options = self.machine_st.to_stream_options(alias, eof_action, reposition, stream_type);
+        let options = self
+            .machine_st
+            .to_stream_options(alias, eof_action, reposition, stream_type);
         *stream.options_mut() = options;
 
         Ok(())
@@ -4850,12 +4997,14 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn truncate_if_no_lifted_heap_growth_diff(&mut self) {
-        self.machine_st.truncate_if_no_lifted_heap_diff(|h| heap_loc_as_cell!(h))
+        self.machine_st
+            .truncate_if_no_lifted_heap_diff(|h| heap_loc_as_cell!(h))
     }
 
     #[inline(always)]
     pub(crate) fn truncate_if_no_lifted_heap_growth(&mut self) {
-        self.machine_st.truncate_if_no_lifted_heap_diff(|_| empty_list_as_cell!())
+        self.machine_st
+            .truncate_if_no_lifted_heap_diff(|_| empty_list_as_cell!())
     }
 
     #[inline(always)]
@@ -4875,7 +5024,8 @@ impl Machine {
         );
 
         let list_addr = self.deref_register(2);
-        self.machine_st.bind(Ref::heap_cell(attr_var_list), list_addr);
+        self.machine_st
+            .bind(Ref::heap_cell(attr_var_list), list_addr);
     }
 
     #[inline(always)]
@@ -4895,17 +5045,19 @@ impl Machine {
         let module = self.deref_register(2);
 
         match self.match_attribute(attr_var_list, module, attr) {
-            Some(AttrListMatch { match_site: MatchSite::Match(match_site), .. }) => {
+            Some(AttrListMatch {
+                match_site: MatchSite::Match(match_site),
+                ..
+            }) => {
                 let list_head = self.machine_st.heap[match_site];
 
                 if list_head.get_value() as usize == match_site {
                     // at the end of the list, no match found in this case.
                     self.machine_st.fail = true;
                 } else {
-                    let (_, qualified_goal) = self.machine_st.strip_module(
-                        list_head,
-                        empty_list_as_cell!(),
-                    );
+                    let (_, qualified_goal) = self
+                        .machine_st
+                        .strip_module(list_head, empty_list_as_cell!());
 
                     unify!(self.machine_st, qualified_goal, attr);
                 }
@@ -4940,9 +5092,8 @@ impl Machine {
         if let Some(b) = b {
             let iter = self.machine_st.gather_attr_vars_created_since(b);
 
-            let var_list_addr = heap_loc_as_cell!(
-                iter_to_heap_list(&mut self.machine_st.heap, iter)
-            );
+            let var_list_addr =
+                heap_loc_as_cell!(iter_to_heap_list(&mut self.machine_st.heap, iter));
 
             let list_addr = self.machine_st.registers[2];
             unify!(self.machine_st, var_list_addr, list_addr);
@@ -4965,7 +5116,10 @@ impl Machine {
         let module = self.deref_register(2);
 
         match self.match_attribute(self.machine_st.heap[attr_var_list], module, attr) {
-            Some(AttrListMatch { prev_tail, match_site: MatchSite::Match(match_site) }) => {
+            Some(AttrListMatch {
+                prev_tail,
+                match_site: MatchSite::Match(match_site),
+            }) => {
                 let prev_tail = if let Some(prev_tail) = prev_tail {
                     // not at the head.
                     prev_tail
@@ -4988,10 +5142,10 @@ impl Machine {
                     self.machine_st.heap[prev_tail] = heap_loc_as_cell!(prev_tail);
                 }
 
-                self.machine_st.trail(TrailRef::AttrVarListLink(prev_tail, match_site));
+                self.machine_st
+                    .trail(TrailRef::AttrVarListLink(prev_tail, match_site));
             }
-            _ => {
-            }
+            _ => {}
         }
     }
 
@@ -5028,8 +5182,10 @@ impl Machine {
 
         let h = self.machine_st.heap.len();
 
-        self.machine_st.heap.push(str_loc_as_cell!(h+1));
-        self.machine_st.heap.extend(functor!(atom!(":"), [cell(module), cell(attr)]));
+        self.machine_st.heap.push(str_loc_as_cell!(h + 1));
+        self.machine_st
+            .heap
+            .extend(functor!(atom!(":"), [cell(module), cell(attr)]));
 
         match self.match_attribute(self.machine_st.heap[attr_var_list], module, attr) {
             Some(AttrListMatch { match_site, .. }) => {
@@ -5038,9 +5194,9 @@ impl Machine {
                         let l = self.machine_st.heap[match_site].get_value();
 
                         // at the end of the (non-empty) list here.
-                        self.machine_st.heap[match_site] = list_loc_as_cell!(h+4);
+                        self.machine_st.heap[match_site] = list_loc_as_cell!(h + 4);
                         self.machine_st.heap.push(heap_loc_as_cell!(h));
-                        self.machine_st.heap.push(heap_loc_as_cell!(h+5));
+                        self.machine_st.heap.push(heap_loc_as_cell!(h + 5));
 
                         (match_site, l)
                     }
@@ -5052,16 +5208,21 @@ impl Machine {
                     }
                 };
 
-                self.machine_st.trail(TrailRef::AttrVarListLink(match_site, l as usize));
+                self.machine_st
+                    .trail(TrailRef::AttrVarListLink(match_site, l as usize));
             }
             None => {
                 // the list is empty.
-                self.machine_st.heap[attr_var_list] = list_loc_as_cell!(h+4);
+                self.machine_st.heap[attr_var_list] = list_loc_as_cell!(h + 4);
                 self.machine_st.heap.push(heap_loc_as_cell!(h));
-                self.machine_st.heap.push(heap_loc_as_cell!(h+5));
+                self.machine_st.heap.push(heap_loc_as_cell!(h + 5));
 
-                self.machine_st.attr_var_init.attr_var_queue.push(attr_var_list - 1);
-                self.machine_st.trail(TrailRef::AttrVarListLink(attr_var_list, attr_var_list));
+                self.machine_st
+                    .attr_var_init
+                    .attr_var_queue
+                    .push(attr_var_list - 1);
+                self.machine_st
+                    .trail(TrailRef::AttrVarListLink(attr_var_list, attr_var_list));
             }
         }
     }
@@ -5178,7 +5339,9 @@ impl Machine {
 
         let chunk = str_loc_as_cell!(self.machine_st.heap.len());
 
-        self.machine_st.heap.push(atom_as_cell!(atom!("cont_chunk"), 1 + num_cells));
+        self.machine_st
+            .heap
+            .push(atom_as_cell!(atom!("cont_chunk"), 1 + num_cells));
         self.machine_st.heap.push(p_functor);
         self.machine_st.heap.extend(addrs);
 
@@ -5188,9 +5351,8 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn get_lifted_heap_from_offset_diff(&mut self) {
         let lh_offset = self.machine_st.registers[1];
-        let lh_offset = cell_as_fixnum!(
-            self.machine_st.store(self.machine_st.deref(lh_offset))
-        ).get_num() as usize;
+        let lh_offset = cell_as_fixnum!(self.machine_st.store(self.machine_st.deref(lh_offset)))
+            .get_num() as usize;
 
         if lh_offset >= self.machine_st.lifted_heap.len() {
             let solutions = self.machine_st.registers[2];
@@ -5201,7 +5363,7 @@ impl Machine {
             let h = self.machine_st.heap.len();
             let mut last_index = h;
 
-            for value in self.machine_st.lifted_heap[lh_offset ..].iter().cloned() {
+            for value in self.machine_st.lifted_heap[lh_offset..].iter().cloned() {
                 last_index = self.machine_st.heap.len();
                 self.machine_st.heap.push(value + h);
             }
@@ -5221,9 +5383,8 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn get_lifted_heap_from_offset(&mut self) {
         let lh_offset = self.machine_st.registers[1];
-        let lh_offset = cell_as_fixnum!(self.machine_st.store(self.machine_st.deref(
-            lh_offset
-        ))).get_num() as usize;
+        let lh_offset = cell_as_fixnum!(self.machine_st.store(self.machine_st.deref(lh_offset)))
+            .get_num() as usize;
 
         if lh_offset >= self.machine_st.lifted_heap.len() {
             let solutions = self.machine_st.registers[2];
@@ -5275,7 +5436,12 @@ impl Machine {
         let dest = self.machine_st.registers[1];
 
         if let Some((addr, b_cutoff, prev_block)) = self.machine_st.cont_pts.pop() {
-            let b = self.machine_st.stack.index_or_frame(self.machine_st.b).prelude.b;
+            let b = self
+                .machine_st
+                .stack
+                .index_or_frame(self.machine_st.b)
+                .prelude
+                .b;
 
             if b <= b_cutoff {
                 self.machine_st.scc_block = prev_block;
@@ -5335,10 +5501,7 @@ impl Machine {
             Ok(Number::Fixnum(bp)) => bp.get_num() as usize,
             Ok(Number::Integer(n)) => n.to_usize().unwrap(),
             _ => {
-                let stub = functor_stub(
-                    atom!("call_with_inference_limit"),
-                    3,
-                );
+                let stub = functor_stub(atom!("call_with_inference_limit"), 3);
 
                 let err = self.machine_st.type_error(ValidType::Integer, a2);
                 return Err(self.machine_st.error_form(err, stub));
@@ -5375,7 +5538,7 @@ impl Machine {
         let a3 = self.deref_register(3);
 
         let arity = match Number::try_from(a3) {
-            Ok(Number::Fixnum(n))  => n.get_num() as usize,
+            Ok(Number::Fixnum(n)) => n.get_num() as usize,
             Ok(Number::Integer(n)) => {
                 if let Some(n) = n.to_usize() {
                     n
@@ -5388,12 +5551,10 @@ impl Machine {
             }
         };
 
-        self.indices.get_predicate_code_index(
-            name,
-            arity,
-            module_name,
-        ).map(|index| index.local().is_some())
-         .unwrap_or(false)
+        self.indices
+            .get_predicate_code_index(name, arity, module_name)
+            .map(|index| index.local().is_some())
+            .unwrap_or(false)
     }
 
     #[inline(always)]
@@ -5490,7 +5651,7 @@ impl Machine {
 
         if bp == self.machine_st.b && self.machine_st.cwil.is_empty() {
             self.machine_st.cwil.reset();
-            self.machine_st.increment_call_count_fn = |_| { Ok(()) };
+            self.machine_st.increment_call_count_fn = |_| Ok(());
         }
     }
 
@@ -5522,13 +5683,18 @@ impl Machine {
             self.machine_st.registers[i] = self.machine_st.stack[stack_loc!(AndFrame, e, i)];
         }
 
-        self.machine_st.b0 = cell_as_fixnum!(self.machine_st.stack[stack_loc!(AndFrame, e, frame_len - 2)])
-            .get_num() as usize;
+        self.machine_st.b0 = cell_as_fixnum!(
+            self.machine_st.stack[stack_loc!(AndFrame, e, frame_len - 2)]
+        )
+        .get_num() as usize;
 
-        self.machine_st.num_of_args = cell_as_fixnum!(self.machine_st.stack[stack_loc!(AndFrame, e, frame_len - 1)])
-            .get_num() as usize;
+        self.machine_st.num_of_args = cell_as_fixnum!(
+            self.machine_st.stack[stack_loc!(AndFrame, e, frame_len - 1)]
+        )
+        .get_num() as usize;
 
-        let p = cell_as_fixnum!(self.machine_st.stack[stack_loc!(AndFrame, e, frame_len)]).get_num() as usize;
+        let p = cell_as_fixnum!(self.machine_st.stack[stack_loc!(AndFrame, e, frame_len)]).get_num()
+            as usize;
 
         self.machine_st.deallocate();
         self.machine_st.p = p;
@@ -5537,13 +5703,15 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn restore_cut_policy(&mut self) {
         if self.machine_st.cont_pts.is_empty() {
-            self.machine_st.run_cleaners_fn = |_| { false };
+            self.machine_st.run_cleaners_fn = |_| false;
         }
     }
 
     #[inline(always)]
     pub(crate) fn set_cut_point(&mut self, r: RegType) -> bool {
-        let cp = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
+        let cp = self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st[r]));
         self.machine_st.cut_body(cp);
 
         (self.machine_st.run_cleaners_fn)(self)
@@ -5551,7 +5719,9 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn set_cut_point_by_default(&mut self, r: RegType) {
-        let cp = self.machine_st.store(self.machine_st.deref(self.machine_st[r]));
+        let cp = self
+            .machine_st
+            .store(self.machine_st.deref(self.machine_st[r]));
         self.machine_st.cut_body(cp);
     }
 
@@ -5646,7 +5816,12 @@ impl Machine {
         let a2 = self.deref_register(2);
 
         let bp = cell_as_fixnum!(a2).get_num() as usize;
-        let prev_b = self.machine_st.stack.index_or_frame(self.machine_st.b).prelude.b;
+        let prev_b = self
+            .machine_st
+            .stack
+            .index_or_frame(self.machine_st.b)
+            .prelude
+            .b;
 
         if prev_b <= bp {
             self.machine_st.unify_atom(atom!("!"), a1)
@@ -5689,9 +5864,9 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn push_ball_stack(&mut self) {
         if self.machine_st.ball.stub.len() > 0 {
-            self.machine_st.ball_stack.push(
-                mem::replace(&mut self.machine_st.ball, Ball::new())
-            );
+            self.machine_st
+                .ball_stack
+                .push(mem::replace(&mut self.machine_st.ball, Ball::new()));
         } else {
             self.machine_st.fail = true;
         }
@@ -5728,13 +5903,15 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn get_b_value(&mut self) {
         let n = Fixnum::as_cutpoint(i64::try_from(self.machine_st.b).unwrap());
-        self.machine_st.unify_fixnum(n, self.machine_st.registers[1]);
+        self.machine_st
+            .unify_fixnum(n, self.machine_st.registers[1]);
     }
 
     #[inline(always)]
     pub(crate) fn get_cut_point(&mut self) {
         let n = Fixnum::as_cutpoint(i64::try_from(self.machine_st.b0).unwrap());
-        self.machine_st.unify_fixnum(n, self.machine_st.registers[1]);
+        self.machine_st
+            .unify_fixnum(n, self.machine_st.registers[1]);
     }
 
     #[inline(always)]
@@ -5758,7 +5935,9 @@ impl Machine {
 
             let p = str_loc_as_cell!(machine_st.heap.len());
 
-            machine_st.heap.extend(functor!(atom!("dir_entry"), [fixnum(cp)]));
+            machine_st
+                .heap
+                .extend(functor!(atom!("dir_entry"), [fixnum(cp)]));
             machine_st.unify_fixnum(e, machine_st.registers[2]);
 
             if !machine_st.fail {
@@ -5863,7 +6042,9 @@ impl Machine {
 
         set_prompt(true);
         // let result = self.machine_st.read_term(self.user_input, &mut self.indices);
-        let result = self.machine_st.read_term_from_user_input(self.user_input, &mut self.indices);
+        let result = self
+            .machine_st
+            .read_term_from_user_input(self.user_input, &mut self.indices);
         set_prompt(false);
 
         match result {
@@ -5887,9 +6068,17 @@ impl Machine {
         )?;
 
         if let Stream::Readline(..) = stream {
-            self.machine_st.read_term(stream, &mut self.indices, MachineState::read_term_from_user_input_eof_handler)
+            self.machine_st.read_term(
+                stream,
+                &mut self.indices,
+                MachineState::read_term_from_user_input_eof_handler,
+            )
         } else {
-            self.machine_st.read_term(stream, &mut self.indices, MachineState::read_term_eof_handler)
+            self.machine_st.read_term(
+                stream,
+                &mut self.indices,
+                MachineState::read_term_eof_handler,
+            )
         }
     }
 
@@ -5907,7 +6096,8 @@ impl Machine {
         let mut parser = Parser::new(chars, &mut self.machine_st);
         let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
 
-        let term_write_result = parser.read_term(&op_dir, Tokens::Default)
+        let term_write_result = parser
+            .read_term(&op_dir, Tokens::Default)
             .map_err(|err| error_after_read_term(err, 0, &parser))
             .and_then(|term| {
                 write_term_to_heap(
@@ -5936,7 +6126,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn read_from_chars(&mut self) -> CallResult {
-        if let Some(atom_or_string) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(atom_or_string) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             if let Some(term_write_result) = self.read_term_and_write_to_heap(atom_or_string)? {
                 let result = heap_loc_as_cell!(term_write_result.heap_loc);
                 let var = self.deref_register(2).as_var().unwrap();
@@ -5952,7 +6145,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn read_term_from_chars(&mut self) -> CallResult {
-        if let Some(atom_or_string) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(atom_or_string) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             if let Some(term_write_result) = self.read_term_and_write_to_heap(atom_or_string)? {
                 self.machine_st.read_term_body(term_write_result)
             } else {
@@ -6015,19 +6211,18 @@ impl Machine {
     pub(crate) fn set_seed(&mut self) {
         let seed = self.deref_register(1);
 
-
         match Number::try_from(seed) {
             Ok(Number::Fixnum(n)) => {
                 let _: StdRng = SeedableRng::seed_from_u64(Integer::from(n).to_u64().unwrap());
-            },
+            }
             Ok(Number::Integer(n)) => {
                 let _: StdRng = SeedableRng::seed_from_u64(n.to_u64().unwrap());
-            },
+            }
             Ok(Number::Rational(n)) => {
                 if n.denominator() == &UBig::from(1 as u32) {
                     let _: StdRng = SeedableRng::seed_from_u64(n.numerator().to_u64().unwrap());
                 }
-            },
+            }
             _ => {
                 self.machine_st.fail = true;
             }
@@ -6095,10 +6290,14 @@ impl Machine {
         let reposition = self.machine_st.registers[6];
         let stream_type = self.machine_st.registers[7];
 
-        let options = self.machine_st.to_stream_options(alias, eof_action, reposition, stream_type);
+        let options = self
+            .machine_st
+            .to_stream_options(alias, eof_action, reposition, stream_type);
 
         if options.reposition() {
-            return Err(self.machine_st.reposition_error(atom!("socket_client_open"), 3));
+            return Err(self
+                .machine_st
+                .reposition_error(atom!("socket_client_open"), 3));
         }
 
         if let Some(alias) = options.get_alias() {
@@ -6113,7 +6312,8 @@ impl Machine {
 
         let stream = match TcpStream::connect(socket_addr.as_str()).map_err(|e| e.kind()) {
             Ok(tcp_stream) => {
-                let mut stream = Stream::from_tcp_stream(socket_addr, tcp_stream, &mut self.machine_st.arena);
+                let mut stream =
+                    Stream::from_tcp_stream(socket_addr, tcp_stream, &mut self.machine_st.arena);
 
                 *stream.options_mut() = options;
 
@@ -6126,13 +6326,17 @@ impl Machine {
                 stream_as_cell!(stream)
             }
             Err(ErrorKind::PermissionDenied) => {
-                return Err(self.machine_st.open_permission_error(addr, atom!("socket_client_open"), 3));
+                return Err(self.machine_st.open_permission_error(
+                    addr,
+                    atom!("socket_client_open"),
+                    3,
+                ));
             }
             Err(ErrorKind::NotFound) => {
                 let stub = functor_stub(atom!("socket_client_open"), 3);
-                let err = self.machine_st.existence_error(
-                    ExistenceError::SourceSink(addr),
-                );
+                let err = self
+                    .machine_st
+                    .existence_error(ExistenceError::SourceSink(addr));
 
                 return Err(self.machine_st.error_form(err, stub));
             }
@@ -6182,32 +6386,44 @@ impl Machine {
             format!("{}:{}", socket_atom.as_str(), port)
         };
 
-        let (tcp_listener, port) =
-            match TcpListener::bind(server_addr).map_err(|e| e.kind()) {
-                Ok(tcp_listener) => {
-                    let port = tcp_listener.local_addr().map(|addr| addr.port()).ok();
+        let (tcp_listener, port) = match TcpListener::bind(server_addr).map_err(|e| e.kind()) {
+            Ok(tcp_listener) => {
+                let port = tcp_listener.local_addr().map(|addr| addr.port()).ok();
 
-                    if let Some(port) = port {
-                        (arena_alloc!(tcp_listener, &mut self.machine_st.arena), port as usize)
-                    } else {
-                        self.machine_st.fail = true;
-                        return Ok(());
-                    }
-                }
-                Err(ErrorKind::PermissionDenied) => {
-                    return Err(self.machine_st.open_permission_error(addr, atom!("socket_server_open"), 2));
-                }
-                _ => {
+                if let Some(port) = port {
+                    (
+                        arena_alloc!(tcp_listener, &mut self.machine_st.arena),
+                        port as usize,
+                    )
+                } else {
                     self.machine_st.fail = true;
                     return Ok(());
                 }
-            };
+            }
+            Err(ErrorKind::PermissionDenied) => {
+                return Err(self.machine_st.open_permission_error(
+                    addr,
+                    atom!("socket_server_open"),
+                    2,
+                ));
+            }
+            _ => {
+                self.machine_st.fail = true;
+                return Ok(());
+            }
+        };
 
         let addr = self.deref_register(3);
-        self.machine_st.bind(addr.as_var().unwrap(), typed_arena_ptr_as_cell!(tcp_listener));
+        self.machine_st.bind(
+            addr.as_var().unwrap(),
+            typed_arena_ptr_as_cell!(tcp_listener),
+        );
 
         if had_zero_port {
-            self.machine_st.unify_fixnum(Fixnum::build_with(port as i64), self.machine_st.registers[2]);
+            self.machine_st.unify_fixnum(
+                Fixnum::build_with(port as i64),
+                self.machine_st.registers[2],
+            );
         }
 
         Ok(())
@@ -6220,10 +6436,14 @@ impl Machine {
         let reposition = self.machine_st.registers[6];
         let stream_type = self.machine_st.registers[7];
 
-        let options = self.machine_st.to_stream_options(alias, eof_action, reposition, stream_type);
+        let options = self
+            .machine_st
+            .to_stream_options(alias, eof_action, reposition, stream_type);
 
         if options.reposition() {
-            return Err(self.machine_st.reposition_error(atom!("socket_server_accept"), 4));
+            return Err(self
+                .machine_st
+                .reposition_error(atom!("socket_server_accept"), 4));
         }
 
         if let Some(alias) = options.get_alias() {
@@ -6288,7 +6508,10 @@ impl Machine {
     #[cfg(feature = "tls")]
     #[inline(always)]
     pub(crate) fn tls_client_connect(&mut self) -> CallResult {
-        if let Some(hostname) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(hostname) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             let stream0 = self.machine_st.get_stream_or_alias(
                 self.machine_st.registers[2],
                 &self.indices.stream_aliases,
@@ -6297,17 +6520,16 @@ impl Machine {
             )?;
 
             let connector = TlsConnector::new().unwrap();
-            let stream =
-                match connector.connect(hostname.as_str(), stream0) {
-                    Ok(tls_stream) => tls_stream,
-                    Err(_) => {
-                        return Err(self.machine_st.open_permission_error(
-                            self.machine_st.registers[1],
-                            atom!("tls_client_negotiate"),
-                            3,
-                        ));
-                    }
-                };
+            let stream = match connector.connect(hostname.as_str(), stream0) {
+                Ok(tls_stream) => tls_stream,
+                Err(_) => {
+                    return Err(self.machine_st.open_permission_error(
+                        self.machine_st.registers[1],
+                        atom!("tls_client_negotiate"),
+                        3,
+                    ));
+                }
+            };
 
             let addr = atom!("TLS");
             let stream = Stream::from_tls_stream(addr, stream, &mut self.machine_st.arena);
@@ -6315,7 +6537,8 @@ impl Machine {
 
             self.machine_st.heap.push(stream_as_cell!(stream));
             let stream_addr = self.deref_register(3);
-            self.machine_st.bind(stream_addr.as_var().unwrap(), stream_as_cell!(stream));
+            self.machine_st
+                .bind(stream_addr.as_var().unwrap(), stream_as_cell!(stream));
 
             Ok(())
         } else {
@@ -6328,18 +6551,20 @@ impl Machine {
     pub(crate) fn tls_accept_client(&mut self) -> CallResult {
         let pkcs12 = self.string_encoding_bytes(self.machine_st.registers[1], atom!("octet"));
 
-        if let Some(password) = self.machine_st.value_to_str_like(self.machine_st.registers[2]) {
-            let identity =
-                match Identity::from_pkcs12(&pkcs12, password.as_str()) {
-                    Ok(identity) => identity,
-                    Err(_) => {
-                        return Err(self.machine_st.open_permission_error(
-                            self.machine_st.registers[1],
-                            atom!("tls_server_negotiate"),
-                            3,
-                        ));
-                    }
-                };
+        if let Some(password) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[2])
+        {
+            let identity = match Identity::from_pkcs12(&pkcs12, password.as_str()) {
+                Ok(identity) => identity,
+                Err(_) => {
+                    return Err(self.machine_st.open_permission_error(
+                        self.machine_st.registers[1],
+                        atom!("tls_server_negotiate"),
+                        3,
+                    ));
+                }
+            };
 
             let stream0 = self.machine_st.get_stream_or_alias(
                 self.machine_st.registers[3],
@@ -6350,23 +6575,23 @@ impl Machine {
 
             let acceptor = TlsAcceptor::new(identity).unwrap();
 
-            let stream =
-                match acceptor.accept(stream0) {
-                    Ok(tls_stream) => tls_stream,
-                    Err(_) => {
-                        return Err(self.machine_st.open_permission_error(
-                            self.machine_st.registers[3],
-                            atom!("tls_server_negotiate"),
-                            3,
-                        ));
-                    }
-                };
+            let stream = match acceptor.accept(stream0) {
+                Ok(tls_stream) => tls_stream,
+                Err(_) => {
+                    return Err(self.machine_st.open_permission_error(
+                        self.machine_st.registers[3],
+                        atom!("tls_server_negotiate"),
+                        3,
+                    ));
+                }
+            };
 
             let stream = Stream::from_tls_stream(atom!("TLS"), stream, &mut self.machine_st.arena);
             self.indices.streams.insert(stream);
 
             let stream_addr = self.deref_register(4);
-            self.machine_st.bind(stream_addr.as_var().unwrap(), stream_as_cell!(stream));
+            self.machine_st
+                .bind(stream_addr.as_var().unwrap(), stream_as_cell!(stream));
         } else {
             unreachable!();
         }
@@ -6467,14 +6692,15 @@ impl Machine {
                 })
             }
             atom!("mode") => atom_as_cell!(stream.mode()),
-            atom!("direction") =>
+            atom!("direction") => {
                 atom_as_cell!(if stream.is_input_stream() && stream.is_output_stream() {
                     atom!("input_output")
                 } else if stream.is_input_stream() {
                     atom!("input")
                 } else {
                     atom!("output")
-                }),
+                })
+            }
             atom!("alias") => {
                 atom_as_cell!(if let Some(alias) = stream.options().get_alias() {
                     alias
@@ -6489,8 +6715,10 @@ impl Machine {
 
                     let position_term = functor!(
                         atom!("position_and_lines_read"),
-                        [integer(position, &mut self.machine_st.arena),
-                         integer(lines_read, &mut self.machine_st.arena)]
+                        [
+                            integer(position, &mut self.machine_st.arena),
+                            integer(lines_read, &mut self.machine_st.arena)
+                        ]
                     );
 
                     self.machine_st.heap.extend(position_term.into_iter());
@@ -6507,12 +6735,11 @@ impl Machine {
             atom!("eof_action") => {
                 atom_as_cell!(stream.options().eof_action().as_atom())
             }
-            atom!("reposition") =>
-                atom_as_cell!(if stream.options().reposition() {
-                    atom!("true")
-                } else {
-                    atom!("false")
-                }),
+            atom!("reposition") => atom_as_cell!(if stream.options().reposition() {
+                atom!("true")
+            } else {
+                atom!("false")
+            }),
             atom!("type") => {
                 atom_as_cell!(stream.options().stream_type().as_property_atom())
             }
@@ -6535,7 +6762,11 @@ impl Machine {
         ball.boundary = self.machine_st.heap.len();
 
         copy_term(
-            CopyBallTerm::new(&mut self.machine_st.stack, &mut self.machine_st.heap, &mut ball.stub),
+            CopyBallTerm::new(
+                &mut self.machine_st.stack,
+                &mut self.machine_st.heap,
+                &mut ball.stub,
+            ),
             value,
             AttrVarPolicy::DeepCopy,
         );
@@ -6551,7 +6782,8 @@ impl Machine {
         match self.indices.global_variables.get_mut(&key) {
             Some((_, ref mut loc)) => match loc {
                 Some(ref mut value) => {
-                    self.machine_st.trail(TrailRef::BlackboardOffset(key, *value));
+                    self.machine_st
+                        .trail(TrailRef::BlackboardOffset(key, *value));
                     *value = new_value;
                 }
                 loc @ None => {
@@ -6572,18 +6804,18 @@ impl Machine {
     pub(crate) fn term_attributed_variables(&mut self) {
         if self.machine_st.registers[1].is_constant() {
             let a2 = self.deref_register(2);
-            self.machine_st.unify_atom(
-                atom!("[]"),
-                a2,
-            );
+            self.machine_st.unify_atom(atom!("[]"), a2);
 
             return;
         }
 
-        let seen_vars = self.machine_st.attr_vars_of_term(self.machine_st.registers[1]);
-        let outcome = heap_loc_as_cell!(
-            iter_to_heap_list(&mut self.machine_st.heap, seen_vars.into_iter())
-        );
+        let seen_vars = self
+            .machine_st
+            .attr_vars_of_term(self.machine_st.registers[1]);
+        let outcome = heap_loc_as_cell!(iter_to_heap_list(
+            &mut self.machine_st.heap,
+            seen_vars.into_iter()
+        ));
 
         unify_fn!(self.machine_st, self.machine_st.registers[2], outcome);
     }
@@ -6602,9 +6834,10 @@ impl Machine {
 
         self.machine_st.variable_set(&mut seen_set, stored_v);
 
-        let outcome = heap_loc_as_cell!(
-            iter_to_heap_list(&mut self.machine_st.heap, seen_set.into_iter())
-        );
+        let outcome = heap_loc_as_cell!(iter_to_heap_list(
+            &mut self.machine_st.heap,
+            seen_set.into_iter()
+        ));
 
         unify_fn!(self.machine_st, a2, outcome);
     }
@@ -6612,9 +6845,7 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn term_variables_under_max_depth(&mut self) {
         // Term, MaxDepth, VarList
-        let max_depth = cell_as_fixnum!(
-            self.deref_register(2)
-        ).get_num() as usize;
+        let max_depth = cell_as_fixnum!(self.deref_register(2)).get_num() as usize;
 
         self.machine_st.term_variables_under_max_depth(
             self.machine_st.registers[1],
@@ -6693,9 +6924,10 @@ impl Machine {
             self.machine_st.heap.extend(functor.into_iter());
         }
 
-        heap_loc_as_cell!(
-            iter_to_heap_list(&mut self.machine_st.heap, functor_list.into_iter())
-        )
+        heap_loc_as_cell!(iter_to_heap_list(
+            &mut self.machine_st.heap,
+            functor_list.into_iter()
+        ))
     }
 
     #[inline(always)]
@@ -6720,11 +6952,9 @@ impl Machine {
                 Some(module) => module.code_dir.get(&key),
                 None => {
                     let stub = functor_stub(key.0, key.1);
-                    let err = self.machine_st.session_error(
-                        SessionError::from(CompilationError::InvalidModuleResolution(
-                            module_name,
-                        )),
-                    );
+                    let err = self.machine_st.session_error(SessionError::from(
+                        CompilationError::InvalidModuleResolution(module_name),
+                    ));
 
                     return Err(self.machine_st.error_form(err, stub));
                 }
@@ -6741,9 +6971,9 @@ impl Machine {
             }
             _ => {
                 let stub = functor_stub(name, arity);
-                let err = self.machine_st.existence_error(
-                    ExistenceError::Procedure(name, arity),
-                );
+                let err = self
+                    .machine_st
+                    .existence_error(ExistenceError::Procedure(name, arity));
 
                 return Err(self.machine_st.error_form(err, stub));
             }
@@ -6827,9 +7057,9 @@ impl Machine {
             Ok(_) => {}
             Err(_) => {
                 let stub = functor_stub(atom!("open"), 4);
-                let err = self.machine_st.existence_error(
-                    ExistenceError::Stream(self.machine_st.registers[1]),
-                );
+                let err = self
+                    .machine_st
+                    .existence_error(ExistenceError::Stream(self.machine_st.registers[1]));
 
                 return Err(self.machine_st.error_form(err, stub));
             }
@@ -6880,10 +7110,7 @@ impl Machine {
         let buffer_atom = self.machine_st.atom_tbl.build_with(buffer);
 
         let a1 = self.deref_register(1);
-        self.machine_st.unify_complete_string(
-            buffer_atom,
-            a1,
-        );
+        self.machine_st.unify_complete_string(buffer_atom, a1);
     }
 
     #[inline(always)]
@@ -6918,105 +7145,91 @@ impl Machine {
                 let mut context = Sha3_224::new();
                 context.input(&bytes);
 
-                heap_loc_as_cell!(
-                    iter_to_heap_list(
-                        &mut self.machine_st.heap,
-                        context
-                            .result()
-                            .as_ref()
-                            .iter()
-                            .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                    )
-                )
+                heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    context
+                        .result()
+                        .as_ref()
+                        .iter()
+                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+                ))
             }
             atom!("sha3_256") => {
                 let mut context = Sha3_256::new();
                 context.input(&bytes);
-                heap_loc_as_cell!(
-                    iter_to_heap_list(
-                        &mut self.machine_st.heap,
-                        context
-                            .result()
-                            .as_ref()
-                            .iter()
-                            .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                    )
-                )
+                heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    context
+                        .result()
+                        .as_ref()
+                        .iter()
+                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+                ))
             }
             atom!("sha3_384") => {
                 let mut context = Sha3_384::new();
                 context.input(&bytes);
 
-                heap_loc_as_cell!(
-                    iter_to_heap_list(
-                        &mut self.machine_st.heap,
-                        context
-                            .result()
-                            .as_ref()
-                            .iter()
-                            .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                    )
-                )
+                heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    context
+                        .result()
+                        .as_ref()
+                        .iter()
+                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+                ))
             }
             atom!("sha3_512") => {
                 let mut context = Sha3_512::new();
                 context.input(&bytes);
 
-                heap_loc_as_cell!(
-                    iter_to_heap_list(
-                        &mut self.machine_st.heap,
-                        context
-                            .result()
-                            .as_ref()
-                            .iter()
-                            .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                    )
-                )
+                heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    context
+                        .result()
+                        .as_ref()
+                        .iter()
+                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+                ))
             }
             atom!("blake2s256") => {
                 let mut context = Blake2s::new();
                 context.input(&bytes);
 
-                heap_loc_as_cell!(
-                    iter_to_heap_list(
-                        &mut self.machine_st.heap,
-                        context
-                            .result()
-                            .as_ref()
-                            .iter()
-                            .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                    )
-                )
+                heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    context
+                        .result()
+                        .as_ref()
+                        .iter()
+                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+                ))
             }
             atom!("blake2b512") => {
                 let mut context = Blake2b::new();
                 context.input(&bytes);
 
-                heap_loc_as_cell!(
-                    iter_to_heap_list(
-                        &mut self.machine_st.heap,
-                        context
-                            .result()
-                            .as_ref()
-                            .iter()
-                            .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                    )
-                )
+                heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    context
+                        .result()
+                        .as_ref()
+                        .iter()
+                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+                ))
             }
             atom!("ripemd160") => {
                 let mut context = Ripemd160::new();
                 context.input(&bytes);
 
-                heap_loc_as_cell!(
-                    iter_to_heap_list(
-                        &mut self.machine_st.heap,
-                        context
-                            .result()
-                            .as_ref()
-                            .iter()
-                            .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                    )
-                )
+                heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    context
+                        .result()
+                        .as_ref()
+                        .iter()
+                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+                ))
             }
             _ => {
                 let ints = digest::digest(
@@ -7032,14 +7245,12 @@ impl Machine {
                     &bytes,
                 );
 
-                heap_loc_as_cell!(
-                    iter_to_heap_list(
-                        &mut self.machine_st.heap,
-                        ints.as_ref()
-                            .iter()
-                            .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                    )
-                )
+                heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    ints.as_ref()
+                        .iter()
+                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+                ))
             }
         };
 
@@ -7052,10 +7263,14 @@ impl Machine {
         let data = self.string_encoding_bytes(self.machine_st.registers[1], encoding);
 
         let stub1_gen = || functor_stub(atom!("crypto_data_hkdf"), 4);
-        let salt = self.machine_st.integers_to_bytevec(self.machine_st.registers[3], stub1_gen);
+        let salt = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[3], stub1_gen);
 
         let stub2_gen = || functor_stub(atom!("crypto_data_hkdf"), 4);
-        let info = self.machine_st.integers_to_bytevec(self.machine_st.registers[4], stub2_gen);
+        let info = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[4], stub2_gen);
 
         let algorithm = cell_as_atom!(self.deref_register(5));
 
@@ -7101,14 +7316,12 @@ impl Machine {
                 }
             }
 
-            heap_loc_as_cell!(
-                iter_to_heap_list(
-                    &mut self.machine_st.heap,
-                    bytes
-                        .iter()
-                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                )
-            )
+            heap_loc_as_cell!(iter_to_heap_list(
+                &mut self.machine_st.heap,
+                bytes
+                    .iter()
+                    .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+            ))
         };
 
         unify!(self.machine_st, self.machine_st.registers[7], ints_list);
@@ -7117,9 +7330,13 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn crypto_password_hash(&mut self) {
         let stub1_gen = || functor_stub(atom!("crypto_password_hash"), 3);
-        let data = self.machine_st.integers_to_bytevec(self.machine_st.registers[1], stub1_gen);
+        let data = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[1], stub1_gen);
         let stub2_gen = || functor_stub(atom!("crypto_password_hash"), 3);
-        let salt = self.machine_st.integers_to_bytevec(self.machine_st.registers[2], stub2_gen);
+        let salt = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[2], stub2_gen);
 
         let iterations = self.deref_register(3);
 
@@ -7148,14 +7365,12 @@ impl Machine {
                 &mut bytes,
             );
 
-            heap_loc_as_cell!(
-                iter_to_heap_list(
-                    &mut self.machine_st.heap,
-                    bytes
-                        .iter()
-                        .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-                )
-            )
+            heap_loc_as_cell!(iter_to_heap_list(
+                &mut self.machine_st.heap,
+                bytes
+                    .iter()
+                    .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+            ))
         };
 
         unify!(self.machine_st, self.machine_st.registers[4], ints_list);
@@ -7169,10 +7384,14 @@ impl Machine {
         let aad = self.string_encoding_bytes(self.machine_st.registers[2], encoding);
 
         let stub2_gen = || functor_stub(atom!("crypto_data_encrypt"), 7);
-        let key = self.machine_st.integers_to_bytevec(self.machine_st.registers[4], stub2_gen);
+        let key = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[4], stub2_gen);
 
         let stub3_gen = || functor_stub(atom!("crypto_data_encrypt"), 7);
-        let iv = self.machine_st.integers_to_bytevec(self.machine_st.registers[5], stub3_gen);
+        let iv = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[5], stub3_gen);
 
         let unbound_key = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &key).unwrap();
         let nonce = aead::Nonce::try_assume_unique_for_key(&iv).unwrap();
@@ -7180,11 +7399,7 @@ impl Machine {
 
         let mut in_out = data;
 
-        let tag = match key.seal_in_place_separate_tag(
-            nonce,
-            aead::Aad::from(aad),
-            &mut in_out,
-        ) {
+        let tag = match key.seal_in_place_separate_tag(nonce, aead::Aad::from(aad), &mut in_out) {
             Ok(d) => d,
             _ => {
                 self.machine_st.fail = true;
@@ -7192,19 +7407,21 @@ impl Machine {
             }
         };
 
-        let tag_list = heap_loc_as_cell!(
-            iter_to_heap_list(
-                &mut self.machine_st.heap,
-                tag.as_ref()
-                    .iter()
-                    .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-            )
-        );
+        let tag_list = heap_loc_as_cell!(iter_to_heap_list(
+            &mut self.machine_st.heap,
+            tag.as_ref()
+                .iter()
+                .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+        ));
 
         let complete_string = self.u8s_to_string(&in_out);
 
         unify!(self.machine_st, self.machine_st.registers[6], tag_list);
-        unify!(self.machine_st, self.machine_st.registers[7], complete_string);
+        unify!(
+            self.machine_st,
+            self.machine_st.registers[7],
+            complete_string
+        );
     }
 
     #[inline(always)]
@@ -7215,9 +7432,13 @@ impl Machine {
         let aad = self.string_encoding_bytes(self.machine_st.registers[2], encoding);
         let stub1_gen = || functor_stub(atom!("crypto_data_decrypt"), 7);
 
-        let key = self.machine_st.integers_to_bytevec(self.machine_st.registers[3], stub1_gen);
+        let key = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[3], stub1_gen);
         let stub2_gen = || functor_stub(atom!("crypto_data_decrypt"), 7);
-        let iv = self.machine_st.integers_to_bytevec(self.machine_st.registers[4], stub2_gen);
+        let iv = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[4], stub2_gen);
 
         let unbound_key = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &key).unwrap();
         let nonce = aead::Nonce::try_assume_unique_for_key(&iv).unwrap();
@@ -7226,14 +7447,13 @@ impl Machine {
         let mut in_out = data;
 
         let complete_string = {
-            let decrypted_data =
-                match key.open_in_place(nonce, aead::Aad::from(aad), &mut in_out) {
-                    Ok(d) => d,
-                    _ => {
-                        self.machine_st.fail = true;
-                        return;
-                    }
-                };
+            let decrypted_data = match key.open_in_place(nonce, aead::Aad::from(aad), &mut in_out) {
+                Ok(d) => d,
+                _ => {
+                    self.machine_st.fail = true;
+                    return;
+                }
+            };
 
             let buffer = match encoding {
                 atom!("octet") => String::from_iter(decrypted_data.iter().map(|b| *b as char)),
@@ -7256,15 +7476,22 @@ impl Machine {
             }
         };
 
-        unify!(self.machine_st, self.machine_st.registers[6], complete_string);
+        unify!(
+            self.machine_st,
+            self.machine_st.registers[6],
+            complete_string
+        );
     }
 
     #[inline(always)]
     pub(crate) fn crypto_curve_scalar_mult(&mut self) {
-
         let stub_gen = || functor_stub(atom!("crypto_curve_scalar_mult"), 4);
-        let scalar_bytes = self.machine_st.integers_to_bytevec(self.machine_st.registers[2], stub_gen);
-        let point_bytes = self.machine_st.integers_to_bytevec(self.machine_st.registers[3], stub_gen);
+        let scalar_bytes = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[2], stub_gen);
+        let point_bytes = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[3], stub_gen);
 
         let mut point = secp256k1::Point::decode(&point_bytes).unwrap();
         let scalar = secp256k1::Scalar::decode_reduce(&scalar_bytes);
@@ -7280,7 +7507,11 @@ impl Machine {
         let pkcs8_bytes = signature::Ed25519KeyPair::generate_pkcs8(rng()).unwrap();
         let complete_string = self.u8s_to_string(pkcs8_bytes.as_ref());
 
-        unify!(self.machine_st, self.machine_st.registers[1], complete_string)
+        unify!(
+            self.machine_st,
+            self.machine_st.registers[1],
+            complete_string
+        )
     }
 
     #[inline(always)]
@@ -7297,7 +7528,11 @@ impl Machine {
 
         let complete_string = self.u8s_to_string(key_pair.public_key().as_ref());
 
-        unify!(self.machine_st, self.machine_st.registers[2], complete_string);
+        unify!(
+            self.machine_st,
+            self.machine_st.registers[2],
+            complete_string
+        );
     }
 
     #[inline(always)]
@@ -7316,14 +7551,12 @@ impl Machine {
 
         let sig = key_pair.sign(&data);
 
-        let sig_list = heap_loc_as_cell!(
-            iter_to_heap_list(
-                &mut self.machine_st.heap,
-                sig.as_ref()
-                    .iter()
-                    .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
-            )
-        );
+        let sig_list = heap_loc_as_cell!(iter_to_heap_list(
+            &mut self.machine_st.heap,
+            sig.as_ref()
+                .iter()
+                .map(|b| fixnum_as_cell!(Fixnum::build_with(*b as i64))),
+        ));
 
         unify!(self.machine_st, self.machine_st.registers[4], sig_list);
     }
@@ -7334,7 +7567,9 @@ impl Machine {
         let encoding = cell_as_atom!(self.deref_register(3));
         let data = self.string_encoding_bytes(self.machine_st.registers[2], encoding);
         let stub_gen = || functor_stub(atom!("ed25519_verify"), 5);
-        let signature = self.machine_st.integers_to_bytevec(self.machine_st.registers[4], stub_gen);
+        let signature = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[4], stub_gen);
 
         let peer_public_key = signature::UnparsedPublicKey::new(&signature::ED25519, &key);
 
@@ -7349,12 +7584,18 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn curve25519_scalar_mult(&mut self) {
         let stub1_gen = || functor_stub(atom!("curve25519_scalar_mult"), 3);
-        let scalar_bytes = self.machine_st.integers_to_bytevec(self.machine_st.registers[1], stub1_gen);
+        let scalar_bytes = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[1], stub1_gen);
         let stub2_gen = || functor_stub(atom!("curve25519_scalar_mult"), 3);
-        let point_bytes = self.machine_st.integers_to_bytevec(self.machine_st.registers[2], stub2_gen);
+        let point_bytes = self
+            .machine_st
+            .integers_to_bytevec(self.machine_st.registers[2], stub2_gen);
 
-        let result = x25519::x25519(&<[u8; 32]>::try_from(&point_bytes[..]).unwrap(),
-                                    &<[u8; 32]>::try_from(&scalar_bytes[..]).unwrap());
+        let result = x25519::x25519(
+            &<[u8; 32]>::try_from(&point_bytes[..]).unwrap(),
+            &<[u8; 32]>::try_from(&scalar_bytes[..]).unwrap(),
+        );
 
         let string = self.u8s_to_string(&result[..]);
 
@@ -7369,7 +7610,8 @@ impl Machine {
             for c in string.as_str().chars() {
                 if c as u32 > 255 {
                     let non_octet = self.machine_st.atom_tbl.build_with(&c.to_string());
-                    self.machine_st.unify_atom(non_octet, self.machine_st.registers[2]);
+                    self.machine_st
+                        .unify_atom(non_octet, self.machine_st.registers[2]);
                     return;
                 }
             }
@@ -7380,7 +7622,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn load_html(&mut self) {
-        if let Some(string) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(string) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             let doc = select::document::Document::from_read(string.as_str().as_bytes()).unwrap();
             let result = self.html_node_to_term(doc.nth(0).unwrap());
 
@@ -7392,7 +7637,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn load_xml(&mut self) {
-        if let Some(string) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(string) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             match roxmltree::Document::parse(string.as_str()) {
                 Ok(doc) => {
                     let result = self.xml_node_to_term(doc.root_element());
@@ -7409,7 +7657,10 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn get_env(&mut self) {
-        if let Some(key) = self.machine_st.value_to_str_like(self.machine_st.registers[1]) {
+        if let Some(key) = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+        {
             match env::var(key.as_str()) {
                 Ok(value) => {
                     let cstr = put_complete_string(
@@ -7431,15 +7682,24 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn set_env(&mut self) {
-        let key = self.machine_st.value_to_str_like(self.machine_st.registers[1]).unwrap();
-        let value = self.machine_st.value_to_str_like(self.machine_st.registers[2]).unwrap();
+        let key = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+            .unwrap();
+        let value = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[2])
+            .unwrap();
 
         env::set_var(key.as_str(), value.as_str());
     }
 
     #[inline(always)]
     pub(crate) fn unset_env(&mut self) {
-        let key = self.machine_st.value_to_str_like(self.machine_st.registers[1]).unwrap();
+        let key = self
+            .machine_st
+            .value_to_str_like(self.machine_st.registers[1])
+            .unwrap();
         env::remove_var(key.as_str());
     }
 
@@ -7449,10 +7709,12 @@ impl Machine {
 
         match fixnum!(Number, pid as i64, &mut self.machine_st.arena) {
             Number::Fixnum(pid) => {
-                self.machine_st.unify_fixnum(pid, self.machine_st.registers[1]);
+                self.machine_st
+                    .unify_fixnum(pid, self.machine_st.registers[1]);
             }
             Number::Integer(pid) => {
-                self.machine_st.unify_big_int(pid, self.machine_st.registers[1]);
+                self.machine_st
+                    .unify_big_int(pid, self.machine_st.registers[1]);
             }
             _ => {
                 unreachable!();
@@ -7467,19 +7729,20 @@ impl Machine {
         // if not found, the code looks for COMSPEC env var to do it in a DOS-style
         // the output is printed directly to stdout
         // the output status code is returned after finishing
-        fn command_result(machine: &mut MachineState, command: std::io::Result<process::ExitStatus>) {
+        fn command_result(
+            machine: &mut MachineState,
+            command: std::io::Result<process::ExitStatus>,
+        ) {
             match command {
-                Ok(status) => {
-                    match status.code() {
-                        Some(code) => {
-                            let code = integer_as_cell!(Number::arena_from(code, &mut machine.arena));
-                            unify!(machine, code, machine.registers[2]);
-                        }
-                        _ => {
-                            machine.fail = true;
-                        }
+                Ok(status) => match status.code() {
+                    Some(code) => {
+                        let code = integer_as_cell!(Number::arena_from(code, &mut machine.arena));
+                        unify!(machine, code, machine.registers[2]);
                     }
-                }
+                    _ => {
+                        machine.fail = true;
+                    }
+                },
                 _ => {
                     machine.fail = true;
                 }
@@ -7487,9 +7750,7 @@ impl Machine {
         }
 
         let a1 = self.deref_register(1);
-        let command = self.machine_st.value_to_str_like(
-            a1
-        ).unwrap();
+        let command = self.machine_st.value_to_str_like(a1).unwrap();
 
         match env::var("SHELL") {
             Ok(value) => {
@@ -7499,20 +7760,18 @@ impl Machine {
                     .status();
                 command_result(&mut self.machine_st, command);
             }
-            _ => {
-                match env::var("COMSPEC") {
-                    Ok(value) => {
-                        let command = process::Command::new(&value)
-                            .arg("/C")
-                            .arg(command.as_str())
-                            .status();
-                        command_result(&mut self.machine_st, command);
-                    }
-                    _ => {
-                        self.machine_st.fail = true;
-                    }
+            _ => match env::var("COMSPEC") {
+                Ok(value) => {
+                    let command = process::Command::new(&value)
+                        .arg("/C")
+                        .arg(command.as_str())
+                        .status();
+                    command_result(&mut self.machine_st, command);
                 }
-            }
+                _ => {
+                    self.machine_st.fail = true;
+                }
+            },
         };
     }
 
@@ -7536,7 +7795,10 @@ impl Machine {
         };
 
         if self.deref_register(1).is_var() {
-            let b64 = self.machine_st.value_to_str_like(self.machine_st.registers[2]).unwrap();
+            let b64 = self
+                .machine_st
+                .value_to_str_like(self.machine_st.registers[2])
+                .unwrap();
             let bytes = base64::decode_config(b64.as_str(), config);
 
             match bytes {
@@ -7552,7 +7814,13 @@ impl Machine {
             }
         } else {
             let mut bytes = vec![];
-            for c in self.machine_st.value_to_str_like(self.machine_st.registers[1]).unwrap().as_str().chars() {
+            for c in self
+                .machine_st
+                .value_to_str_like(self.machine_st.registers[1])
+                .unwrap()
+                .as_str()
+                .chars()
+            {
                 bytes.push(c as u8);
             }
 
@@ -7574,7 +7842,11 @@ impl Machine {
         match LIBRARIES.borrow().get(library_name.as_str()) {
             Some(library) => {
                 let lib_stream = Stream::from_static_string(library, &mut self.machine_st.arena);
-                unify!(self.machine_st, stream_as_cell!(lib_stream), self.machine_st.registers[2]);
+                unify!(
+                    self.machine_st,
+                    stream_as_cell!(lib_stream),
+                    self.machine_st.registers[2]
+                );
 
                 let mut path_buf = machine::current_dir();
 
@@ -7584,13 +7856,16 @@ impl Machine {
                 let library_path_str = path_buf.to_str().unwrap();
                 let library_path = self.machine_st.atom_tbl.build_with(library_path_str);
 
-                self.machine_st.unify_atom(library_path, self.machine_st.registers[3]);
+                self.machine_st
+                    .unify_atom(library_path, self.machine_st.registers[3]);
             }
             None => {
                 let stub = functor_stub(atom!("load"), 1);
-                let err = self.machine_st.existence_error(
-                    ExistenceError::ModuleSource(ModuleSource::Library(library_name))
-                );
+                let err = self
+                    .machine_st
+                    .existence_error(ExistenceError::ModuleSource(ModuleSource::Library(
+                        library_name,
+                    )));
 
                 return Err(self.machine_st.error_form(err, stub));
             }
@@ -7611,7 +7886,8 @@ impl Machine {
         let mut parser = Parser::new(stream, &mut self.machine_st);
 
         match devour_whitespace(&mut parser) {
-            Ok(false) => { // not at EOF.
+            Ok(false) => {
+                // not at EOF.
                 stream.add_lines_read(parser.lines_read());
             }
             Ok(true) => {
@@ -7632,13 +7908,16 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn is_sto_enabled(&mut self) {
         if self.machine_st.unify_fn as usize == MachineState::unify_with_occurs_check as usize {
-            self.machine_st.unify_atom(atom!("true"), self.machine_st.registers[1]);
+            self.machine_st
+                .unify_atom(atom!("true"), self.machine_st.registers[1]);
         } else if self.machine_st.unify_fn as usize
             == MachineState::unify_with_occurs_check_with_error as usize
         {
-            self.machine_st.unify_atom(atom!("error"), self.machine_st.registers[1]);
+            self.machine_st
+                .unify_atom(atom!("error"), self.machine_st.registers[1]);
         } else {
-            self.machine_st.unify_atom(atom!("false"), self.machine_st.registers[1]);
+            self.machine_st
+                .unify_atom(atom!("false"), self.machine_st.registers[1]);
         }
     }
 
@@ -7686,8 +7965,7 @@ impl Machine {
         self.machine_st.fail = true;
     }
 
-    pub(crate) fn debug_hook(&mut self) {
-    }
+    pub(crate) fn debug_hook(&mut self) {}
 
     #[inline(always)]
     pub(crate) fn pop_count(&mut self) {
@@ -7726,7 +8004,11 @@ impl Machine {
         self.machine_st.atom_tbl.build_with(&s)
     }
 
-    pub(super) fn string_encoding_bytes(&mut self, data_arg: HeapCellValue, encoding: Atom) -> Vec<u8> {
+    pub(super) fn string_encoding_bytes(
+        &mut self,
+        data_arg: HeapCellValue,
+        encoding: Atom,
+    ) -> Vec<u8> {
         let data = self.machine_st.value_to_str_like(data_arg).unwrap();
 
         match encoding {
@@ -7763,9 +8045,10 @@ impl Machine {
                 self.machine_st.heap.push(value);
             }
 
-            let attrs = heap_loc_as_cell!(
-                iter_to_heap_list(&mut self.machine_st.heap, avec.into_iter())
-            );
+            let attrs = heap_loc_as_cell!(iter_to_heap_list(
+                &mut self.machine_st.heap,
+                avec.into_iter()
+            ));
 
             let mut cvec = Vec::new();
 
@@ -7773,15 +8056,18 @@ impl Machine {
                 cvec.push(self.xml_node_to_term(child));
             }
 
-            let children = heap_loc_as_cell!(
-                iter_to_heap_list(&mut self.machine_st.heap, cvec.into_iter())
-            );
+            let children = heap_loc_as_cell!(iter_to_heap_list(
+                &mut self.machine_st.heap,
+                cvec.into_iter()
+            ));
 
             let tag = self.machine_st.atom_tbl.build_with(node.tag_name().name());
 
             let result = str_loc_as_cell!(self.machine_st.heap.len());
 
-            self.machine_st.heap.push(atom_as_cell!(atom!("element"), 3));
+            self.machine_st
+                .heap
+                .push(atom_as_cell!(atom!("element"), 3));
             self.machine_st.heap.push(atom_as_cell!(tag));
             self.machine_st.heap.push(attrs);
             self.machine_st.heap.push(children);
@@ -7792,13 +8078,11 @@ impl Machine {
 
     pub(super) fn html_node_to_term(&mut self, node: select::node::Node) -> HeapCellValue {
         match node.name() {
-            None => {
-                put_complete_string(
-                    &mut self.machine_st.heap,
-                    &node.text(),
-                    &mut self.machine_st.atom_tbl,
-                )
-            }
+            None => put_complete_string(
+                &mut self.machine_st.heap,
+                &node.text(),
+                &mut self.machine_st.atom_tbl,
+            ),
             Some(name) => {
                 let mut avec = Vec::new();
 
@@ -7817,9 +8101,10 @@ impl Machine {
                     self.machine_st.heap.push(value);
                 }
 
-                let attrs = heap_loc_as_cell!(
-                    iter_to_heap_list(&mut self.machine_st.heap, avec.into_iter())
-                );
+                let attrs = heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    avec.into_iter()
+                ));
 
                 let mut cvec = Vec::new();
 
@@ -7827,14 +8112,17 @@ impl Machine {
                     cvec.push(self.html_node_to_term(child));
                 }
 
-                let children = heap_loc_as_cell!(
-                    iter_to_heap_list(&mut self.machine_st.heap, cvec.into_iter())
-                );
+                let children = heap_loc_as_cell!(iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    cvec.into_iter()
+                ));
 
                 let tag = self.machine_st.atom_tbl.build_with(name);
                 let result = str_loc_as_cell!(self.machine_st.heap.len());
 
-                self.machine_st.heap.push(atom_as_cell!(atom!("element"), 3));
+                self.machine_st
+                    .heap
+                    .push(atom_as_cell!(atom!("element"), 3));
                 self.machine_st.heap.push(atom_as_cell!(tag));
                 self.machine_st.heap.push(attrs);
                 self.machine_st.heap.push(children);

--- a/src/machine/term_stream.rs
+++ b/src/machine/term_stream.rs
@@ -1,8 +1,8 @@
 use crate::forms::*;
-use crate::machine::*;
 use crate::machine::load_state::*;
 use crate::machine::loader::*;
 use crate::machine::machine_errors::*;
+use crate::machine::*;
 use crate::parser::ast::*;
 use crate::parser::parser::*;
 use crate::read::devour_whitespace;
@@ -45,7 +45,10 @@ impl<'a> BootstrappingTermStream<'a> {
         listing_src: ListingSource,
     ) -> Self {
         let parser = Parser::new(stream, machine_st);
-        Self { parser, listing_src }
+        Self {
+            parser,
+            listing_src,
+        }
     }
 }
 
@@ -101,7 +104,7 @@ impl<TS> LoadStatePayload<TS> {
             non_counted_bt_preds: IndexSet::with_hasher(FxBuildHasher::default()),
             predicates: predicate_queue![],
             clause_clauses: vec![],
-         }
+        }
     }
 }
 
@@ -122,20 +125,18 @@ impl TermStream for LiveTermStream {
     }
 }
 
-pub struct InlineTermStream {
-}
+pub struct InlineTermStream {}
 
 impl TermStream for InlineTermStream {
     fn next(&mut self, _: &CompositeOpDir) -> Result<Term, CompilationError> {
-	    Err(CompilationError::from(ParserError::unexpected_eof()))
+        Err(CompilationError::from(ParserError::unexpected_eof()))
     }
 
     fn eof(&mut self) -> Result<bool, CompilationError> {
-	    Ok(true)
+        Ok(true)
     }
 
     fn listing_src(&self) -> &ListingSource {
-	    &ListingSource::User
+        &ListingSource::User
     }
 }
-

--- a/src/machine/unify.rs
+++ b/src/machine/unify.rs
@@ -1,9 +1,9 @@
 use crate::arena::*;
 use crate::forms::*;
 use crate::heap_iter::stackful_preorder_iter;
-use crate::machine::*;
 use crate::machine::machine_state::*;
 use crate::machine::partial_string::*;
+use crate::machine::*;
 use crate::types::*;
 
 use std::cmp::Ordering;
@@ -190,8 +190,8 @@ pub(crate) trait Unifier: DerefMut<Target = MachineState> {
                     machine_st.pdl.push(pstr_iter1.focus);
                 }
             }
-            continuable @ PStrCmpResult::FirstIterContinuable(iteratee) |
-            continuable @ PStrCmpResult::SecondIterContinuable(iteratee) => {
+            continuable @ PStrCmpResult::FirstIterContinuable(iteratee)
+            | continuable @ PStrCmpResult::SecondIterContinuable(iteratee) => {
                 if continuable.is_second_iter() {
                     std::mem::swap(&mut pstr_iter1, &mut pstr_iter2);
                 }
@@ -439,10 +439,8 @@ pub(crate) trait Unifier: DerefMut<Target = MachineState> {
     }
 
     fn unify_big_num<N>(&mut self, n1: TypedArenaPtr<N>, value: HeapCellValue)
-        where N: PartialEq<Rational>
-               + PartialEq<Integer>
-               + PartialEq<i64>
-               + ArenaAllocated
+    where
+        N: PartialEq<Rational> + PartialEq<Integer> + PartialEq<i64> + ArenaAllocated,
     {
         if let Some(r) = value.as_var() {
             Self::bind(self, r, typed_arena_ptr_as_cell!(n1));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -236,12 +236,14 @@ macro_rules! cell_as_stream {
 }
 
 macro_rules! cell_as_load_state_payload {
-    ($cell:expr) => { unsafe {
-        let ptr = cell_as_untyped_arena_ptr!($cell);
-        let ptr = std::mem::transmute::<_, *mut LiveLoadState>(ptr.payload_offset());
+    ($cell:expr) => {
+        unsafe {
+            let ptr = cell_as_untyped_arena_ptr!($cell);
+            let ptr = std::mem::transmute::<_, *mut LiveLoadState>(ptr.payload_offset());
 
-        TypedArenaPtr::new(ptr)
-    }};
+            TypedArenaPtr::new(ptr)
+        }
+    };
 }
 
 macro_rules! match_untyped_arena_ptr_pat_body {
@@ -258,13 +260,15 @@ macro_rules! match_untyped_arena_ptr_pat_body {
         $code
     }};
     ($ptr:ident, OssifiedOpDir, $n:ident, $code:expr) => {{
-        let payload_ptr = unsafe { std::mem::transmute::<_, *mut OssifiedOpDir>($ptr.payload_offset()) };
+        let payload_ptr =
+            unsafe { std::mem::transmute::<_, *mut OssifiedOpDir>($ptr.payload_offset()) };
         let $n = TypedArenaPtr::new(payload_ptr);
         #[allow(unused_braces)]
         $code
     }};
     ($ptr:ident, LiveLoadState, $n:ident, $code:expr) => {{
-        let payload_ptr = unsafe { std::mem::transmute::<_, *mut LiveLoadState>($ptr.payload_offset()) };
+        let payload_ptr =
+            unsafe { std::mem::transmute::<_, *mut LiveLoadState>($ptr.payload_offset()) };
         let $n = TypedArenaPtr::new(payload_ptr);
         #[allow(unused_braces)]
         $code
@@ -275,21 +279,24 @@ macro_rules! match_untyped_arena_ptr_pat_body {
         $code
     }};
     ($ptr:ident, TcpListener, $listener:ident, $code:expr) => {{
-        let payload_ptr = unsafe { std::mem::transmute::<_, *mut TcpListener>($ptr.payload_offset()) };
+        let payload_ptr =
+            unsafe { std::mem::transmute::<_, *mut TcpListener>($ptr.payload_offset()) };
         #[allow(unused_mut)]
         let mut $listener = TypedArenaPtr::new(payload_ptr);
         #[allow(unused_braces)]
         $code
     }};
     ($ptr:ident, HttpListener, $listener:ident, $code:expr) => {{
-        let payload_ptr = unsafe { std::mem::transmute::<_, *mut HttpListener>($ptr.payload_offset()) };
+        let payload_ptr =
+            unsafe { std::mem::transmute::<_, *mut HttpListener>($ptr.payload_offset()) };
         #[allow(unused_mut)]
         let mut $listener = TypedArenaPtr::new(payload_ptr);
         #[allow(unused_braces)]
         $code
     }};
     ($ptr:ident, HttpResponse, $listener:ident, $code:expr) => {{
-        let payload_ptr = unsafe { std::mem::transmute::<_, *mut HttpResponse>($ptr.payload_offset()) };
+        let payload_ptr =
+            unsafe { std::mem::transmute::<_, *mut HttpResponse>($ptr.payload_offset()) };
         #[allow(unused_mut)]
         let mut $listener = TypedArenaPtr::new(payload_ptr);
         #[allow(unused_braces)]
@@ -297,7 +304,8 @@ macro_rules! match_untyped_arena_ptr_pat_body {
     }};
     ($ptr:ident, IndexPtr, $ip:ident, $code:expr) => {{
         #[allow(unused_mut)]
-        let mut $ip = TypedArenaPtr::new(unsafe { std::mem::transmute::<_, *mut IndexPtr>($ptr.get_ptr()) });
+        let mut $ip =
+            TypedArenaPtr::new(unsafe { std::mem::transmute::<_, *mut IndexPtr>($ptr.get_ptr()) });
         #[allow(unused_braces)]
         $code
     }};
@@ -315,7 +323,7 @@ macro_rules! match_untyped_arena_ptr_pat {
             | ArenaHeaderTag::NamedTcpStream
             | ArenaHeaderTag::NamedTlsStream
             | ArenaHeaderTag::HttpReadStream
-	    | ArenaHeaderTag::HttpWriteStream
+            | ArenaHeaderTag::HttpWriteStream
             | ArenaHeaderTag::ReadlineStream
             | ArenaHeaderTag::StaticStringStream
             | ArenaHeaderTag::ByteStream
@@ -323,10 +331,10 @@ macro_rules! match_untyped_arena_ptr_pat {
             | ArenaHeaderTag::StandardErrorStream
     };
     (IndexPtr) => {
-        ArenaHeaderTag::IndexPtrUndefined |
-        ArenaHeaderTag::IndexPtrDynamicUndefined |
-        ArenaHeaderTag::IndexPtrDynamicIndex |
-        ArenaHeaderTag::IndexPtrIndex
+        ArenaHeaderTag::IndexPtrUndefined
+            | ArenaHeaderTag::IndexPtrDynamicUndefined
+            | ArenaHeaderTag::IndexPtrDynamicIndex
+            | ArenaHeaderTag::IndexPtrIndex
     };
     ($tag:ident) => {
         ArenaHeaderTag::$tag
@@ -347,71 +355,71 @@ macro_rules! match_untyped_arena_ptr {
 }
 
 macro_rules! read_heap_cell_pat_body {
-    ($cell:ident, Cons, $n:ident, $code:expr) => ({
+    ($cell:ident, Cons, $n:ident, $code:expr) => {{
         let $n = cell_as_untyped_arena_ptr!($cell);
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, F64, $n:ident, $code:expr) => ({
+    }};
+    ($cell:ident, F64, $n:ident, $code:expr) => {{
         let $n = cell_as_f64_ptr!($cell);
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, Atom, ($name:ident, $arity:ident), $code:expr) => ({
+    }};
+    ($cell:ident, Atom, ($name:ident, $arity:ident), $code:expr) => {{
         let ($name, $arity) = cell_as_atom_cell!($cell).get_name_and_arity();
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, PStr, $atom:ident, $code:expr) => ({
+    }};
+    ($cell:ident, PStr, $atom:ident, $code:expr) => {{
         let $atom = cell_as_atom!($cell);
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, CStr, $atom:ident, $code:expr) => ({
+    }};
+    ($cell:ident, CStr, $atom:ident, $code:expr) => {{
         let $atom = cell_as_atom!($cell);
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, CStr | PStr, $atom:ident, $code:expr) => ({
+    }};
+    ($cell:ident, CStr | PStr, $atom:ident, $code:expr) => {{
         let $atom = cell_as_atom!($cell);
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, PStr | CStr, $atom:ident, $code:expr) => ({
+    }};
+    ($cell:ident, PStr | CStr, $atom:ident, $code:expr) => {{
         let $atom = cell_as_atom!($cell);
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, Fixnum, $value:ident, $code:expr) => ({
+    }};
+    ($cell:ident, Fixnum, $value:ident, $code:expr) => {{
         let $value = Fixnum::from_bytes($cell.into_bytes());
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, CutPoint, $value:ident, $code:expr) => ({
+    }};
+    ($cell:ident, CutPoint, $value:ident, $code:expr) => {{
         let $value = Fixnum::from_bytes($cell.into_bytes());
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, Fixnum | CutPoint, $value:ident, $code:expr) => ({
+    }};
+    ($cell:ident, Fixnum | CutPoint, $value:ident, $code:expr) => {{
         let $value = Fixnum::from_bytes($cell.into_bytes());
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, CutPoint | Fixnum, $value:ident, $code:expr) => ({
+    }};
+    ($cell:ident, CutPoint | Fixnum, $value:ident, $code:expr) => {{
         let $value = Fixnum::from_bytes($cell.into_bytes());
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, Char, $value:ident, $code:expr) => ({
+    }};
+    ($cell:ident, Char, $value:ident, $code:expr) => {{
         let $value = unsafe { char::from_u32_unchecked($cell.get_value() as u32) };
         #[allow(unused_braces)]
         $code
-    });
-    ($cell:ident, $($tags:tt)|+, $value:ident, $code:expr) => ({
+    }};
+    ($cell:ident, $($tags:tt)|+, $value:ident, $code:expr) => {{
         let $value = $cell.get_value() as usize;
         #[allow(unused_braces)]
         $code
-    });
+    }};
 }
 
 macro_rules! read_heap_cell_pat {
@@ -596,7 +604,9 @@ macro_rules! index_store {
         IndexStore {
             code_dir: $code_dir,
             extensible_predicates: ExtensiblePredicates::with_hasher(FxBuildHasher::default()),
-            local_extensible_predicates: LocalExtensiblePredicates::with_hasher(FxBuildHasher::default()),
+            local_extensible_predicates: LocalExtensiblePredicates::with_hasher(
+                FxBuildHasher::default(),
+            ),
             global_variables: GlobalVarDir::with_hasher(FxBuildHasher::default()),
             goal_expansion_indices: GoalExpansionIndices::with_hasher(FxBuildHasher::default()),
             meta_predicates: MetaPredicateDir::with_hasher(FxBuildHasher::default()),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -88,7 +88,7 @@ macro_rules! cell_as_atom_cell {
 macro_rules! cell_as_f64_ptr {
     ($cell:expr) => {{
         let offset = $cell.get_value() as usize;
-        F64Ptr::from_offset(offset)
+        F64Ptr::from_offset(F64Offset::new(offset))
     }};
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -258,7 +258,8 @@ impl GenContext {
 pub struct OpDesc {
     prec: B11,
     spec: B8,
-    #[allow(unused)] padding: B13,
+    #[allow(unused)]
+    padding: B13,
 }
 
 impl OpDesc {
@@ -417,13 +418,13 @@ pub enum ParserError {
 impl ParserError {
     pub fn line_and_col_num(&self) -> Option<(usize, usize)> {
         match self {
-            &ParserError::BackQuotedString(line_num, col_num) |
-            &ParserError::IncompleteReduction(line_num, col_num) |
-            &ParserError::MissingQuote(line_num, col_num) |
-            &ParserError::NonPrologChar(line_num, col_num) |
-            &ParserError::ParseBigInt(line_num, col_num) |
-            &ParserError::UnexpectedChar(_, line_num, col_num) |
-            &ParserError::Utf8Error(line_num, col_num) => Some((line_num, col_num)),
+            &ParserError::BackQuotedString(line_num, col_num)
+            | &ParserError::IncompleteReduction(line_num, col_num)
+            | &ParserError::MissingQuote(line_num, col_num)
+            | &ParserError::NonPrologChar(line_num, col_num)
+            | &ParserError::ParseBigInt(line_num, col_num)
+            | &ParserError::UnexpectedChar(_, line_num, col_num)
+            | &ParserError::Utf8Error(line_num, col_num) => Some((line_num, col_num)),
             _ => None,
         }
     }
@@ -432,8 +433,12 @@ impl ParserError {
         match self {
             ParserError::BackQuotedString(..) => atom!("back_quoted_string"),
             ParserError::IncompleteReduction(..) => atom!("incomplete_reduction"),
-            ParserError::InvalidSingleQuotedCharacter(..) => atom!("invalid_single_quoted_character"),
-            ParserError::IO(e) if e.kind() == ErrorKind::UnexpectedEof => atom!("unexpected_end_of_file"),
+            ParserError::InvalidSingleQuotedCharacter(..) => {
+                atom!("invalid_single_quoted_character")
+            }
+            ParserError::IO(e) if e.kind() == ErrorKind::UnexpectedEof => {
+                atom!("unexpected_end_of_file")
+            }
             ParserError::IO(_) => atom!("input_output_error"),
             ParserError::LexicalError(_) => atom!("lexical_error"),
             ParserError::MissingQuote(..) => atom!("missing_quote"),
@@ -522,9 +527,12 @@ pub enum Fixity {
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Fixnum {
     num: B56,
-    #[allow(unused)] f: bool,
-    #[allow(unused)] m: bool,
-    #[allow(unused)] tag: B6,
+    #[allow(unused)]
+    f: bool,
+    #[allow(unused)]
+    m: bool,
+    #[allow(unused)]
+    tag: B6,
 }
 
 impl Fixnum {
@@ -630,7 +638,6 @@ impl Literal {
         }
     }
 }
-
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VarPtr(Rc<RefCell<Var>>);

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -10,6 +10,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{Error as IOError, ErrorKind};
 use std::ops::{Deref, Neg};
 use std::rc::Rc;
+use std::sync::Arc;
 use std::vec::Vec;
 
 use crate::parser::dashu::{Integer, Rational};
@@ -18,6 +19,7 @@ use fxhash::FxBuildHasher;
 use indexmap::IndexMap;
 use modular_bitfield::error::OutOfBounds;
 use modular_bitfield::prelude::*;
+use tokio::sync::RwLock;
 
 pub type Specifier = u32;
 
@@ -631,7 +633,7 @@ impl fmt::Display for Literal {
 }
 
 impl Literal {
-    pub fn to_atom(&self, atom_tbl: &mut AtomTable) -> Option<Atom> {
+    pub fn to_atom(&self, atom_tbl: &Arc<RwLock<AtomTable>>) -> Option<Atom> {
         match self {
             Literal::Atom(atom) => Some(atom.defrock_brackets(atom_tbl)),
             _ => None,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -19,7 +19,6 @@ use fxhash::FxBuildHasher;
 use indexmap::IndexMap;
 use modular_bitfield::error::OutOfBounds;
 use modular_bitfield::prelude::*;
-use tokio::sync::RwLock;
 
 pub type Specifier = u32;
 
@@ -633,7 +632,7 @@ impl fmt::Display for Literal {
 }
 
 impl Literal {
-    pub fn to_atom(&self, atom_tbl: &Arc<RwLock<AtomTable>>) -> Option<Atom> {
+    pub fn to_atom(&self, atom_tbl: &Arc<AtomTable>) -> Option<Atom> {
         match self {
             Literal::Atom(atom) => Some(atom.defrock_brackets(atom_tbl)),
             _ => None,

--- a/src/parser/char_reader.rs
+++ b/src/parser/char_reader.rs
@@ -20,7 +20,7 @@ use std::str;
 
 pub struct CharReader<R> {
     inner: R,
-    buf: SmallVec<[u8;32]>,
+    buf: SmallVec<[u8; 32]>,
     pos: usize,
 }
 
@@ -78,7 +78,7 @@ pub trait CharRead {
                 self.consume(c.len_utf8());
                 Some(Ok(c))
             }
-            result => result
+            result => result,
         }
     }
 
@@ -161,9 +161,7 @@ impl<R: Read> CharRead for CharReader<R> {
 
                         return Some(Ok(c));
                     }
-                    Err(e) => {
-                        e
-                    }
+                    Err(e) => e,
                 };
 
                 if buf.len() - e.valid_up_to() >= 4 {
@@ -192,13 +190,15 @@ impl<R: Read> CharRead for CharReader<R> {
                     // the buffer, it will be returned on the next
                     // loop.
 
-                    return Some(Err(io::Error::new(io::ErrorKind::InvalidData,
-                                                   BadUtf8Error { bytes: badbytes })));
+                    return Some(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        BadUtf8Error { bytes: badbytes },
+                    )));
                 } else {
                     if self.pos >= self.buf.len() {
                         return None;
                     } else if self.buf.len() - self.pos >= 4 {
-                        return match str::from_utf8(&self.buf[self.pos .. e.valid_up_to()]) {
+                        return match str::from_utf8(&self.buf[self.pos..e.valid_up_to()]) {
                             Ok(s) => {
                                 let mut chars = s.chars();
                                 let c = chars.next().unwrap();
@@ -206,10 +206,12 @@ impl<R: Read> CharRead for CharReader<R> {
                                 Some(Ok(c))
                             }
                             Err(e) => {
-                                let badbytes = self.buf[self.pos .. e.valid_up_to()].to_vec();
+                                let badbytes = self.buf[self.pos..e.valid_up_to()].to_vec();
 
-                                Some(Err(io::Error::new(io::ErrorKind::InvalidData,
-                                                        BadUtf8Error { bytes: badbytes })))
+                                Some(Err(io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    BadUtf8Error { bytes: badbytes },
+                                )))
                             }
                         };
                     } else {
@@ -223,7 +225,7 @@ impl<R: Read> CharRead for CharReader<R> {
 
                         let buf_len = self.buf.len();
 
-                        let mut word = [0u8;4];
+                        let mut word = [0u8; 4];
                         let word_slice = &mut word[buf_len..4];
 
                         match self.inner.read(word_slice) {
@@ -250,7 +252,7 @@ impl<R: Read> CharRead for CharReader<R> {
         let c_len = c.len_utf8();
         let mut shifted_slice = [0u8; 32];
 
-        shifted_slice[0..src_len].copy_from_slice(&self.buf[self.pos .. self.buf.len()]);
+        shifted_slice[0..src_len].copy_from_slice(&self.buf[self.pos..self.buf.len()]);
 
         self.buf.resize(c_len, 0);
         self.buf.extend_from_slice(&shifted_slice[0..src_len]);
@@ -311,7 +313,10 @@ impl<R: Read> Read for CharReader<R> {
         }
 
         if !buf.is_empty() {
-            Err(io::Error::new(ErrorKind::UnexpectedEof, "failed to fill whole buffer"))
+            Err(io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            ))
         } else {
             Ok(())
         }
@@ -364,11 +369,13 @@ where
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("CharReader")
             .field("reader", &self.inner)
-            .field("buf", &format_args!("{}/{}", self.buf.capacity() - self.pos, self.buf.len()))
+            .field(
+                "buf",
+                &format_args!("{}/{}", self.buf.capacity() - self.pos, self.buf.len()),
+            )
             .finish()
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -638,7 +638,7 @@ impl<'a, R: CharRead> Lexer<'a, R> {
             Ok(Token::Literal(Literal::Atom(atom!("[]"))))
         } else {
             Ok(Token::Literal(Literal::Atom(
-                self.machine_st.atom_tbl.build_with(&token),
+                self.machine_st.atom_tbl.blocking_write().build_with(&token),
             )))
         }
     }
@@ -1083,7 +1083,7 @@ impl<'a, R: CharRead> Lexer<'a, R> {
 
                 if c == '"' {
                     let s = self.char_code_list_token(c)?;
-                    let atom = self.machine_st.atom_tbl.build_with(&s);
+                    let atom = self.machine_st.atom_tbl.blocking_write().build_with(&s);
 
                     return if let DoubleQuotes::Atom = self.machine_st.flags.double_quotes {
                         Ok(Token::Literal(Literal::Atom(atom)))

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -637,9 +637,10 @@ impl<'a, R: CharRead> Lexer<'a, R> {
         if token.as_str() == "[]" {
             Ok(Token::Literal(Literal::Atom(atom!("[]"))))
         } else {
-            Ok(Token::Literal(Literal::Atom(
-                self.machine_st.atom_tbl.blocking_write().build_with(&token),
-            )))
+            Ok(Token::Literal(Literal::Atom(AtomTable::build_with(
+                &self.machine_st.atom_tbl,
+                &token,
+            ))))
         }
     }
 
@@ -1083,7 +1084,7 @@ impl<'a, R: CharRead> Lexer<'a, R> {
 
                 if c == '"' {
                     let s = self.char_code_list_token(c)?;
-                    let atom = self.machine_st.atom_tbl.blocking_write().build_with(&s);
+                    let atom = AtomTable::build_with(&self.machine_st.atom_tbl, &s);
 
                     return if let DoubleQuotes::Atom = self.machine_st.flags.double_quotes {
                         Ok(Token::Literal(Literal::Atom(atom)))

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -86,14 +86,14 @@ impl<'a, R: CharRead> Lexer<'a, R> {
     pub fn lookahead_char(&mut self) -> Result<char, ParserError> {
         match self.reader.peek_char() {
             Some(Ok(c)) => Ok(c),
-            _ => Err(ParserError::unexpected_eof())
+            _ => Err(ParserError::unexpected_eof()),
         }
     }
 
     pub fn read_char(&mut self) -> Result<char, ParserError> {
         match self.reader.read_char() {
             Some(Ok(c)) => Ok(c),
-            _ => Err(ParserError::unexpected_eof())
+            _ => Err(ParserError::unexpected_eof()),
         }
     }
 
@@ -168,13 +168,15 @@ impl<'a, R: CharRead> Lexer<'a, R> {
 
             match comment_loop() {
                 Err(e) if e.is_unexpected_eof() => {
-                    return Err(ParserError::IncompleteReduction(self.line_num, self.col_num));
+                    return Err(ParserError::IncompleteReduction(
+                        self.line_num,
+                        self.col_num,
+                    ));
                 }
                 Err(e) => {
                     return Err(e);
                 }
-                Ok(_) => {
-                }
+                Ok(_) => {}
             }
 
             if prolog_char!(c) {
@@ -362,7 +364,10 @@ impl<'a, R: CharRead> Lexer<'a, R> {
         if hexadecimal_digit_char!(c) {
             self.escape_sequence_to_char(|c| hexadecimal_digit_char!(c), 16)
         } else {
-            Err(ParserError::IncompleteReduction(self.line_num, self.col_num))
+            Err(ParserError::IncompleteReduction(
+                self.line_num,
+                self.col_num,
+            ))
         }
     }
 
@@ -395,7 +400,10 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                 },
             )
         } else {
-            Err(ParserError::IncompleteReduction(self.line_num, self.col_num))
+            Err(ParserError::IncompleteReduction(
+                self.line_num,
+                self.col_num,
+            ))
         }
     }
 
@@ -463,9 +471,12 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                 .map(|n| Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena)))
                 .or_else(|_| {
                     Integer::from_str_radix(&token, 16)
-                        .map(|n| Token::Literal(Literal::Integer(
-                            arena_alloc!(n, &mut self.machine_st.arena)
-                        )))
+                        .map(|n| {
+                            Token::Literal(Literal::Integer(arena_alloc!(
+                                n,
+                                &mut self.machine_st.arena
+                            )))
+                        })
                         .map_err(|_| ParserError::ParseBigInt(self.line_num, self.col_num))
                 })
         } else {
@@ -495,9 +506,12 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                 .map(|n| Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena)))
                 .or_else(|_| {
                     Integer::from_str_radix(&token, 8)
-                        .map(|n| Token::Literal(Literal::Integer(
-                            arena_alloc!(n, &mut self.machine_st.arena)
-                        )))
+                        .map(|n| {
+                            Token::Literal(Literal::Integer(arena_alloc!(
+                                n,
+                                &mut self.machine_st.arena
+                            )))
+                        })
                         .map_err(|_| ParserError::ParseBigInt(self.line_num, self.col_num))
                 })
         } else {
@@ -527,9 +541,12 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                 .map(|n| Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena)))
                 .or_else(|_| {
                     Integer::from_str_radix(&token, 2)
-                        .map(|n| Token::Literal(Literal::Integer(
-                            arena_alloc!(n, &mut self.machine_st.arena)
-                        )))
+                        .map(|n| {
+                            Token::Literal(Literal::Integer(arena_alloc!(
+                                n,
+                                &mut self.machine_st.arena
+                            )))
+                        })
                         .map_err(|_| ParserError::ParseBigInt(self.line_num, self.col_num))
                 })
         } else {
@@ -629,7 +646,10 @@ impl<'a, R: CharRead> Lexer<'a, R> {
     fn vacate_with_float(&mut self, mut token: String) -> Result<Token, ParserError> {
         self.return_char(token.pop().unwrap());
         let n = parse_lossy::<f64, _>(token.as_bytes())?;
-        Ok(Token::Literal(Literal::from(float_alloc!(n, self.machine_st.arena))))
+        Ok(Token::Literal(Literal::from(float_alloc!(
+            n,
+            self.machine_st.arena
+        ))))
     }
 
     fn skip_underscore_in_number(&mut self) -> Result<char, ParserError> {
@@ -675,7 +695,10 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                         token
                             .parse::<Integer>()
                             .map(|n| {
-                                Token::Literal(Literal::Integer(arena_alloc!(n, &mut self.machine_st.arena)))
+                                Token::Literal(Literal::Integer(arena_alloc!(
+                                    n,
+                                    &mut self.machine_st.arena
+                                )))
                             })
                             .map_err(|_| ParserError::ParseBigInt(self.line_num, self.col_num))
                     })
@@ -740,17 +763,19 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                         }
 
                         let n = parse_lossy::<f64, _>(token.as_bytes())?;
-                        Ok(Token::Literal(Literal::from(
-                            float_alloc!(n, self.machine_st.arena)
-                        )))
+                        Ok(Token::Literal(Literal::from(float_alloc!(
+                            n,
+                            self.machine_st.arena
+                        ))))
                     } else {
                         return Ok(self.vacate_with_float(token)?);
                     }
                 } else {
                     let n = parse_lossy::<f64, _>(token.as_bytes())?;
-                    Ok(Token::Literal(Literal::from(
-                        float_alloc!(n, self.machine_st.arena)
-                    )))
+                    Ok(Token::Literal(Literal::from(float_alloc!(
+                        n,
+                        self.machine_st.arena
+                    ))))
                 }
             } else {
                 self.return_char('.');
@@ -761,7 +786,10 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                         token
                             .parse::<Integer>()
                             .map(|n| {
-                                Token::Literal(Literal::Integer(arena_alloc!(n, &mut self.machine_st.arena)))
+                                Token::Literal(Literal::Integer(arena_alloc!(
+                                    n,
+                                    &mut self.machine_st.arena
+                                )))
                             })
                             .map_err(|_| ParserError::ParseBigInt(self.line_num, self.col_num))
                     })
@@ -772,7 +800,9 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                     self.hexadecimal_constant(c).or_else(|e| {
                         if let ParserError::ParseBigInt(..) = e {
                             i64::from_str_radix(&token, 10)
-                                .map(|n| Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena)))
+                                .map(|n| {
+                                    Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena))
+                                })
                                 .or_else(|_| {
                                     token
                                         .parse::<Integer>()
@@ -794,7 +824,9 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                     self.octal_constant(c).or_else(|e| {
                         if let ParserError::ParseBigInt(..) = e {
                             i64::from_str_radix(&token, 10)
-                                .map(|n| Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena)))
+                                .map(|n| {
+                                    Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena))
+                                })
                                 .or_else(|_| {
                                     token
                                         .parse::<Integer>()
@@ -816,7 +848,9 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                     self.binary_constant(c).or_else(|e| {
                         if let ParserError::ParseBigInt(..) = e {
                             i64::from_str_radix(&token, 10)
-                                .map(|n| Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena)))
+                                .map(|n| {
+                                    Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena))
+                                })
                                 .or_else(|_| {
                                     token
                                         .parse::<Integer>()
@@ -856,15 +890,16 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                         .map(|c| Token::Literal(Literal::Fixnum(Fixnum::build_with(c as i64))))
                         .or_else(|err| {
                             match err {
-                                ParserError::UnexpectedChar('\'', ..) => {
-                                }
+                                ParserError::UnexpectedChar('\'', ..) => {}
                                 err => return Err(err),
                             }
 
                             self.return_char(c);
 
                             i64::from_str_radix(&token, 10)
-                                .map(|n| Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena)))
+                                .map(|n| {
+                                    Token::Literal(fixnum!(Literal, n, &mut self.machine_st.arena))
+                                })
                                 .or_else(|_| {
                                     token
                                         .parse::<Integer>()
@@ -901,7 +936,10 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                         token
                             .parse::<Integer>()
                             .map(|n| {
-                                Token::Literal(Literal::Integer(arena_alloc!(n, &mut self.machine_st.arena)))
+                                Token::Literal(Literal::Integer(arena_alloc!(
+                                    n,
+                                    &mut self.machine_st.arena
+                                )))
                             })
                             .map_err(|_| ParserError::ParseBigInt(self.line_num, self.col_num))
                     })
@@ -940,11 +978,12 @@ impl<'a, R: CharRead> Lexer<'a, R> {
 
     pub fn scan_for_layout(&mut self) -> Result<bool, ParserError> {
         match self.lookahead_char() {
-            Err(e) => {
-                Err(e)
-            }
+            Err(e) => Err(e),
             Ok(c) => {
-                let mut layout_info = LayoutInfo { inserted: false, more: true };
+                let mut layout_info = LayoutInfo {
+                    inserted: false,
+                    more: true,
+                };
                 let mut cr = Some(c);
 
                 loop {
@@ -1054,7 +1093,7 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                 }
 
                 if c == '\u{0}' {
-                    return Err(ParserError::unexpected_eof())
+                    return Err(ParserError::unexpected_eof());
                 }
 
                 self.name_token(c)

--- a/src/parser/macros.rs
+++ b/src/parser/macros.rs
@@ -7,13 +7,14 @@ macro_rules! char_class {
 #[macro_export]
 macro_rules! alpha_char {
     ($c: expr) => {
-        (!$c.is_numeric() &&
-         !$c.is_whitespace() &&
-         !$c.is_control() &&
-         !$crate::graphic_token_char!($c) &&
-         !$crate::layout_char!($c) &&
-         !$crate::meta_char!($c) &&
-         !$crate::solo_char!($c)) || $c == '_'
+        (!$c.is_numeric()
+            && !$c.is_whitespace()
+            && !$c.is_control()
+            && !$crate::graphic_token_char!($c)
+            && !$crate::layout_char!($c)
+            && !$crate::meta_char!($c)
+            && !$crate::solo_char!($c))
+            || $c == '_'
     };
 }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -7,7 +7,6 @@ use crate::parser::ast::*;
 use crate::parser::char_reader::*;
 use crate::parser::lexer::*;
 
-
 use std::cell::Cell;
 use std::mem;
 use std::ops::Neg;
@@ -120,26 +119,17 @@ pub(crate) fn as_partial_string(
     }
 
     match &tail {
-        Term::AnonVar | Term::Var(..) => {
-            Ok((string, Some(Box::new(tail))))
-        }
-        Term::Literal(_, Literal::Atom(atom!("[]"))) => {
-            Ok((string, None))
-        }
+        Term::AnonVar | Term::Var(..) => Ok((string, Some(Box::new(tail)))),
+        Term::Literal(_, Literal::Atom(atom!("[]"))) => Ok((string, None)),
         Term::Literal(_, Literal::String(tail)) => {
             string += tail.as_str();
             Ok((string, None))
         }
-        _ => {
-            Ok((string, Some(Box::new(tail))))
-        }
+        _ => Ok((string, Some(Box::new(tail)))),
     }
 }
 
-pub fn get_op_desc(
-    name: Atom,
-    op_dir: &CompositeOpDir,
-) -> Option<CompositeOpDesc> {
+pub fn get_op_desc(name: Atom, op_dir: &CompositeOpDir) -> Option<CompositeOpDesc> {
     let mut op_desc = CompositeOpDesc {
         pre: 0,
         inf: 0,
@@ -409,7 +399,8 @@ impl<'a, R: CharRead> Parser<'a, R> {
     }
 
     fn promote_atom_op(&mut self, atom: Atom, priority: usize, assoc: u32) {
-        self.terms.push(Term::Literal(Cell::default(), Literal::Atom(atom)));
+        self.terms
+            .push(Term::Literal(Cell::default(), Literal::Atom(atom)));
         self.stack.push(TokenDesc {
             tt: TokenType::Term,
             priority,
@@ -419,7 +410,9 @@ impl<'a, R: CharRead> Parser<'a, R> {
 
     fn shift(&mut self, token: Token, priority: usize, spec: Specifier) {
         let tt = match token {
-            Token::Literal(Literal::String(s)) if self.lexer.machine_st.flags.double_quotes.is_codes() => {
+            Token::Literal(Literal::String(s))
+                if self.lexer.machine_st.flags.double_quotes.is_codes() =>
+            {
                 let mut list = Term::Literal(Cell::default(), Literal::Atom(atom!("[]")));
 
                 for c in s.as_str().chars().rev() {
@@ -436,7 +429,9 @@ impl<'a, R: CharRead> Parser<'a, R> {
                 self.terms.push(list);
                 TokenType::Term
             }
-            Token::Literal(Literal::String(s)) if self.lexer.machine_st.flags.double_quotes.is_chars() => {
+            Token::Literal(Literal::String(s))
+                if self.lexer.machine_st.flags.double_quotes.is_chars() =>
+            {
                 self.terms.push(Term::CompleteString(Cell::default(), s));
                 TokenType::Term
             }
@@ -588,20 +583,19 @@ impl<'a, R: CharRead> Parser<'a, R> {
                         let tail = subterms.pop().unwrap();
                         let head = subterms.pop().unwrap();
 
-                        self.terms.push(
-                            match as_partial_string(head, tail) {
-                                Ok((string_buf, Some(tail))) => {
-                                    Term::PartialString(Cell::default(), string_buf, tail)
-                                }
-                                Ok((string_buf, None)) => {
-                                    let atom = self.lexer.machine_st.atom_tbl.build_with(&string_buf);
-                                    Term::CompleteString(Cell::default(), atom)
-                                }
-                                Err(term) => term,
-                            },
-                        );
+                        self.terms.push(match as_partial_string(head, tail) {
+                            Ok((string_buf, Some(tail))) => {
+                                Term::PartialString(Cell::default(), string_buf, tail)
+                            }
+                            Ok((string_buf, None)) => {
+                                let atom = self.lexer.machine_st.atom_tbl.build_with(&string_buf);
+                                Term::CompleteString(Cell::default(), atom)
+                            }
+                            Err(term) => term,
+                        });
                     } else {
-                        self.terms.push(Term::Clause(Cell::default(), name, subterms));
+                        self.terms
+                            .push(Term::Clause(Cell::default(), name, subterms));
                     }
 
                     if let Some(&mut TokenDesc {
@@ -695,7 +689,8 @@ impl<'a, R: CharRead> Parser<'a, R> {
                 td.tt = TokenType::Term;
                 td.priority = 0;
 
-                self.terms.push(Term::Literal(Cell::default(), Literal::Atom(atom!("[]"))));
+                self.terms
+                    .push(Term::Literal(Cell::default(), Literal::Atom(atom!("[]"))));
                 return Ok(true);
             }
         }
@@ -736,8 +731,8 @@ impl<'a, R: CharRead> Parser<'a, R> {
         if arity > self.terms.len() {
             return Err(ParserError::IncompleteReduction(
                 self.lexer.line_num,
-                self.lexer.col_num
-            ))
+                self.lexer.col_num,
+            ));
         }
 
         let idx = self.terms.len() - arity;
@@ -755,18 +750,16 @@ impl<'a, R: CharRead> Parser<'a, R> {
         });
 
         self.terms.push(match list {
-            Term::Cons(_, head, tail) => {
-                match as_partial_string(*head, *tail) {
-                    Ok((string_buf, Some(tail))) => {
-                        Term::PartialString(Cell::default(), string_buf, tail)
-                    }
-                    Ok((string_buf, None)) => {
-                        let atom = self.lexer.machine_st.atom_tbl.build_with(&string_buf);
-                        Term::CompleteString(Cell::default(), atom)
-                    }
-                    Err(term) => term,
+            Term::Cons(_, head, tail) => match as_partial_string(*head, *tail) {
+                Ok((string_buf, Some(tail))) => {
+                    Term::PartialString(Cell::default(), string_buf, tail)
                 }
-            }
+                Ok((string_buf, None)) => {
+                    let atom = self.lexer.machine_st.atom_tbl.build_with(&string_buf);
+                    Term::CompleteString(Cell::default(), atom)
+                }
+                Err(term) => term,
+            },
             term => term,
         });
 
@@ -784,10 +777,7 @@ impl<'a, R: CharRead> Parser<'a, R> {
                 td.priority = 0;
                 td.spec = TERM;
 
-                let term = Term::Literal(
-                    Cell::default(),
-                    Literal::Atom(atom!("{}")),
-                );
+                let term = Term::Literal(Cell::default(), Literal::Atom(atom!("{}")));
 
                 self.terms.push(term);
                 return Ok(true);
@@ -818,11 +808,8 @@ impl<'a, R: CharRead> Parser<'a, R> {
                             }
                         };
 
-                        self.terms.push(Term::Clause(
-                            Cell::default(),
-                            atom!("{}"),
-                            vec![term],
-                        ));
+                        self.terms
+                            .push(Term::Clause(Cell::default(), atom!("{}"), vec![term]));
 
                         return Ok(true);
                     }
@@ -933,7 +920,8 @@ impl<'a, R: CharRead> Parser<'a, R> {
             if let Some(term) = self.terms.last().cloned() {
                 match term {
                     Term::Literal(_, Literal::Atom(name))
-                        if name == atom!("-") && (is_prefix!(desc.spec) || is_negate!(desc.spec)) =>
+                        if name == atom!("-")
+                            && (is_prefix!(desc.spec) || is_negate!(desc.spec)) =>
                     {
                         self.stack.pop();
                         self.terms.pop();
@@ -1069,7 +1057,11 @@ impl<'a, R: CharRead> Parser<'a, R> {
     }
 
     // on success, returns the parsed term and the number of lines read.
-    pub fn read_term(&mut self, op_dir: &CompositeOpDir, tokens: Tokens) -> Result<Term, ParserError> {
+    pub fn read_term(
+        &mut self,
+        op_dir: &CompositeOpDir,
+        tokens: Tokens,
+    ) -> Result<Term, ParserError> {
         self.tokens = match tokens {
             Tokens::Default => read_tokens(&mut self.lexer)?,
             Tokens::Provided(tokens) => tokens,

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,6 +1,5 @@
 use dashu::Integer;
 use dashu::Rational;
-use tokio::sync::RwLock;
 
 use crate::arena::*;
 use crate::atom_table::*;
@@ -286,14 +285,14 @@ fn read_tokens<R: CharRead>(lexer: &mut Lexer<R>) -> Result<Vec<Token>, ParserEr
     Ok(tokens)
 }
 
-fn atomize_term(atom_tbl: &RwLock<AtomTable>, term: &Term) -> Option<Atom> {
+fn atomize_term(atom_tbl: &AtomTable, term: &Term) -> Option<Atom> {
     match term {
         Term::Literal(_, ref c) => atomize_constant(atom_tbl, *c),
         _ => None,
     }
 }
 
-fn atomize_constant(atom_tbl: &RwLock<AtomTable>, c: Literal) -> Option<Atom> {
+fn atomize_constant(atom_tbl: &AtomTable, c: Literal) -> Option<Atom> {
     match c {
         Literal::Atom(ref name) => Some(*name),
         Literal::Char(c) => Some(AtomTable::build_with(atom_tbl, &c.to_string())),

--- a/src/rcu.rs
+++ b/src/rcu.rs
@@ -1,0 +1,213 @@
+use std::{
+    cell::OnceCell,
+    fmt::Debug,
+    mem::ManuallyDrop,
+    ops::Deref,
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicPtr, AtomicU8},
+        Arc, Weak,
+    },
+};
+
+use tokio::sync::RwLock;
+
+// the epoch counters of all threads that have ever accessed an Rcu
+// threads that have finished will have a dangling Weak reference and can be cleand up
+// having this be shared between all Rcu's is a tradeof,
+// writes will be slower as more epoch counters need to be waited for
+// reads should be faster as a thread only needs to register itself once on the first read
+//
+static EPOCH_COUNTERS: RwLock<Vec<Weak<AtomicU8>>> = RwLock::const_new(Vec::new());
+
+thread_local! {
+    // odd value means the current thread is about to access the active_epoch of an Rcu
+    // a thread has a single epoch counter for all Rcu it accesses,
+    // as a thread can only access one Rcu at a time
+    static THREAD_EPOCH_COUNTER: OnceCell<Arc<AtomicU8>> = OnceCell::new();
+}
+
+pub struct Rcu<T> {
+    active_value: AtomicPtr<T>,
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for Rcu<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let active_epoch = self.active_epoch();
+        f.debug_struct("Rcu")
+            .field("active_value", &active_epoch)
+            .finish()
+    }
+}
+
+impl<T> Rcu<T> {
+    pub fn new(initial_value: T) -> Self {
+        Rcu {
+            active_value: AtomicPtr::new(Arc::into_raw(Arc::new(initial_value)).cast_mut()),
+        }
+    }
+
+    pub fn active_epoch(&self) -> RcuRef<T, T> {
+        THREAD_EPOCH_COUNTER.with(|epoch_counter| {
+            let epoch_counter = epoch_counter.get_or_init(|| {
+                let epoch_counter = Arc::new(AtomicU8::new(0));
+                // register the current threads epoch counter on init
+                EPOCH_COUNTERS
+                    .blocking_write()
+                    .push(Arc::downgrade(&epoch_counter));
+                epoch_counter
+            });
+
+            let old = epoch_counter.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            assert!(old % 2 == 0, "Old Epoch counter value should be even!");
+        });
+
+        let arc_ptr = self.active_value.load(std::sync::atomic::Ordering::Acquire);
+
+        let arc = unsafe {
+            // Safety:
+            // - the ptr was created in Rcu::new or Rcu::replace with Arc::into_raw
+            // - the Rcu is responsible for of the arc's strong refrences
+            // - the Rcu is alive as this function takes a reference to the Rcu
+            // - replace will wait with decrementing the old values strong count until our epoich counter is even again
+            Arc::increment_strong_count(arc_ptr);
+            // Safety:
+            // - the ptr was created in Rcu::new or Rcu::replace with Arc::into_raw
+            // - we have just ensured an additional strong count by incrementing the count
+            Arc::from_raw(arc_ptr)
+        };
+
+        THREAD_EPOCH_COUNTER.with(|epoch_counter| {
+            let old = epoch_counter
+                .get().expect("we initialized the OnceCell when we incremented the epoch counter the fist time")
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            assert!(old % 2 != 0, "Old Epoch counter value should be odd!");
+        });
+
+        RcuRef {
+            data: arc.deref().into(),
+            arc,
+        }
+    }
+
+    /*
+     *  replace the Rcu'S content with a new value
+     *
+     *  This does not syncronize write and last to update the active_value pointer wins,
+     *  all writes that do not win will be lost, though not leaked.
+     *  This will block untill the old value can be reclaimed,
+     *  i.e. all threads whitnest to be in the read critical sections
+     *       have been witnest to have left the critical section at least once
+     */
+    pub fn replace(&self, new_value: T) {
+        let arc_ptr = self.active_value.swap(
+            Arc::into_raw(Arc::new(new_value)).cast_mut(),
+            std::sync::atomic::Ordering::AcqRel,
+        );
+
+        // maually drop as we need to ensure not to drop the arc while
+        // we have not witnest all threads to be or have been outside the read critical section
+        // i.e. even epoch counter or different odd epoch counter
+        // Safety:
+        // - the ptr was created in Rcu::new or Rcu::replace with Arc::into_raw
+        // - the Rcu itself holds one strong count
+        let arc = unsafe { ManuallyDrop::new(Arc::from_raw(arc_ptr)) };
+
+        let epochs = EPOCH_COUNTERS.blocking_read().clone();
+        let mut epochs = epochs
+            .into_iter()
+            .flat_map(|elem| {
+                let arc = elem.upgrade()?;
+                let init_val = arc.load(std::sync::atomic::Ordering::Acquire);
+                if init_val % 2 == 0 {
+                    // already even can be ignored
+                    return None;
+                }
+                // odd initial value thread is in read critical section
+                // need to wait for the value to change before we can drop the arc
+                Some((init_val, elem))
+            })
+            .collect::<Vec<_>>();
+
+        while !epochs.is_empty() {
+            epochs.retain(|elem| {
+                let Some(arc) = elem.1.upgrade() else {
+                    // as the thread is dead it can't have a ref to old arc
+                    return false;
+                };
+                // the epoch counter has not changed so the thread is still in the same instance of the critical section
+                // any different value is ok as
+                // - even values indicate the thread is outside the critical section
+                // - a diffrent odd value indicates the thread has left the critical section and can subsequently only read the new active_value
+                arc.load(std::sync::atomic::Ordering::Acquire) == elem.0
+            })
+        }
+
+        // Safety:
+        // - we have not dropped the arc another way
+        // - we witnessed all threads either with an even epoch count or with a new odd count
+        //   as such they must have left the critical section at some point
+        ManuallyDrop::into_inner(arc);
+    }
+}
+
+pub struct RcuRef<T, M>
+where
+    T: ?Sized,
+    M: ?Sized,
+{
+    arc: Arc<T>,
+    data: NonNull<M>,
+}
+
+impl<T: ?Sized, M: ?Sized + Debug> Debug for RcuRef<T, M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RcuRef")
+            .field("data", &self.deref())
+            .finish()
+    }
+}
+
+// use assoiated functions rather than methods so that we don't overlap
+// with functions of the Deref Target type
+impl<T: ?Sized, M: ?Sized> RcuRef<T, M> {
+    pub fn map<N: ?Sized, F: for<'a> FnOnce(&'a M) -> &'a N>(referece: Self, f: F) -> RcuRef<T, N> {
+        RcuRef {
+            arc: referece.arc,
+            data: f(unsafe { referece.data.as_ref() }).into(),
+        }
+    }
+
+    pub fn try_map<N: ?Sized, F: for<'a> FnOnce(&'a M) -> Option<&'a N>>(
+        referece: Self,
+        f: F,
+    ) -> Option<RcuRef<T, N>> {
+        let val = f(unsafe { referece.data.as_ref() })?;
+        Some(RcuRef {
+            arc: Arc::clone(&referece.arc),
+            data: val.into(),
+        })
+    }
+
+    pub fn same_epoch(this: &Self, other: &Self) -> bool {
+        Arc::ptr_eq(&this.arc, &other.arc)
+    }
+
+    pub fn clone(this: &Self) -> Self {
+        Self {
+            arc: Arc::clone(&this.arc),
+            data: this.data,
+        }
+    }
+}
+
+impl<T: ?Sized, M: ?Sized> Deref for RcuRef<T, M> {
+    type Target = M;
+
+    fn deref(&self) -> &Self::Target {
+        // Safety: The pointer points into the arc we are holding
+        // while we are alive so is the target
+        // as the content is in an Rcu no mutable acess is given out
+        unsafe { self.data.as_ref() }
+    }
+}

--- a/src/rcu.rs
+++ b/src/rcu.rs
@@ -189,8 +189,12 @@ impl<T: ?Sized, M: ?Sized> RcuRef<T, M> {
         })
     }
 
-    pub fn same_epoch(this: &Self, other: &Self) -> bool {
+    pub fn same_epoch<M2>(this: &Self, other: &RcuRef<T, M2>) -> bool {
         Arc::ptr_eq(&this.arc, &other.arc)
+    }
+
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        this.data == other.data
     }
 
     pub fn clone(this: &Self) -> Self {
@@ -198,6 +202,10 @@ impl<T: ?Sized, M: ?Sized> RcuRef<T, M> {
             arc: Arc::clone(&this.arc),
             data: this.data,
         }
+    }
+
+    pub fn get_root(this: &Self) -> &T {
+        &this.arc
     }
 }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -30,15 +30,13 @@ use std::io::{Cursor, Error, ErrorKind, Read};
 
 type SubtermDeque = VecDeque<(usize, usize)>;
 
-pub(crate) fn devour_whitespace<'a, R: CharRead>(parser: &mut Parser<'a, R>) -> Result<bool, ParserError> {
+pub(crate) fn devour_whitespace<'a, R: CharRead>(
+    parser: &mut Parser<'a, R>,
+) -> Result<bool, ParserError> {
     match parser.lexer.scan_for_layout() {
-        Err(e) if e.is_unexpected_eof() => {
-            Ok(true)
-        }
+        Err(e) if e.is_unexpected_eof() => Ok(true),
         Err(e) => Err(e),
-        Ok(_) => {
-            Ok(false)
-        }
+        Ok(_) => Ok(false),
     }
 }
 
@@ -60,7 +58,6 @@ pub(crate) fn error_after_read_term<R>(
     CompilationError::from(err)
 }
 
-
 impl MachineState {
     pub(crate) fn read(
         &mut self,
@@ -74,7 +71,8 @@ impl MachineState {
 
             parser.add_lines_read(prior_num_lines_read);
 
-            let term = parser.read_term(&op_dir, Tokens::Default)
+            let term = parser
+                .read_term(&op_dir, Tokens::Default)
                 .map_err(|err| error_after_read_term(err, prior_num_lines_read, &parser))?; // CompilationError::from
 
             (term, parser.lines_read() - prior_num_lines_read)
@@ -117,9 +115,7 @@ impl ReadlineStream {
     #[cfg(feature = "repl")]
     #[inline]
     pub fn new(pending_input: &str, add_history: bool) -> Self {
-        let config = Config::builder()
-            .check_cursor_position(true)
-            .build();
+        let config = Config::builder().check_cursor_position(true).build();
 
         let helper = Helper::new();
 
@@ -156,8 +152,7 @@ impl ReadlineStream {
     }
 
     #[cfg(not(feature = "repl"))]
-    pub fn set_atoms_for_completion(&mut self, atoms: *const IndexSet<Atom>) {
-    }
+    pub fn set_atoms_for_completion(&mut self, atoms: *const IndexSet<Atom>) {}
 
     #[inline]
     pub fn reset(&mut self) {
@@ -180,7 +175,9 @@ impl ReadlineStream {
 
                 unsafe {
                     if PROMPT {
-                        self.rl.add_history_entry(self.pending_input.get_ref().get_ref()).unwrap();
+                        self.rl
+                            .add_history_entry(self.pending_input.get_ref().get_ref())
+                            .unwrap();
                         self.save_history();
                         PROMPT = false;
                     }
@@ -220,8 +217,7 @@ impl ReadlineStream {
     }
 
     #[cfg(not(feature = "repl"))]
-    fn save_history(&mut self) {
-    }
+    fn save_history(&mut self) {}
 
     #[inline]
     pub(crate) fn peek_byte(&mut self) -> std::io::Result<u8> {
@@ -253,7 +249,7 @@ impl Read for ReadlineStream {
                 self.call_readline()?;
                 self.pending_input.read(buf)
             }
-            result => result
+            result => result,
         }
     }
 }
@@ -266,16 +262,14 @@ impl CharRead for ReadlineStream {
                 Some(Ok(c)) => {
                     return Some(Ok(c));
                 }
-                _ => {
-                    match self.call_readline() {
-                        Err(e) => {
-                            return Some(Err(e));
-                        }
-                        _ => {
-                            set_prompt(false);
-                        }
+                _ => match self.call_readline() {
+                    Err(e) => {
+                        return Some(Err(e));
                     }
-                }
+                    _ => {
+                        set_prompt(false);
+                    }
+                },
             }
         }
     }
@@ -347,17 +341,18 @@ impl<'a, 'b> TermWriter<'a, 'b> {
         match term {
             &TermRef::Cons(..) => list_loc_as_cell!(h),
             &TermRef::AnonVar(_) | &TermRef::Var(..) => heap_loc_as_cell!(h),
-            &TermRef::CompleteString(_, _, ref src) =>
+            &TermRef::CompleteString(_, _, ref src) => {
                 if src.as_str().is_empty() {
                     empty_list_as_cell!()
                 } else if self.heap[h].get_tag() == HeapCellValueTag::CStr {
                     heap_loc_as_cell!(h)
                 } else {
                     pstr_loc_as_cell!(h)
-                },
+                }
+            }
             &TermRef::PartialString(..) => pstr_loc_as_cell!(h),
             &TermRef::Literal(_, _, literal) => HeapCellValue::from(*literal),
-            &TermRef::Clause(_,_,_,subterms) if subterms.len() == 0 => heap_loc_as_cell!(h),
+            &TermRef::Clause(_, _, _, subterms) if subterms.len() == 0 => heap_loc_as_cell!(h),
             &TermRef::Clause(..) => str_loc_as_cell!(h),
         }
     }
@@ -427,7 +422,8 @@ impl<'a, 'b> TermWriter<'a, 'b> {
                 }
                 &TermRef::AnonVar(_) => {
                     if let Some((arity, site_h)) = self.queue.pop_front() {
-                        self.var_dict.insert(VarKey::AnonVar(h), heap_loc_as_cell!(site_h));
+                        self.var_dict
+                            .insert(VarKey::AnonVar(h), heap_loc_as_cell!(site_h));
 
                         if arity > 1 {
                             self.queue.push_front((arity - 1, site_h + 1));

--- a/src/read.rs
+++ b/src/read.rs
@@ -16,10 +16,6 @@ use crate::types::*;
 
 use fxhash::FxBuildHasher;
 
-use tokio::sync::RwLock;
-
-use std::sync::Arc;
-
 #[cfg(feature = "repl")]
 use rustyline::error::ReadlineError;
 #[cfg(feature = "repl")]
@@ -29,6 +25,7 @@ use rustyline::{Config, Editor};
 
 use std::collections::VecDeque;
 use std::io::{Cursor, Error, ErrorKind, Read};
+use std::sync::Arc;
 
 type SubtermDeque = VecDeque<(usize, usize)>;
 
@@ -148,7 +145,7 @@ impl ReadlineStream {
         }
     }
 
-    pub fn set_atoms_for_completion(&mut self, atoms: &Arc<RwLock<AtomTable>>) {
+    pub fn set_atoms_for_completion(&mut self, atoms: &Arc<AtomTable>) {
         #[cfg(feature = "repl")]
         {
             let helper = self.rl.helper_mut().unwrap();
@@ -291,7 +288,7 @@ impl CharRead for ReadlineStream {
 pub(crate) fn write_term_to_heap<'a, 'b>(
     term: &'a Term,
     heap: &'b mut Heap,
-    atom_tbl: &RwLock<AtomTable>,
+    atom_tbl: &AtomTable,
 ) -> Result<TermWriteResult, CompilationError> {
     let term_writer = TermWriter::new(heap, atom_tbl);
     term_writer.write_term_to_heap(term)
@@ -300,7 +297,7 @@ pub(crate) fn write_term_to_heap<'a, 'b>(
 #[derive(Debug)]
 struct TermWriter<'a, 'b> {
     heap: &'a mut Heap,
-    atom_tbl: &'b RwLock<AtomTable>,
+    atom_tbl: &'b AtomTable,
     queue: SubtermDeque,
     var_dict: HeapVarDict,
 }
@@ -313,7 +310,7 @@ pub struct TermWriteResult {
 
 impl<'a, 'b> TermWriter<'a, 'b> {
     #[inline]
-    fn new(heap: &'a mut Heap, atom_tbl: &'b RwLock<AtomTable>) -> Self {
+    fn new(heap: &'a mut Heap, atom_tbl: &'b AtomTable) -> Self {
         TermWriter {
             heap,
             atom_tbl,

--- a/src/repl_helper.rs
+++ b/src/repl_helper.rs
@@ -1,9 +1,9 @@
 use indexmap::IndexSet;
-use rustyline::completion::{Completer, Candidate};
+use rustyline::completion::{Candidate, Completer};
+use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
 use rustyline::hint::Hinter;
 use rustyline::validate::Validator;
-use rustyline::highlight::{MatchingBracketHighlighter, Highlighter};
-use rustyline::{Helper as RlHelper, Result, Context};
+use rustyline::{Context, Helper as RlHelper, Result};
 
 use crate::atom_table::{Atom, STATIC_ATOMS_MAP};
 
@@ -43,7 +43,7 @@ fn get_prefix(line: &str, pos: usize) -> Option<usize> {
         }
 
         if i == pos {
-            break
+            break;
         }
     }
 
@@ -58,27 +58,29 @@ pub struct StrPtr(*const str);
 
 impl Candidate for StrPtr {
     fn display(&self) -> &str {
-        unsafe {
-            self.0.as_ref().unwrap()
-        }
+        unsafe { self.0.as_ref().unwrap() }
     }
 
     fn replacement(&self) -> &str {
-        unsafe {
-            self.0.as_ref().unwrap()
-        }
+        unsafe { self.0.as_ref().unwrap() }
     }
 }
 
 impl Completer for Helper {
     type Candidate = StrPtr;
 
-    fn complete(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Result<(usize, Vec<Self::Candidate>)> {
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> Result<(usize, Vec<Self::Candidate>)> {
         let start_of_prefix = get_prefix(line, pos);
         if let Some(idx) = start_of_prefix {
             let sub_str = line.get(idx..pos).unwrap();
             Ok((idx, unsafe {
-                let mut matching = (*self.atoms).iter()
+                let mut matching = (*self.atoms)
+                    .iter()
                     .chain(STATIC_ATOMS_MAP.values())
                     .filter(|a| a.as_str().starts_with(sub_str))
                     .map(|s| StrPtr(s.as_str()))

--- a/src/repl_helper.rs
+++ b/src/repl_helper.rs
@@ -70,11 +70,13 @@ impl Completer for Helper {
         if let Some(idx) = start_of_prefix {
             let sub_str = line.get(idx..pos).unwrap();
 
-            let guard = tokio::runtime::Handle::current()
-                .block_on(self.atoms.upgrade().unwrap().read_owned());
+            let atom_table = self.atoms.upgrade().unwrap();
+            println!("locking atom table to load completions");
+            let guard = atom_table.blocking_read();
 
             let mut matching = guard
                 .table
+                .blocking_read()
                 .iter()
                 .chain(STATIC_ATOMS_MAP.values())
                 .map(|a| a.as_str())

--- a/src/repl_helper.rs
+++ b/src/repl_helper.rs
@@ -70,7 +70,7 @@ impl Completer for Helper {
 
             let atom_table = self.atoms.upgrade().unwrap();
 
-            let index_set = atom_table.active_epoch().table.blocking_read().clone();
+            let index_set = atom_table.active_table();
 
             let mut matching = index_set
                 .iter()

--- a/src/repl_helper.rs
+++ b/src/repl_helper.rs
@@ -71,7 +71,6 @@ impl Completer for Helper {
             let sub_str = line.get(idx..pos).unwrap();
 
             let atom_table = self.atoms.upgrade().unwrap();
-            println!("locking atom table to load completions");
             let guard = atom_table.blocking_read();
 
             let mut matching = guard

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,7 +24,7 @@ pub enum HeapCellValueTag {
     PStrOffset = 0b001111,
     // constants.
     Cons = 0b0,
-    F64  = 0b010001,
+    F64 = 0b010001,
     Fixnum = 0b010011,
     Char = 0b010101,
     Atom = 0b010111,
@@ -45,7 +45,7 @@ pub enum HeapCellValueView {
     PStrOffset = 0b001111,
     // constants.
     Cons = 0b0,
-    F64  = 0b010001,
+    F64 = 0b010001,
     Fixnum = 0b010011,
     Char = 0b010101,
     Atom = 0b010111,
@@ -56,9 +56,9 @@ pub enum HeapCellValueView {
     TrailedHeapVar = 0b101111,
     TrailedStackVar = 0b101011,
     TrailedAttrVar = 0b100001,
-    TrailedAttrVarListLink =  0b100011,
-    TrailedAttachedValue =    0b100101,
-    TrailedBlackboardEntry =  0b100111,
+    TrailedAttrVarListLink = 0b100011,
+    TrailedAttachedValue = 0b100101,
+    TrailedBlackboardEntry = 0b100111,
     TrailedBlackboardOffset = 0b110011,
 }
 
@@ -88,7 +88,7 @@ impl ConsPtr {
             .with_tag(tag)
     }
 
-    #[cfg(target_pointer_width="32")]
+    #[cfg(target_pointer_width = "32")]
     #[inline(always)]
     pub fn as_ptr(self) -> *mut u8 {
         let bytes = self.into_bytes();
@@ -96,7 +96,7 @@ impl ConsPtr {
         unsafe { mem::transmute(raw_ptr_bytes) }
     }
 
-    #[cfg(target_pointer_width="64")]
+    #[cfg(target_pointer_width = "64")]
     #[inline(always)]
     pub fn as_ptr(self) -> *mut u8 {
         self.ptr() as *mut _
@@ -121,28 +121,24 @@ pub(crate) enum RefTag {
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Ref {
     val: B56,
-    #[allow(unused)] m: bool,
-    #[allow(unused)] f: bool,
+    #[allow(unused)]
+    m: bool,
+    #[allow(unused)]
+    f: bool,
     tag: RefTag,
 }
 
 impl Ord for Ref {
     fn cmp(&self, rhs: &Ref) -> Ordering {
         match self.get_tag() {
-            RefTag::HeapCell | RefTag::AttrVar => {
-                match rhs.get_tag() {
-                    RefTag::StackCell => Ordering::Less,
-                    _ => self.get_value().cmp(&rhs.get_value()),
-                }
-            }
-            RefTag::StackCell => {
-                match rhs.get_tag() {
-                    RefTag::StackCell =>
-                        self.get_value().cmp(&rhs.get_value()),
-                    _ =>
-                        Ordering::Greater,
-                }
-            }
+            RefTag::HeapCell | RefTag::AttrVar => match rhs.get_tag() {
+                RefTag::StackCell => Ordering::Less,
+                _ => self.get_value().cmp(&rhs.get_value()),
+            },
+            RefTag::StackCell => match rhs.get_tag() {
+                RefTag::StackCell => self.get_value().cmp(&rhs.get_value()),
+                _ => Ordering::Greater,
+            },
         }
     }
 }
@@ -204,9 +200,9 @@ pub(crate) enum TrailEntryTag {
     TrailedHeapVar = 0b101111,
     TrailedStackVar = 0b101011,
     TrailedAttrVar = 0b100001,
-    TrailedAttrVarListLink =  0b100011,
-    TrailedAttachedValue =    0b100101,
-    TrailedBlackboardEntry =  0b100111,
+    TrailedAttrVarListLink = 0b100011,
+    TrailedAttachedValue = 0b100101,
+    TrailedBlackboardEntry = 0b100111,
     TrailedBlackboardOffset = 0b110011,
 }
 
@@ -215,9 +211,12 @@ pub(crate) enum TrailEntryTag {
 #[repr(u64)]
 pub(crate) struct TrailEntry {
     val: B56,
-    #[allow(unused)] f: bool,
-    #[allow(unused)] m: bool,
-    #[allow(unused)] tag: TrailEntryTag,
+    #[allow(unused)]
+    f: bool,
+    #[allow(unused)]
+    m: bool,
+    #[allow(unused)]
+    tag: TrailEntryTag,
 }
 
 impl TrailEntry {
@@ -233,9 +232,9 @@ impl TrailEntry {
     #[inline(always)]
     pub(crate) fn get_tag(self) -> TrailEntryTag {
         match self.tag_or_err() {
-	        Ok(tag) => tag,
-	        Err(_) => TrailEntryTag::TrailedAttachedValue,
-	    }
+            Ok(tag) => tag,
+            Err(_) => TrailEntryTag::TrailedAttachedValue,
+        }
     }
 
     #[inline]
@@ -257,14 +256,13 @@ pub struct HeapCellValue {
 impl fmt::Debug for HeapCellValue {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> fmt::Result {
         match self.get_tag() {
-            HeapCellValueTag::F64 => {
-                f.debug_struct("HeapCellValue")
-                    .field("tag", &HeapCellValueTag::F64)
-                    .field("offset", &self.get_value())
-                    .field("m", &self.m())
-                    .field("f", &self.f())
-                    .finish()
-            }
+            HeapCellValueTag::F64 => f
+                .debug_struct("HeapCellValue")
+                .field("tag", &HeapCellValueTag::F64)
+                .field("offset", &self.get_value())
+                .field("m", &self.m())
+                .field("f", &self.f())
+                .finish(),
             HeapCellValueTag::Cons => {
                 let cons_ptr = ConsPtr::from_bytes(self.into_bytes());
 
@@ -276,8 +274,7 @@ impl fmt::Debug for HeapCellValue {
                     .finish()
             }
             HeapCellValueTag::Atom => {
-                let (name, arity) = cell_as_atom_cell!(self)
-                     .get_name_and_arity();
+                let (name, arity) = cell_as_atom_cell!(self).get_name_and_arity();
 
                 f.debug_struct("HeapCellValue")
                     .field("tag", &HeapCellValueTag::Atom)
@@ -288,8 +285,7 @@ impl fmt::Debug for HeapCellValue {
                     .finish()
             }
             HeapCellValueTag::PStr => {
-                let (name, _) = cell_as_atom_cell!(self)
-                     .get_name_and_arity();
+                let (name, _) = cell_as_atom_cell!(self).get_name_and_arity();
 
                 f.debug_struct("HeapCellValue")
                     .field("tag", &HeapCellValueTag::PStr)
@@ -298,14 +294,13 @@ impl fmt::Debug for HeapCellValue {
                     .field("f", &self.f())
                     .finish()
             }
-            tag => {
-                f.debug_struct("HeapCellValue")
-                    .field("tag", &tag)
-                    .field("value", &self.get_value())
-                    .field("m", &self.get_mark_bit())
-                    .field("f", &self.get_forwarding_bit())
-                    .finish()
-            }
+            tag => f
+                .debug_struct("HeapCellValue")
+                .field("tag", &tag)
+                .field("value", &self.get_value())
+                .field("m", &self.get_mark_bit())
+                .field("f", &self.get_forwarding_bit())
+                .finish(),
         }
     }
 }
@@ -320,10 +315,7 @@ impl<T: ArenaAllocated> From<TypedArenaPtr<T>> for HeapCellValue {
 impl From<F64Ptr> for HeapCellValue {
     #[inline]
     fn from(f64_ptr: F64Ptr) -> HeapCellValue {
-        HeapCellValue::build_with(
-            HeapCellValueTag::F64,
-            f64_ptr.as_offset().to_u64(),
-        )
+        HeapCellValue::build_with(HeapCellValueTag::F64, f64_ptr.as_offset().to_u64())
     }
 }
 
@@ -402,9 +394,13 @@ impl HeapCellValue {
     #[inline]
     pub fn is_ref(self) -> bool {
         match self.get_tag() {
-            HeapCellValueTag::Str | HeapCellValueTag::Lis | HeapCellValueTag::Var |
-            HeapCellValueTag::StackVar | HeapCellValueTag::AttrVar | HeapCellValueTag::PStrLoc |
-            HeapCellValueTag::PStrOffset => true,
+            HeapCellValueTag::Str
+            | HeapCellValueTag::Lis
+            | HeapCellValueTag::Var
+            | HeapCellValueTag::StackVar
+            | HeapCellValueTag::AttrVar
+            | HeapCellValueTag::PStrLoc
+            | HeapCellValueTag::PStrOffset => true,
             _ => false,
         }
     }
@@ -431,16 +427,13 @@ impl HeapCellValue {
     #[inline]
     pub fn is_constant(self) -> bool {
         match self.get_tag() {
-            HeapCellValueTag::Cons | HeapCellValueTag::F64 | HeapCellValueTag::Fixnum |
-            HeapCellValueTag::Char | HeapCellValueTag::CStr => {
-                true
-            }
-            HeapCellValueTag::Atom => {
-                cell_as_atom_cell!(self).get_arity() == 0
-            }
-            _ => {
-                false
-            }
+            HeapCellValueTag::Cons
+            | HeapCellValueTag::F64
+            | HeapCellValueTag::Fixnum
+            | HeapCellValueTag::Char
+            | HeapCellValueTag::CStr => true,
+            HeapCellValueTag::Atom => cell_as_atom_cell!(self).get_arity() == 0,
+            _ => false,
         }
     }
 
@@ -455,17 +448,13 @@ impl HeapCellValue {
             HeapCellValueTag::Str => {
                 cell_as_atom_cell!(heap[self.get_value() as usize]).get_arity() > 0
             }
-            HeapCellValueTag::Lis |
-            HeapCellValueTag::CStr |
-            HeapCellValueTag::PStr |
-            HeapCellValueTag::PStrLoc |
-            HeapCellValueTag::PStrOffset => {
-               true
-            }
-            HeapCellValueTag::Atom => {
-                cell_as_atom_cell!(self).get_arity() > 0
-            }
-            _ => { false }
+            HeapCellValueTag::Lis
+            | HeapCellValueTag::CStr
+            | HeapCellValueTag::PStr
+            | HeapCellValueTag::PStrLoc
+            | HeapCellValueTag::PStrOffset => true,
+            HeapCellValueTag::Atom => cell_as_atom_cell!(self).get_arity() > 0,
+            _ => false,
         }
     }
 
@@ -530,9 +519,7 @@ impl HeapCellValue {
     #[inline]
     pub fn to_pstr(self) -> Option<PartialString> {
         match self.tag() {
-            HeapCellValueTag::PStr => {
-                Some(PartialString::from(Atom::from(self.val() << 3)))
-            }
+            HeapCellValueTag::PStr => Some(PartialString::from(Atom::from(self.val() << 3))),
             _ => None,
         }
     }
@@ -545,26 +532,35 @@ impl HeapCellValue {
         }
     }
 
-    #[cfg(target_pointer_width="32")]
+    #[cfg(target_pointer_width = "32")]
     #[inline]
     pub fn from_raw_ptr_bytes(ptr_bytes: [u8; 4]) -> Self {
-        HeapCellValue::from_bytes([ptr_bytes[0], ptr_bytes[1], ptr_bytes[2], ptr_bytes[3], 0, 0, 0, 0])
+        HeapCellValue::from_bytes([
+            ptr_bytes[0],
+            ptr_bytes[1],
+            ptr_bytes[2],
+            ptr_bytes[3],
+            0,
+            0,
+            0,
+            0,
+        ])
     }
-    #[cfg(target_pointer_width="64")]
+    #[cfg(target_pointer_width = "64")]
     #[inline]
     pub fn from_raw_ptr_bytes(ptr_bytes: [u8; 8]) -> Self {
         HeapCellValue::from_bytes(ptr_bytes)
     }
 
     #[inline]
-    #[cfg(target_pointer_width="32")]
+    #[cfg(target_pointer_width = "32")]
     pub fn to_raw_ptr_bytes(self) -> [u8; 4] {
         let bytes = self.into_bytes();
         [bytes[0], bytes[1], bytes[2], bytes[3]]
     }
 
     #[inline]
-    #[cfg(target_pointer_width="64")]
+    #[cfg(target_pointer_width = "64")]
     pub fn to_raw_ptr_bytes(self) -> [u8; 8] {
         self.into_bytes()
     }
@@ -577,7 +573,9 @@ impl HeapCellValue {
     #[inline]
     pub fn to_untyped_arena_ptr(self) -> Option<UntypedArenaPtr> {
         match self.get_tag() {
-            HeapCellValueTag::Cons => Some(UntypedArenaPtr::from_bytes(self.to_untyped_arena_ptr_bytes())),
+            HeapCellValueTag::Cons => Some(UntypedArenaPtr::from_bytes(
+                self.to_untyped_arena_ptr_bytes(),
+            )),
             _ => None,
         }
     }
@@ -586,7 +584,7 @@ impl HeapCellValue {
     pub fn get_forwarding_bit(self) -> bool {
         match self.get_tag() {
             HeapCellValueTag::Cons => ConsPtr::from_bytes(self.into_bytes()).f(),
-            _ => self.f()
+            _ => self.f(),
         }
     }
 
@@ -604,9 +602,7 @@ impl HeapCellValue {
     #[inline(always)]
     pub fn get_mark_bit(self) -> bool {
         match self.get_tag() {
-            HeapCellValueTag::Cons => {
-                ConsPtr::from_bytes(self.into_bytes()).m()
-            }
+            HeapCellValueTag::Cons => ConsPtr::from_bytes(self.into_bytes()).m(),
             _ => self.m(),
         }
     }
@@ -633,15 +629,12 @@ impl HeapCellValue {
                     Some(TermOrderCategory::Variable)
                 }
                 HeapCellValueTag::Char => Some(TermOrderCategory::Atom),
-                HeapCellValueTag::Atom => {
-                    Some(if cell_as_atom_cell!(self).get_arity() > 0 {
-                        TermOrderCategory::Compound
-                    } else {
-                        TermOrderCategory::Atom
-                    })
-                }
-                HeapCellValueTag::Lis | HeapCellValueTag::PStrLoc |
-                HeapCellValueTag::CStr => {
+                HeapCellValueTag::Atom => Some(if cell_as_atom_cell!(self).get_arity() > 0 {
+                    TermOrderCategory::Compound
+                } else {
+                    TermOrderCategory::Atom
+                }),
+                HeapCellValueTag::Lis | HeapCellValueTag::PStrLoc | HeapCellValueTag::CStr => {
                     Some(TermOrderCategory::Compound)
                 }
                 HeapCellValueTag::Str => {
@@ -654,9 +647,7 @@ impl HeapCellValue {
                         Some(TermOrderCategory::Compound)
                     }
                 }
-                _ => {
-                    None
-                }
+                _ => None,
             },
         }
     }
@@ -680,16 +671,17 @@ const_assert!(mem::size_of::<HeapCellValue>() == 8);
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UntypedArenaPtr {
-    #[allow(unused)] ptr: B61,
+    #[allow(unused)]
+    ptr: B61,
     m: bool,
-    #[allow(unused)] padding: B2,
+    #[allow(unused)]
+    padding: B2,
 }
 
 impl UntypedArenaPtr {
     #[inline(always)]
     pub fn build_with(ptr: usize) -> Self {
-        UntypedArenaPtr::new()
-            .with_ptr(ptr as u64)
+        UntypedArenaPtr::new().with_ptr(ptr as u64)
     }
 }
 
@@ -722,7 +714,7 @@ impl UntypedArenaPtr {
         self.set_m(m);
     }
 
-    #[cfg(target_pointer_width="32")]
+    #[cfg(target_pointer_width = "32")]
     #[inline]
     pub fn get_ptr(self) -> *const u8 {
         let bytes = self.into_bytes();
@@ -730,10 +722,10 @@ impl UntypedArenaPtr {
         unsafe { mem::transmute(raw_ptr_bytes) }
     }
 
-    #[cfg(target_pointer_width="64")]
+    #[cfg(target_pointer_width = "64")]
     #[inline]
     pub fn get_ptr(self) -> *const u8 {
-        self.ptr() as *const u8    
+        self.ptr() as *const u8
     }
 
     #[inline]
@@ -763,17 +755,15 @@ impl Add<usize> for HeapCellValue {
 
     fn add(self, rhs: usize) -> Self::Output {
         match self.get_tag() {
-            tag @ HeapCellValueTag::Str |
-            tag @ HeapCellValueTag::Lis |
-            tag @ HeapCellValueTag::PStrOffset |
-            tag @ HeapCellValueTag::PStrLoc |
-            tag @ HeapCellValueTag::Var |
-            tag @ HeapCellValueTag::AttrVar => {
+            tag @ HeapCellValueTag::Str
+            | tag @ HeapCellValueTag::Lis
+            | tag @ HeapCellValueTag::PStrOffset
+            | tag @ HeapCellValueTag::PStrLoc
+            | tag @ HeapCellValueTag::Var
+            | tag @ HeapCellValueTag::AttrVar => {
                 HeapCellValue::build_with(tag, (self.get_value() as usize + rhs) as u64)
             }
-            _ => {
-                self
-            }
+            _ => self,
         }
     }
 }
@@ -783,17 +773,15 @@ impl Sub<usize> for HeapCellValue {
 
     fn sub(self, rhs: usize) -> Self::Output {
         match self.get_tag() {
-            tag @ HeapCellValueTag::Str |
-            tag @ HeapCellValueTag::Lis |
-            tag @ HeapCellValueTag::PStrOffset |
-            tag @ HeapCellValueTag::PStrLoc |
-            tag @ HeapCellValueTag::Var |
-            tag @ HeapCellValueTag::AttrVar => {
+            tag @ HeapCellValueTag::Str
+            | tag @ HeapCellValueTag::Lis
+            | tag @ HeapCellValueTag::PStrOffset
+            | tag @ HeapCellValueTag::PStrLoc
+            | tag @ HeapCellValueTag::Var
+            | tag @ HeapCellValueTag::AttrVar => {
                 HeapCellValue::build_with(tag, (self.get_value() as usize - rhs) as u64)
             }
-            _ => {
-                self
-            }
+            _ => self,
         }
     }
 }
@@ -811,21 +799,18 @@ impl Sub<i64> for HeapCellValue {
     fn sub(self, rhs: i64) -> Self::Output {
         if rhs < 0 {
             match self.get_tag() {
-                tag @ HeapCellValueTag::Str |
-                tag @ HeapCellValueTag::Lis |
-                tag @ HeapCellValueTag::PStrOffset |
-                tag @ HeapCellValueTag::PStrLoc |
-                tag @ HeapCellValueTag::Var |
-                tag @ HeapCellValueTag::AttrVar => {
+                tag @ HeapCellValueTag::Str
+                | tag @ HeapCellValueTag::Lis
+                | tag @ HeapCellValueTag::PStrOffset
+                | tag @ HeapCellValueTag::PStrLoc
+                | tag @ HeapCellValueTag::Var
+                | tag @ HeapCellValueTag::AttrVar => {
                     HeapCellValue::build_with(tag, self.get_value() + rhs.abs() as u64)
                 }
-                _ => {
-                    self
-                }
+                _ => self,
             }
         } else {
             self.sub(rhs as usize)
         }
     }
 }
-

--- a/src/variable_records.rs
+++ b/src/variable_records.rs
@@ -56,8 +56,10 @@ impl VarSafetyStatus {
 
 #[derive(Debug, Clone, Copy)]
 pub enum PermVarAllocation {
-    Done { shallow_safety: VarSafetyStatus,
-           deep_safety: VarSafetyStatus },
+    Done {
+        shallow_safety: VarSafetyStatus,
+        deep_safety: VarSafetyStatus,
+    },
     Pending,
 }
 
@@ -81,11 +83,13 @@ impl PermVarAllocation {
 
 #[derive(Debug, Clone)]
 pub enum VarAlloc {
-    Temp { term_loc: GenContext,
-           temp_reg: usize,
-           temp_var_data: TempVarData,
-           safety: VarSafetyStatus,
-           to_perm_var_num: Option<usize> },
+    Temp {
+        term_loc: GenContext,
+        temp_reg: usize,
+        temp_var_data: TempVarData,
+        safety: VarSafetyStatus,
+        to_perm_var_num: Option<usize>,
+    },
     Perm(usize, PermVarAllocation), // stack offset, allocation info
 }
 
@@ -102,7 +106,9 @@ impl VarAlloc {
     pub(crate) fn set_register(&mut self, reg_num: usize) {
         match self {
             VarAlloc::Perm(ref mut p, _) => *p = reg_num,
-            VarAlloc::Temp { ref mut temp_reg, .. } => *temp_reg = reg_num,
+            VarAlloc::Temp {
+                ref mut temp_reg, ..
+            } => *temp_reg = reg_num,
         };
     }
 }
@@ -191,7 +197,8 @@ impl VariableRecords {
         // Compute the conflict set of u.
 
         // 1.
-        let mut use_sets: IndexMap<usize, IndexSet<(GenContext, usize), FxBuildHasher>> = IndexMap::new();
+        let mut use_sets: IndexMap<usize, IndexSet<(GenContext, usize), FxBuildHasher>> =
+            IndexMap::new();
 
         for (var_gen_index, record) in self.0.iter_mut().enumerate() {
             match &mut record.allocation {
@@ -203,8 +210,7 @@ impl VariableRecords {
 
                     use_sets.insert(var_gen_index, use_set);
                 }
-                _ => {
-                }
+                _ => {}
             }
         }
 
@@ -214,7 +220,11 @@ impl VariableRecords {
                 if let GenContext::Last(cn_u) = term_loc {
                     for (var_gen_index, record) in self.0.iter_mut().enumerate() {
                         match &mut record.allocation {
-                            VarAlloc::Temp { term_loc, temp_var_data, .. } => {
+                            VarAlloc::Temp {
+                                term_loc,
+                                temp_var_data,
+                                ..
+                            } => {
                                 if cn_u == term_loc.chunk_num() && u != var_gen_index {
                                     if !temp_var_data.uses_reg(reg) {
                                         temp_var_data.no_use_set.insert(reg);
@@ -228,7 +238,7 @@ impl VariableRecords {
             }
 
             // 3.
-            if let VarAlloc::Temp{ temp_var_data, .. } = &mut self[u].allocation {
+            if let VarAlloc::Temp { temp_var_data, .. } = &mut self[u].allocation {
                 temp_var_data.use_set = use_set;
                 temp_var_data.populate_conflict_set();
             }

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -1,5 +1,4 @@
 use crate::helper::{load_module_test, run_top_level_test_no_args, run_top_level_test_with_args};
-use scryer_prolog::machine::Machine;
 use serial_test::serial;
 
 // issue #857
@@ -170,17 +169,4 @@ fn call_0() {
         "tests-pl/issue831-call0.pl",
         "   error(existence_error(procedure,call/0),call/0).\n",
     );
-}
-
-// issue #1206
-#[serial]
-#[test]
-#[should_panic(expected = "Overwriting atom table base pointer")]
-fn atomtable_is_not_concurrency_safe() {
-    // this is basically the same test as scryer_prolog::atom_table::atomtable_is_not_concurrency_safe
-    // but for this integration test scryer_prolog is compiled with cfg!(not(test))  while for the unit test it is compiled with cfg!(test)
-    // as the atom table implementation differ between cfg!(test) and cfg!(not(test)) both test serve a pourpose
-    // Note: this integration test itself is compiled with cfg!(test) independent of scryer_prolog itself
-    let _machine_a = Machine::with_test_streams();
-    let _machine_b = Machine::with_test_streams();
 }

--- a/tests/scryer/src_tests.rs
+++ b/tests/scryer/src_tests.rs
@@ -73,8 +73,5 @@ fn clpz_load() {
 #[serial]
 #[test]
 fn iso_conformity_tests() {
-    load_module_test(
-        "tests-pl/iso-conformity-tests.pl",
-        "All tests passed",
-    );
+    load_module_test("tests-pl/iso-conformity-tests.pl", "All tests passed");
 }


### PR DESCRIPTION
This makes it possible to use multiple machines at the same time and removes one obstacle for moving a Machine to a different thread.

~~Note: currently searching for the reason that all integration test appear deadlock immediatly, unittest already work.~~
~~Update: Found the deadlock, now investigating the slow down, though its probably just a bunch of RwLock locking that can't be easily remedied.~~