### PR TITLE
FIXED: corrections to expansion_simpler/2

### DIFF
--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -3099,13 +3099,13 @@ expansion_simpler(Var is Expr0, Goal) :-
         ground(Expr0), !,
         phrase(expr_conds(Expr0, Expr), Gs),
         (   maplist(call, Gs) -> Value is Expr, Goal = (Var = Value)
-        ;   Goal = false
+        ;   Goal = (Var is Expr0)
         ).
 expansion_simpler(Var =:= Expr0, Goal) :-
         ground(Expr0), !,
         phrase(expr_conds(Expr0, Expr), Gs),
         (   maplist(call, Gs) -> Value is Expr, Goal = (Var =:= Value)
-        ;   Goal = false
+        ;   Goal = (Var =:= Expr0)
         ).
 expansion_simpler(between:between(L,U,V), Goal) :-
         maplist(integer, [L,U,V]),


### PR DESCRIPTION
Example:

    ?- X = 0, Y = 0, Z #= X-1 + Y-1.
       X = 0, Y = 0, Z = -2.

This addresses #2064.

See ca5a5b4392bfbed8cfdbb3b2e7dbaa42ea193007 for a previous issue in this logic.