### PR TITLE
Rename `to_upper` to `upper` and `to_lower` to `lower`

### DIFF
--- a/src/lib/charsio.pl
+++ b/src/lib/charsio.pl
@@ -105,8 +105,8 @@ extend_var_list_([V|Vs], N, VarList, NewVarList, VarType) :-
 % - `symbolic_control`
 % - `symbolic_hexadecimal`
 % - `upper`
-% - `to_lower(Lower)`
-% - `to_upper(Upper)`
+% - `lower(Lower)`
+% - `upper(Upper)`
 % - `whitespace`
 %
 % An example:
@@ -124,8 +124,8 @@ extend_var_list_([V|Vs], N, VarList, NewVarList, VarType) :-
 % ;  Type = octet
 % ;  Type = prolog
 % ;  Type = symbolic_control
-% ;  Type = to_lower("a")
-% ;  Type = to_upper("A")
+% ;  Type = lower("a")
+% ;  Type = upper("A")
 % ;  false.
 % ```
 %
@@ -168,8 +168,8 @@ ctype(sign).
 ctype(solo).
 ctype(symbolic_control).
 ctype(symbolic_hexadecimal).
-ctype(to_lower(_)).
-ctype(to_upper(_)).
+ctype(lower(_)).
+ctype(upper(_)).
 ctype(upper).
 ctype(whitespace).
 

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -2997,13 +2997,13 @@ impl Machine {
                     .get_name_and_arity();
 
                 match (name, arity) {
-                    (atom!("to_upper"), 1) => {
+                    (atom!("upper"), 1) => {
                         let reg = self.machine_st.deref(self.machine_st.heap[s+1]);
                         let atom = AtomTable::build_with(&self.machine_st.atom_tbl, &c.to_uppercase().to_string());
                         let upper_str = string_as_cstr_cell!(atom);
                         unify!(self.machine_st, reg, upper_str);
                     }
-                    (atom!("to_lower"), 1) => {
+                    (atom!("lower"), 1) => {
                         let reg = self.machine_st.deref(self.machine_st.heap[s+1]);
                         let atom = AtomTable::build_with(&self.machine_st.atom_tbl, &c.to_lowercase().to_string());
                         let lower_str = string_as_cstr_cell!(atom);


### PR DESCRIPTION
From discussion here: https://github.com/mthom/scryer-prolog/discussions/2129