### PR TITLE
Revert "FIXED: corrections to expansion_simpler/2"

### DIFF
--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -3099,13 +3099,13 @@ expansion_simpler(Var is Expr0, Goal) :-
         ground(Expr0), !,
         phrase(expr_conds(Expr0, Expr), Gs),
         (   maplist(call, Gs) -> Value is Expr, Goal = (Var = Value)
-        ;   Goal = (Var is Expr0)
+        ;   Goal = false
         ).
 expansion_simpler(Var =:= Expr0, Goal) :-
         ground(Expr0), !,
         phrase(expr_conds(Expr0, Expr), Gs),
         (   maplist(call, Gs) -> Value is Expr, Goal = (Var =:= Value)
-        ;   Goal = (Var =:= Expr0)
+        ;   Goal = false
         ).
 expansion_simpler(between:between(L,U,V), Goal) :-
         maplist(integer, [L,U,V]),


### PR DESCRIPTION
This reverts commit f3b848537aef601b13bd525df09ee74f5bbeeae9.

The root cause of this problem is a mistake in ground/1. See #2073.