### PR TITLE
Use a SeedableRng to generate random numbers

### DIFF
--- a/src/machine/mock_wam.rs
+++ b/src/machine/mock_wam.rs
@@ -246,6 +246,7 @@ impl Machine {
             runtime,
             #[cfg(feature = "ffi")]
             foreign_function_table: Default::default(),
+	    rng: StdRng::from_entropy(),
         };
 
         let mut lib_path = current_dir();

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -54,6 +54,8 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use tokio::runtime::Runtime;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 
 lazy_static! {
     pub static ref INTERRUPT: AtomicBool = AtomicBool::new(false);
@@ -71,6 +73,7 @@ pub struct Machine {
     pub(super) runtime: Runtime,
     #[cfg(feature = "ffi")]
     pub(super) foreign_function_table: ForeignFunctionTable,
+    pub(super) rng: StdRng,
 }
 
 #[derive(Debug)]
@@ -472,6 +475,7 @@ impl Machine {
             runtime,
             #[cfg(feature = "ffi")]
             foreign_function_table: Default::default(),
+	    rng: StdRng::from_entropy(),
         };
 
         let mut lib_path = current_dir();


### PR DESCRIPTION
Until now, set_random wasn't really useful (#1985) because we were not using that random generator in `maybe/0`. With this, we can get deterministic random numbers based on a seed. By default, it will just take a seed from the system, as before.

```
?- use_module(library(random)).
   true.
?- random_integer(0, 100, N).
   N = 13.
?- set_random(seed(42)).
   true
;  ... .
?- random_integer(0, 100, N).
   N = 57.
?- random_integer(0, 100, N).
   N = 21.
?- random_integer(0, 100, N).
   N = 55.
?- set_random(seed(42)).
   true
;  ... .
?- random_integer(0, 100, N).
   N = 57.
?- random_integer(0, 100, N).
   N = 21.
?- random_integer(0, 100, N).
   N = 55. 
```