### PR TITLE
FIXED: Queue triggered propagators to be processed after pexp/3 finishes

### DIFF
--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -5498,7 +5498,9 @@ run_propagator(pexp(X,Y,Z), MState) -->
             )
         ;   nonvar(Y), Y > 0 ->
             (   { even(Y) } ->
-                { geq(Z, 0) }
+                { fd_get(Z, ZD0, ZPs0),
+                  domain_remove_smaller_than(ZD0, 0, ZDG0) },
+                fd_put(Z, ZDG0, ZPs0)
             ;   true
             ),
             (   { fd_get(X, XD, XL, XU, _), fd_get(Z, ZD, ZL, ZU, ZPs) } ->


### PR DESCRIPTION
If reification constraints (such as reified equality) are triggered here, then they may wish to disable this propagator and remove attributes from auxiliary variables. If the pexp/3 propagation is interrupted for that purpose, then the attributes will be unintentionally reattached by the following fd_put/3 calls in this propagator. We must ensure that this propagator completely finishes, so we queue the triggered propagators for later processing.

geq/2 implements propagator activation outside the queue, and thus should not be used in propagators in the way it was used here.

pexp/3 by itself may not seem particularly important. However, it can arise by metamorphosis from Var*Var. Example:

    ?- A#<==> -1#=C*C, C in 0..1.
       A = 0, clpz:(C in 0..1).

This addresses #2089.

@notoria: This may be interesting for you! I hope the description makes sufficiently clear what the issue is here: `geq/2`, as a regular Prolog predicate, does not have access to the implicit propagation queue, and so cannot insert the triggered constraints in the queue that is currently being worked off. Instead, it spawns a separate queue and immediately activates the triggered propagators. After this is done, further code in the propagator where this was started may accidentally "undo" the desired removal of attributes from auxiliary variables, by reattaching attributes to them that previous propagators have already removed.