### PR TITLE
Allow all matrix ci jobs to run to completion even if one fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   build-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - { os: windows-latest, rust-version: stable,  shell: 'msys2 {0}', target: 'x86_64-pc-windows-gnu'}


### PR DESCRIPTION
See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast