### PR TITLE
fix Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,12 @@ COPY --from=cacher /scryer-prolog/target target
 COPY --from=cacher $CARGO_HOME $CARGO_HOME
 RUN cargo build --release --bin scryer-prolog
 
-FROM debian:stable-slim
+# Newer versions of Debian (i.e. bookworm) contain libssl3 instead of libssl1.1 
+# which we depend on.
+FROM debian:bullseye-slim
 COPY --from=builder /scryer-prolog/target/release/scryer-prolog /usr/local/bin
 ENV RUST_BACKTRACE=1
+# Sanity check the binary: if it can't be executed (e.g. if there are missing libraries) 
+# then fail the build
+RUN scryer-prolog --version
 ENTRYPOINT ["/usr/local/bin/scryer-prolog"]


### PR DESCRIPTION
The Docker image is broken with the error message:

    scryer-prolog: error while loading shared libraries:
    libssl.so.1.1: cannot open shared object file: No such
    file or directory

We use the base base image `debian:stable-slim` and in the background a new Debian version was marked stable (bookworm), which has libssl3 instead of libssl1.1 installed.

I downgraded the base image to the previous stable version (bullseye), which seems to fix the issue.