### PR TITLE
Add predicates to work with struct pointers

### DIFF
--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -570,6 +570,12 @@ enum SystemClauseType {
     ForeignCall,
     #[strum_discriminants(strum(props(Arity = "2", Name = "$define_foreign_struct")))]
     DefineForeignStruct,
+    #[strum_discriminants(strum(props(Arity = "2", Name = "$alloc_struct_ptr")))]
+    AllocStructPtr,
+    #[strum_discriminants(strum(props(Arity = "3", Name = "$unfold_struct_ptr")))]
+    UnfoldStructPtr,
+    #[strum_discriminants(strum(props(Arity = "2", Name = "$dealloc_struct_ptr")))]
+    DeallocStructPtr,
     #[strum_discriminants(strum(props(Arity = "3", Name = "$predicate_defined")))]
     PredicateDefined,
     #[strum_discriminants(strum(props(Arity = "3", Name = "$strip_module")))]
@@ -1811,6 +1817,9 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::CallLoadForeignLib |
                     &Instruction::CallForeignCall |
                     &Instruction::CallDefineForeignStruct |
+                    &Instruction::CallAllocStructPtr |
+                    &Instruction::CallUnfoldStructPtr |
+		    &Instruction::CallDeallocStructPtr |
                     &Instruction::CallPredicateDefined |
                     &Instruction::CallStripModule |
                     &Instruction::CallCurrentTime |
@@ -2045,6 +2054,9 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::ExecuteLoadForeignLib |
                     &Instruction::ExecuteForeignCall |
                     &Instruction::ExecuteDefineForeignStruct |
+                    &Instruction::ExecuteAllocStructPtr |
+		    &Instruction::ExecuteUnfoldStructPtr |
+		    &Instruction::ExecuteDeallocStructPtr |
                     &Instruction::ExecutePredicateDefined |
                     &Instruction::ExecuteStripModule |
                     &Instruction::ExecuteCurrentTime |

--- a/src/lib/ffi.pl
+++ b/src/lib/ffi.pl
@@ -1,4 +1,4 @@
-:- module(ffi, [use_foreign_module/2, foreign_struct/2]).
+:- module(ffi, [use_foreign_module/2, foreign_struct/2, alloc_struct_ptr/2, unfold_struct_ptr/3, dealloc_struct_ptr/2]).
 
 /** Foreign Function Interface
 
@@ -102,3 +102,12 @@ assert_predicate(PredicateDefinition) :-
     ),
     Predicate = (Head:-Body),
     assertz(ffi:Predicate).
+
+alloc_struct_ptr(StructName, StructPtr) :-
+    '$alloc_struct_ptr'(StructName, StructPtr).
+
+unfold_struct_ptr(StructName, StructPtr, StructValue) :-
+    '$unfold_struct_ptr'(StructName, StructPtr, StructValue).
+
+dealloc_struct_ptr(StructName, StructPtr) :-
+    '$dealloc_struct_ptr'(StructName, StructPtr).

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -4187,6 +4187,36 @@ impl Machine {
                         try_or_throw!(self.machine_st, self.define_foreign_struct());
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }
+                    &Instruction::CallAllocStructPtr => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.alloc_struct_ptr());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteAllocStructPtr => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.alloc_struct_ptr());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallUnfoldStructPtr => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.unfold_struct_ptr());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteUnfoldStructPtr => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.unfold_struct_ptr());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallDeallocStructPtr => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.dealloc_struct_ptr());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteDeallocStructPtr => {
+                        #[cfg(feature = "ffi")]
+                        try_or_throw!(self.machine_st, self.dealloc_struct_ptr());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
                     &Instruction::CallCurrentTime => {
                         self.current_time();
                         step_or_fail!(self, self.machine_st.p += 1);


### PR DESCRIPTION
Some libraries like SDL require you to pass a struct that they fill. This was nearly impossible to do right now with our FFI interface, so three more predicates have been added.

```
SDL_Event event;
SDL_PollEvents(&event)
```

can be expressed as:

```
alloc_struct_ptr(sdl_event, Ptr),
ffi:'SDL_PollEvent'(Ptr, _),
unfold_struct_ptr(sdl_event, Ptr, [sdl_event, 512, ...]),
dealloc_struct_ptr(sdl_event, Ptr)
```
