### PR TITLE
Resolve all lints and formating; split style checks into separate job

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Resolved all lints and formatted the codebase
+9444e62df9820d6bfd96dbd8849e177bc5cecc2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,47 @@ on:
   workflow_dispatch:
 
 jobs:
+  style:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: nightly
+          targets: x86_64-unknown-linux-gnu
+          components: clippy, rustfmt
+      - run: cargo install cargo2junit --force
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: style_rustc-${{ steps.toolchain.outputs.cachekey }}_cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Check clippy
+        run: cargo clippy --no-deps --all-targets
+      - name: Test and report
+        run: |
+          RUSTC_BOOTSTRAP=1 cargo test --all -- -Z unstable-options --format json --report-time | cargo2junit > cargo_test_results.xml
+      - name: Publish cargo test results artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: cargo-test-results
+          path: cargo_test_results.xml
+      - name: Publish cargo test summary
+        uses: EnricoMi/publish-unit-test-result-action/composite@master
+        with:
+          check_name: Cargo test summary
+          files: cargo_test_results.xml
+          fail_on: nothing
+          comment_mode: off
+
   build-test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -18,13 +59,13 @@ jobs:
       matrix:
         include:
           # operating systems
-          - { os: windows-latest, rust-version: stable,  publish: true, target: 'x86_64-pc-windows-msvc'}
-          - { os: macos-11,       rust-version: stable,  publish: true, target: 'x86_64-apple-darwin' }
-          - { os: ubuntu-20.04,   rust-version: stable,  publish: true, target: 'x86_64-unknown-linux-gnu' }
+          - { os: windows-latest, rust-version: stable,  target: 'x86_64-pc-windows-msvc',   publish: true }
+          - { os: macos-11,       rust-version: stable,  target: 'x86_64-apple-darwin',      publish: true }
+          - { os: ubuntu-20.04,   rust-version: stable,  target: 'x86_64-unknown-linux-gnu', publish: true }
           # architectures
-          - { os: ubuntu-22.04,   rust-version: stable,  publish: true, target: 'x86_64-unknown-linux-gnu', extra: true }
-          - { os: ubuntu-22.04,   rust-version: stable,  publish: true, target: 'i686-unknown-linux-gnu' }
-          - { os: ubuntu-22.04,   rust-version: nightly, publish: true, target: 'wasm32-unknown-unknown', args: '--no-default-features' }
+          - { os: ubuntu-22.04,   rust-version: stable,  target: 'x86_64-unknown-linux-gnu', publish: true }
+          - { os: ubuntu-22.04,   rust-version: stable,  target: 'i686-unknown-linux-gnu',   publish: true }
+          - { os: ubuntu-22.04,   rust-version: nightly, target: 'wasm32-unknown-unknown',   publish: true, args: '--no-default-features' }
           # rust versions
           - { os: ubuntu-22.04,   rust-version: "1.70",  target: 'x86_64-unknown-linux-gnu'}
           - { os: ubuntu-22.04,   rust-version: beta,    target: 'x86_64-unknown-linux-gnu'}
@@ -39,7 +80,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-version }}
           targets: ${{ matrix.target }}
-          components: clippy, rustfmt
       - name: Install i686 dependencies
         if: "contains(matrix.target,'i686')"
         run: |
@@ -62,35 +102,7 @@ jobs:
       - name: Build library
         run: cargo rustc --lib --target ${{ matrix.target }} ${{ matrix.args }} --verbose
       - name: Test
-        if: "!matrix.extra"
         run: cargo test --target ${{ matrix.target }} ${{ matrix.args }} --all --verbose || echo "::warning ::Tests failed"
-
-      # Extra steps only run once to avoid duplication, when matrix.extra is true
-      - name: Test and report
-        if: matrix.extra
-        run: |
-          cargo install cargo2junit --force
-          RUSTC_BOOTSTRAP=1 cargo test --all -- -Z unstable-options --format json --report-time | cargo2junit > cargo_test_results.xml
-      - name: Publish cargo test results artifact
-        if: matrix.extra
-        uses: actions/upload-artifact@v3
-        with:
-          name: cargo-test-results
-          path: cargo_test_results.xml
-      - name: Publish cargo test summary
-        if: matrix.extra
-        uses: EnricoMi/publish-unit-test-result-action/composite@master
-        with:
-          check_name: Cargo test summary
-          files: cargo_test_results.xml
-          fail_on: nothing
-          comment_mode: off
-      - name: Check formatting
-        if: matrix.extra
-        run: cargo fmt --check || echo "::warning ::cargo fmt found some formatting changes that may improve readability"
-      - name: Check clippy
-        if: matrix.extra
-        run: cargo clippy --no-deps || echo "::warning ::cargo clippy found some code style changes that may be more idiomatic"
 
       # On stable rust builds, build a binary and publish as a github actions
       # artifact. These binaries could be useful for testing the pipeline but

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,7 +2032,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scryer-prolog"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "assert_cmd",
  "base64 0.12.3",

--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -31,6 +31,7 @@ struct Level;
 struct NextOrFail;
 struct RegType;
 
+#[allow(clippy::enum_variant_names)]
 #[allow(dead_code)]
 #[derive(ToDeriveInput, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumProperty, EnumString))]
@@ -49,6 +50,7 @@ enum CompareNumber {
     NumberEqual(ArithmeticTerm, ArithmeticTerm),
 }
 
+#[allow(clippy::enum_variant_names)]
 #[allow(dead_code)]
 #[derive(ToDeriveInput, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumProperty, EnumString))]
@@ -206,6 +208,7 @@ enum REPLCodePtr {
     AddNonCountedBacktracking,
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[allow(dead_code)]
 #[derive(ToDeriveInput, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumProperty, EnumString))]
@@ -897,13 +900,13 @@ fn generate_instruction_preface() -> TokenStream {
         }
 
         impl ArithmeticTerm {
-            fn into_functor(&self, arena: &mut Arena) -> MachineStub {
+            fn into_functor(self, arena: &mut Arena) -> MachineStub {
                 match self {
-                    &ArithmeticTerm::Reg(r) => reg_type_into_functor(r),
-                    &ArithmeticTerm::Interm(i) => {
+                    ArithmeticTerm::Reg(r) => reg_type_into_functor(r),
+                    ArithmeticTerm::Interm(i) => {
                         functor!(atom!("intermediate"), [fixnum(i)])
                     }
-                    &ArithmeticTerm::Number(n) => {
+                    ArithmeticTerm::Number(n) => {
                         vec![HeapCellValue::from((n, arena))]
                     }
                 }
@@ -925,24 +928,15 @@ fn generate_instruction_preface() -> TokenStream {
         impl NextOrFail {
             #[inline]
             pub fn is_next(&self) -> bool {
-                if let NextOrFail::Next(_) = self {
-                    true
-                } else {
-                    false
-                }
+                matches!(self, NextOrFail::Next(_))
             }
         }
 
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
         pub enum Death {
             Finite(usize),
+            #[default]
             Infinity,
-        }
-
-        impl Default for Death {
-            fn default() -> Self {
-                Death::Infinity
-            }
         }
 
         #[derive(Clone, Copy, Debug)]
@@ -956,30 +950,30 @@ fn generate_instruction_preface() -> TokenStream {
 
         impl IndexedChoiceInstruction {
             pub(crate) fn offset(&self) -> usize {
-                match self {
-                    &IndexedChoiceInstruction::Retry(offset) => offset,
-                    &IndexedChoiceInstruction::Trust(offset) => offset,
-                    &IndexedChoiceInstruction::Try(offset) => offset,
-                    &IndexedChoiceInstruction::DefaultRetry(offset) => offset,
-                    &IndexedChoiceInstruction::DefaultTrust(offset) => offset,
+                match *self {
+                    IndexedChoiceInstruction::Retry(offset) => offset,
+                    IndexedChoiceInstruction::Trust(offset) => offset,
+                    IndexedChoiceInstruction::Try(offset) => offset,
+                    IndexedChoiceInstruction::DefaultRetry(offset) => offset,
+                    IndexedChoiceInstruction::DefaultTrust(offset) => offset,
                 }
             }
 
-            pub(crate) fn to_functor(&self) -> MachineStub {
+            pub(crate) fn to_functor(self) -> MachineStub {
                 match self {
-                    &IndexedChoiceInstruction::Try(offset) => {
+                    IndexedChoiceInstruction::Try(offset) => {
                         functor!(atom!("try"), [fixnum(offset)])
                     }
-                    &IndexedChoiceInstruction::Trust(offset) => {
+                    IndexedChoiceInstruction::Trust(offset) => {
                         functor!(atom!("trust"), [fixnum(offset)])
                     }
-                    &IndexedChoiceInstruction::Retry(offset) => {
+                    IndexedChoiceInstruction::Retry(offset) => {
                         functor!(atom!("retry"), [fixnum(offset)])
                     }
-                    &IndexedChoiceInstruction::DefaultTrust(offset) => {
+                    IndexedChoiceInstruction::DefaultTrust(offset) => {
                         functor!(atom!("default_trust"), [fixnum(offset)])
                     }
-                    &IndexedChoiceInstruction::DefaultRetry(offset) => {
+                    IndexedChoiceInstruction::DefaultRetry(offset) => {
                         functor!(atom!("default_retry"), [fixnum(offset)])
                     }
                 }
@@ -1038,7 +1032,7 @@ fn generate_instruction_preface() -> TokenStream {
                             ]
                         )
                     }
-                    &IndexingInstruction::SwitchOnConstant(ref constants) => {
+                    IndexingInstruction::SwitchOnConstant(constants) => {
                         let mut key_value_list_stub = vec![];
                         let orig_h = h;
 
@@ -1066,7 +1060,7 @@ fn generate_instruction_preface() -> TokenStream {
                             [key_value_list_stub]
                         )
                     }
-                    &IndexingInstruction::SwitchOnStructure(ref structures) => {
+                    IndexingInstruction::SwitchOnStructure(structures) => {
                         let mut key_value_list_stub = vec![];
                         let orig_h = h;
 
@@ -1177,7 +1171,7 @@ fn generate_instruction_preface() -> TokenStream {
 
             #[inline]
             pub fn is_head_instr(&self) -> bool {
-                match self {
+                matches!(self,
                     Instruction::Deallocate |
                     Instruction::GetConstant(..) |
                     Instruction::GetList(..) |
@@ -1201,9 +1195,7 @@ fn generate_instruction_preface() -> TokenStream {
                     Instruction::SetLocalValue(..) |
                     Instruction::SetVariable(..) |
                     Instruction::SetValue(..) |
-                    Instruction::SetVoid(..) => true,
-                    _ => false,
-                }
+                    Instruction::SetVoid(..))
             }
 
             pub fn enqueue_functors(
@@ -1213,7 +1205,7 @@ fn generate_instruction_preface() -> TokenStream {
                 functors: &mut Vec<MachineStub>,
             ) {
                 match self {
-                    &Instruction::IndexingCode(ref indexing_instrs) => {
+                    Instruction::IndexingCode(indexing_instrs) => {
                         for indexing_instr in indexing_instrs {
                             match indexing_instr {
                                 IndexingLine::Indexing(indexing_instr) => {
@@ -2331,7 +2323,7 @@ pub fn generate_instructions_rs() -> TokenStream {
     let mut is_inlined_arms = vec![];
 
     is_inbuilt_arms.push(quote! {
-        (atom!(":-"), 1 | 2) => true
+        (atom!(":-"), 1 | 2)
     });
 
     for (name, arity, variant) in instr_data.compare_number_variants {
@@ -2388,11 +2380,11 @@ pub fn generate_instructions_rs() -> TokenStream {
         });
 
         is_inbuilt_arms.push(quote! {
-            (atom!(#name), #arity) => true
+            (atom!(#name), #arity)
         });
 
         is_inlined_arms.push(quote! {
-            (atom!(#name), #arity) => true
+            (atom!(#name), #arity)
         });
     }
 
@@ -2421,7 +2413,7 @@ pub fn generate_instructions_rs() -> TokenStream {
         });
 
         is_inbuilt_arms.push(quote! {
-            (atom!(#name), #arity) => true
+            (atom!(#name), #arity)
         });
     }
 
@@ -2487,7 +2479,7 @@ pub fn generate_instructions_rs() -> TokenStream {
         });
 
         is_inbuilt_arms.push(quote! {
-            (atom!(#name), #arity) => true
+            (atom!(#name), #arity)
         });
     }
 
@@ -2549,16 +2541,17 @@ pub fn generate_instructions_rs() -> TokenStream {
         });
 
         is_inbuilt_arms.push(quote! {
-            (atom!(#name), #arity) => true
+            (atom!(#name), #arity)
         });
 
         is_inlined_arms.push(quote! {
-            (atom!(#name), #arity) => true
+            (atom!(#name), #arity)
         });
     }
 
     for (name, arity, variant) in instr_data.system_clause_type_variants {
         let ident = variant.ident.clone();
+        let ident_s = ident.to_string();
 
         let variant_fields: Vec<_> = variant
             .fields
@@ -2574,19 +2567,13 @@ pub fn generate_instructions_rs() -> TokenStream {
             .collect();
 
         clause_type_from_name_and_arity_arms.push(if !variant_fields.is_empty() {
-            if ident.to_string() == "SetCutPoint" {
+            if ident_s == "SetCutPoint" || ident_s == "SetCutPointByDefault" {
                 quote! {
                     (atom!(#name), #arity) => ClauseType::System(
                         SystemClauseType::#ident(temp_v!(1))
                     )
                 }
-            } else if ident.to_string() == "SetCutPointByDefault" {
-                quote! {
-                    (atom!(#name), #arity) => ClauseType::System(
-                        SystemClauseType::#ident(temp_v!(1))
-                    )
-                }
-            } else if ident.to_string() == "InlineCallN" {
+            } else if ident_s == "InlineCallN" {
                 quote! {
                     (atom!(#name), arity) => ClauseType::System(
                         SystemClauseType::#ident(arity)
@@ -2649,11 +2636,11 @@ pub fn generate_instructions_rs() -> TokenStream {
 
         is_inbuilt_arms.push(if let Arity::Ident("arity") = &arity {
             quote! {
-                (atom!(#name), _arity) => true
+                (atom!(#name), _)
             }
         } else {
             quote! {
-                (atom!(#name), #arity) => true
+                (atom!(#name), #arity)
             }
         });
     }
@@ -2724,7 +2711,7 @@ pub fn generate_instructions_rs() -> TokenStream {
         });
 
         is_inbuilt_arms.push(quote! {
-            (atom!(#name), #arity) => true
+            (atom!(#name), #arity)
         });
     }
 
@@ -2798,7 +2785,7 @@ pub fn generate_instructions_rs() -> TokenStream {
         });
 
         is_inbuilt_arms.push(quote! {
-            (atom!(#name), _arity) => true
+            (atom!(#name), _)
         });
     }
 
@@ -2819,8 +2806,8 @@ pub fn generate_instructions_rs() -> TokenStream {
             let placeholder_ids: Vec<_> =
                 (0..enum_arity).map(|n| format_ident!("f_{}", n)).collect();
 
-            if variant_string.starts_with("Call") {
-                let execute_ident = format_ident!("Execute{}", variant_string["Call".len()..]);
+            if let Some(variant_suffix) = variant_string.strip_prefix("Call") {
+                let execute_ident = format_ident!("Execute{}", variant_suffix);
 
                 Some(if enum_arity == 0 {
                     quote! {
@@ -2833,9 +2820,8 @@ pub fn generate_instructions_rs() -> TokenStream {
                             Instruction::#execute_ident(#(#placeholder_ids),*)
                     }
                 })
-            } else if variant_string.starts_with("DefaultCall") {
-                let execute_ident =
-                    format_ident!("DefaultExecute{}", variant_string["DefaultCall".len()..]);
+            } else if let Some(variant_suffix) = variant_string.strip_prefix("DefaultCall") {
+                let execute_ident = format_ident!("DefaultExecute{}", variant_suffix);
 
                 Some(if enum_arity == 0 {
                     quote! {
@@ -2868,29 +2854,20 @@ pub fn generate_instructions_rs() -> TokenStream {
                 0
             };
 
-            if variant_string.starts_with("Execute") {
+            if variant_string.starts_with("Execute") || variant_string.starts_with("DefaultExecute")
+            {
                 Some(if enum_arity == 0 {
                     quote! {
-                        Instruction::#variant_ident => true
+                        Instruction::#variant_ident
                     }
                 } else {
                     quote! {
-                        Instruction::#variant_ident(..) => true
-                    }
-                })
-            } else if variant_string.starts_with("DefaultExecute") {
-                Some(if enum_arity == 0 {
-                    quote! {
-                        Instruction::#variant_ident => true
-                    }
-                } else {
-                    quote! {
-                        Instruction::#variant_ident(..) => true
+                        Instruction::#variant_ident(..)
                     }
                 })
             } else if variant_string == "JmpByExecute" {
                 Some(quote! {
-                    Instruction::#variant_ident(..) => true
+                    Instruction::#variant_ident(..)
                 })
             } else {
                 None
@@ -2955,11 +2932,11 @@ pub fn generate_instructions_rs() -> TokenStream {
 
             Some(if enum_arity == 0 {
                 quote! {
-                    Instruction::#variant_ident => true
+                    Instruction::#variant_ident
                 }
             } else {
                 quote! {
-                    Instruction::#variant_ident(..) => true
+                    Instruction::#variant_ident(..)
                 }
             })
         })
@@ -2970,7 +2947,7 @@ pub fn generate_instructions_rs() -> TokenStream {
         .iter()
         .rev() // produce default, execute & default & execute cases first.
         .cloned()
-        .filter_map(|(name, arity, _, variant)| {
+        .map(|(name, arity, _, variant)| {
             let variant_ident = variant.ident.clone();
             let variant_string = variant.ident.to_string();
             let arity = match arity {
@@ -2978,6 +2955,7 @@ pub fn generate_instructions_rs() -> TokenStream {
                 _ => 1,
             };
 
+            #[allow(clippy::collapsible_else_if)]
             Some(if variant_string.starts_with("Execute") {
                 if arity == 0 {
                     quote! {
@@ -3066,10 +3044,10 @@ pub fn generate_instructions_rs() -> TokenStream {
 
             match arity {
                 Arity::Static(_) if enum_arity == 0 => {
-                    quote! { &Instruction::#ident => (atom!(#name), #arity) }
+                    quote! { Instruction::#ident => (atom!(#name), #arity) }
                 }
                 Arity::Static(_) => {
-                    quote! { &Instruction::#ident(..) => (atom!(#name), #arity) }
+                    quote! { Instruction::#ident(..) => (atom!(#name), #arity) }
                 }
                 Arity::Ident(_) if enum_arity == 0 => {
                     quote! { &Instruction::#ident(#arity) => (atom!(#name), #arity) }
@@ -3169,12 +3147,9 @@ pub fn generate_instructions_rs() -> TokenStream {
             }
 
             pub fn is_inbuilt(name: Atom, arity: usize) -> bool {
-                match (name, arity) {
-                    #(
-                        #is_inbuilt_arms,
-                    )*
-                    _ => false,
-                }
+                matches!((name, arity),
+                    #(#is_inbuilt_arms)|*
+                )
             }
 
             pub fn name(&self) -> Atom {
@@ -3186,12 +3161,9 @@ pub fn generate_instructions_rs() -> TokenStream {
             }
 
             pub fn is_inlined(name: Atom, arity: usize) -> bool {
-                match (name, arity) {
-                    #(
-                        #is_inlined_arms,
-                    )*
-                    _ => false,
-                }
+                matches!((name, arity),
+                    #(#is_inlined_arms)|*
+                )
             }
         }
 
@@ -3230,29 +3202,23 @@ pub fn generate_instructions_rs() -> TokenStream {
             }
 
             pub fn is_execute(&self) -> bool {
-                match self {
-                    #(
-                        #is_execute_arms,
-                    )*
-                    _ => false,
-                }
+                matches!(self,
+                    #(#is_execute_arms)|*
+                )
             }
 
             pub fn is_ctrl_instr(&self) -> bool {
-                match self {
-                    &Instruction::Allocate(_) |
-                    &Instruction::Deallocate |
-                    &Instruction::Proceed |
-                    &Instruction::RevJmpBy(_) => true,
-                    #(
-                        #control_flow_arms,
-                    )*
-                    _ => false,
-                }
+                matches!(self,
+                    Instruction::Allocate(_) |
+                    Instruction::Deallocate |
+                    Instruction::Proceed |
+                    Instruction::RevJmpBy(_) |
+                    #(#control_flow_arms)|*
+                )
             }
 
             pub fn is_query_instr(&self) -> bool {
-                match self {
+                matches!(self,
                     &Instruction::GetVariable(..) |
                     &Instruction::PutConstant(..) |
                     &Instruction::PutList(..) |
@@ -3265,9 +3231,8 @@ pub fn generate_instructions_rs() -> TokenStream {
                     &Instruction::SetLocalValue(..) |
                     &Instruction::SetVariable(..) |
                     &Instruction::SetValue(..) |
-                    &Instruction::SetVoid(..) => true,
-                    _ => false,
-                }
+                    &Instruction::SetVoid(..)
+                )
             }
         }
 
@@ -3335,7 +3300,8 @@ enum Arity {
 
 impl From<&'static str> for Arity {
     fn from(arity: &'static str) -> Self {
-        usize::from_str_radix(&arity, 10)
+        arity
+            .parse::<usize>()
             .map(Arity::Static)
             .unwrap_or_else(|_| Arity::Ident(arity))
     }
@@ -3442,13 +3408,12 @@ impl InstructionData {
             panic!("type ID is: {}", id);
         };
 
-        let v_string = variant.ident.to_string();
-
-        let v_ident = if v_string.starts_with("Call") {
-            format_ident!("{}", v_string["Call".len()..])
-        } else {
-            variant.ident.clone()
-        };
+        let v_ident = variant
+            .ident
+            .to_string()
+            .strip_prefix("Call")
+            .map(|s| format_ident!("{}", s))
+            .unwrap_or_else(|| variant.ident.clone());
 
         let generated_variant =
             create_instr_variant(format_ident!("{}{}", prefix, v_ident), variant.clone());

--- a/build/main.rs
+++ b/build/main.rs
@@ -55,7 +55,7 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("libraries.rs");
 
-    let mut libraries = File::create(&dest_path).unwrap();
+    let mut libraries = File::create(dest_path).unwrap();
     let lib_path = Path::new("src/lib");
 
     libraries
@@ -66,7 +66,7 @@ fn main() {
         )
         .unwrap();
 
-    find_prolog_files(&mut libraries, "", &lib_path);
+    find_prolog_files(&mut libraries, "", lib_path);
     libraries.write_all(b"\n        m\n    };\n}\n").unwrap();
 
     let instructions_path = Path::new(&out_dir).join("instructions.rs");

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -24,6 +24,7 @@ pub(crate) trait Allocator {
         code: &mut CodeDeque,
     );
 
+    #[allow(clippy::too_many_arguments)]
     fn mark_reserved_var<'a, Target: CompilationTarget<'a>>(
         &mut self,
         var_num: usize,
@@ -48,7 +49,7 @@ pub(crate) trait Allocator {
 
     fn reset(&mut self);
     fn reset_arg(&mut self, arg_num: usize);
-    fn reset_at_head(&mut self, args: &Vec<Term>);
+    fn reset_at_head(&mut self, args: &[Term]);
     fn reset_contents(&mut self);
 
     fn advance_arg(&mut self);

--- a/src/bin/scryer-prolog.rs
+++ b/src/bin/scryer-prolog.rs
@@ -1,6 +1,6 @@
 fn main() -> std::process::ExitCode {
-    use scryer_prolog::*;
     use scryer_prolog::atom_table::Atom;
+    use scryer_prolog::*;
     use std::sync::atomic::Ordering;
 
     #[cfg(feature = "repl")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,5 @@
-use std::sync::{Arc, Mutex, Condvar};
 use std::io::BufRead;
+use std::sync::{Arc, Condvar, Mutex};
 
 use warp::http;
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -8,6 +8,7 @@ use std::collections::VecDeque;
 use std::iter::*;
 use std::vec::Vec;
 
+#[allow(clippy::borrowed_box)]
 #[derive(Debug, Clone)]
 pub(crate) enum TermRef<'a> {
     AnonVar(Level),
@@ -35,6 +36,7 @@ impl<'a> TermRef<'a> {
 }
 */
 
+#[allow(clippy::borrowed_box)]
 #[derive(Debug)]
 pub(crate) enum TermIterState<'a> {
     AnonVar(Level),
@@ -113,11 +115,11 @@ impl<'a> QueryIterator<'a> {
 
     fn extend_state(&mut self, lvl: Level, term: &'a QueryTerm) {
         match term {
-            &QueryTerm::Clause(ref cell, ClauseType::CallN(_), ref terms, _) => {
+            QueryTerm::Clause(ref cell, ClauseType::CallN(_), ref terms, _) => {
                 self.state_stack
                     .push(TermIterState::Clause(lvl, 1, cell, atom!("$call"), terms));
             }
-            &QueryTerm::Clause(ref cell, ref ct, ref terms, _) => {
+            QueryTerm::Clause(ref cell, ref ct, ref terms, _) => {
                 self.state_stack
                     .push(TermIterState::Clause(lvl, 0, cell, ct.name(), terms));
             }
@@ -214,7 +216,7 @@ impl<'a> FactIterator<'a> {
             .push_back(TermIterState::subterm_to_state(lvl, term));
     }
 
-    pub(crate) fn from_rule_head_clause(terms: &'a Vec<Term>) -> Self {
+    pub(crate) fn from_rule_head_clause(terms: &'a [Term]) -> Self {
         let state_queue = terms
             .iter()
             .map(|bt| TermIterState::subterm_to_state(Level::Shallow, bt))
@@ -312,14 +314,14 @@ impl<'a> Iterator for FactIterator<'a> {
     }
 }
 
-pub(crate) fn post_order_iter<'a>(term: &'a Term) -> QueryIterator<'a> {
+pub(crate) fn post_order_iter(term: &'_ Term) -> QueryIterator {
     QueryIterator::from_term(term)
 }
 
-pub(crate) fn breadth_first_iter<'a>(
-    term: &'a Term,
+pub(crate) fn breadth_first_iter(
+    term: &'_ Term,
     iterable_root: RootIterationPolicy,
-) -> FactIterator<'a> {
+) -> FactIterator {
     FactIterator::new(term, iterable_root)
 }
 
@@ -343,7 +345,7 @@ pub(crate) struct ClauseIterator<'a> {
     remaining_chunks_on_stack: usize,
 }
 
-fn state_from_chunked_terms<'a>(chunk_vec: &'a VecDeque<ChunkedTerms>) -> ClauseIteratorState<'a> {
+fn state_from_chunked_terms(chunk_vec: &'_ VecDeque<ChunkedTerms>) -> ClauseIteratorState {
     if chunk_vec.len() == 1 {
         if let Some(ChunkedTerms::Branch(ref branches)) = chunk_vec.front() {
             return ClauseIteratorState::RemainingBranches(branches, 0);
@@ -422,7 +424,7 @@ impl<'a> Iterator for ClauseIterator<'a> {
                     if focus < branches.len() =>
                 {
                     self.state_stack
-                        .push(ClauseIteratorState::RemainingBranches(&branches, focus + 1));
+                        .push(ClauseIteratorState::RemainingBranches(branches, focus + 1));
                     let state = state_from_chunked_terms(&branches[focus]);
 
                     if let ClauseIteratorState::RemainingChunks(..) = &state {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 #[macro_use]
 extern crate static_assertions;
 #[cfg(test)]
-#[macro_use] extern crate maplit;
+#[macro_use]
+extern crate maplit;
 
 #[macro_use]
 pub mod macros;
@@ -50,6 +51,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn eval_code(s: &str) -> String {
     use machine::mock_wam::*;
+    use web_sys::console;
 
     let mut wam = Machine::with_test_streams();
     let bytes = wam.test_load_string(s);

--- a/src/machine/args.rs
+++ b/src/machine/args.rs
@@ -14,3 +14,9 @@ impl MachineArgs {
         }
     }
 }
+
+impl Default for MachineArgs {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -1,6 +1,6 @@
 use dashu::base::{Abs, Gcd, Signed, UnsignedAbs};
-use dashu::integer::IBig;
 use dashu::integer::fast_div::ConstDivisor;
+use dashu::integer::IBig;
 use divrem::*;
 use num_order::NumOrd;
 
@@ -84,18 +84,18 @@ fn numerical_type_error(
 
 fn isize_gcd(n1: isize, n2: isize) -> Option<isize> {
     if n1 == 0 {
-        return n2.checked_abs().map(|n| n as isize);
+        return n2.checked_abs();
     }
 
     if n2 == 0 {
-        return n1.checked_abs().map(|n| n as isize);
+        return n1.checked_abs();
     }
 
     let n1 = n1.checked_abs();
     let n2 = n2.checked_abs();
 
-    let mut n1 = if let Some(n1) = n1 { n1 } else { return None };
-    let mut n2 = if let Some(n2) = n2 { n2 } else { return None };
+    let mut n1 = n1?;
+    let mut n2 = n2?;
 
     let mut shift = 0;
 
@@ -115,9 +115,7 @@ fn isize_gcd(n1: isize, n2: isize) -> Option<isize> {
         }
 
         if n1 > n2 {
-            let t = n2;
-            n2 = n1;
-            n1 = t;
+            std::mem::swap(&mut n2, &mut n1);
         }
 
         n2 -= n1;
@@ -350,22 +348,18 @@ pub(crate) fn int_pow(n1: Number, n2: Number, arena: &mut Arena) -> Result<Numbe
         (Number::Fixnum(n1), Number::Integer(n2)) => {
             let n1_i = n1.get_num();
 
-            if !(n1_i == 1 || n1_i == 0 || n1_i == -1) && &*n2 < &Integer::from(0) {
+            if !(n1_i == 1 || n1_i == 0 || n1_i == -1) && n2.is_zero() {
                 let n = Number::Fixnum(n1);
                 Err(numerical_type_error(ValidType::Float, n, stub_gen))
             } else {
                 let n1 = Integer::from(n1_i);
-                Ok(Number::arena_from(binary_pow(n1, &*n2), arena))
+                Ok(Number::arena_from(binary_pow(n1, &n2), arena))
             }
         }
         (Number::Integer(n1), Number::Fixnum(n2)) => {
             let n2_i = n2.get_num();
 
-            if !(&*n1 == &Integer::from(1)
-                || &*n1 == &Integer::from(0)
-                || &*n1 == &Integer::from(-1))
-                && n2_i < 0
-            {
+            if !(*n1 == Integer::from(1) || n1.is_zero() || *n1 == Integer::from(-1)) && n2_i < 0 {
                 let n = Number::Integer(n1);
                 Err(numerical_type_error(ValidType::Float, n, stub_gen))
             } else {
@@ -374,15 +368,13 @@ pub(crate) fn int_pow(n1: Number, n2: Number, arena: &mut Arena) -> Result<Numbe
             }
         }
         (Number::Integer(n1), Number::Integer(n2)) => {
-            if !(&*n1 == &Integer::from(1)
-                || &*n1 == &Integer::from(0)
-                || &*n1 == &Integer::from(-1))
-                && &*n2 < &Integer::from(0)
+            if !(*n1 == Integer::from(1) || n1.is_zero() || *n1 == Integer::from(-1))
+                && n2.is_zero()
             {
                 let n = Number::Integer(n1);
                 Err(numerical_type_error(ValidType::Float, n, stub_gen))
             } else {
-                Ok(Number::arena_from(binary_pow((*n1).clone(), &*n2), arena))
+                Ok(Number::arena_from(binary_pow((*n1).clone(), &n2), arena))
             }
         }
         (n1, Number::Integer(n2)) => {
@@ -455,14 +447,14 @@ pub(crate) fn max(n1: Number, n2: Number) -> Result<Number, MachineStubGen> {
             }
         }
         (Number::Fixnum(n1), Number::Integer(n2)) => {
-            if (&*n2).num_gt(&n1.get_num()) {
+            if (*n2).num_gt(&n1.get_num()) {
                 Ok(Number::Integer(n2))
             } else {
                 Ok(Number::Fixnum(n1))
             }
         }
         (Number::Integer(n1), Number::Fixnum(n2)) => {
-            if (&*n1).num_gt(&n2.get_num()) {
+            if (*n1).num_gt(&n2.get_num()) {
                 Ok(Number::Integer(n1))
             } else {
                 Ok(Number::Fixnum(n2))
@@ -499,14 +491,14 @@ pub(crate) fn min(n1: Number, n2: Number) -> Result<Number, MachineStubGen> {
             }
         }
         (Number::Fixnum(n1), Number::Integer(n2)) => {
-            if (&*n2).num_lt(&n1.get_num()) {
+            if (*n2).num_lt(&n1.get_num()) {
                 Ok(Number::Integer(n2))
             } else {
                 Ok(Number::Fixnum(n1))
             }
         }
         (Number::Integer(n1), Number::Fixnum(n2)) => {
-            if (&*n1).num_lt(&n2.get_num()) {
+            if (*n1).num_lt(&n2.get_num()) {
                 Ok(Number::Integer(n1))
             } else {
                 Ok(Number::Fixnum(n2))
@@ -583,15 +575,13 @@ pub(crate) fn idiv(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, 
         (Number::Fixnum(n1), Number::Fixnum(n2)) => {
             if n2.get_num() == 0 {
                 Err(zero_divisor_eval_error(stub_gen))
+            } else if let Some(result) = n1.get_num().checked_div(n2.get_num()) {
+                Ok(Number::arena_from(result, arena))
             } else {
-                if let Some(result) = n1.get_num().checked_div(n2.get_num()) {
-                    Ok(Number::arena_from(result, arena))
-                } else {
-                    let n1 = Integer::from(n1.get_num());
-                    let n2 = Integer::from(n2.get_num());
+                let n1 = Integer::from(n1.get_num());
+                let n2 = Integer::from(n2.get_num());
 
-                    Ok(Number::arena_from(n1 / n2, arena))
-                }
+                Ok(Number::arena_from(n1 / n2, arena))
             }
         }
         (Number::Fixnum(n1), Number::Integer(n2)) => {
@@ -656,9 +646,9 @@ pub(crate) fn shr(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
             let n1 = Integer::from(n1_i);
 
             if let Ok(n2) = usize::try_from(n2_i) {
-                return Ok(Number::arena_from(n1 >> n2, arena));
+                Ok(Number::arena_from(n1 >> n2, arena))
             } else {
-                return Ok(Number::arena_from(n1 >> usize::max_value(), arena));
+                Ok(Number::arena_from(n1 >> usize::max_value(), arena))
             }
         }
         (Number::Fixnum(n1), Number::Integer(n2)) => {
@@ -667,12 +657,8 @@ pub(crate) fn shr(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
             let result: Result<usize, _> = (&*n2).try_into();
 
             match result {
-                Ok(n2) => {
-                    Ok(Number::arena_from(n1 >> n2, arena))
-                }
-                Err(_) => {
-                    Ok(Number::arena_from(n1 >> usize::max_value(), arena))
-                }
+                Ok(n2) => Ok(Number::arena_from(n1 >> n2, arena)),
+                Err(_) => Ok(Number::arena_from(n1 >> usize::max_value(), arena)),
             }
         }
         (Number::Integer(n1), Number::Fixnum(n2)) => match usize::try_from(n2.get_num()) {
@@ -686,14 +672,13 @@ pub(crate) fn shr(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
             let result: Result<usize, _> = (&*n2).try_into();
 
             match result {
-                Ok(n2) => {
-                    Ok(Number::arena_from(Integer::from(&*n1 >> n2), arena))
-                }
-                Err(_) => {
-                    Ok(Number::arena_from(Integer::from(&*n1 >> usize::max_value()), arena))
-                }
+                Ok(n2) => Ok(Number::arena_from(Integer::from(&*n1 >> n2), arena)),
+                Err(_) => Ok(Number::arena_from(
+                    Integer::from(&*n1 >> usize::max_value()),
+                    arena,
+                )),
             }
-        },
+        }
         (Number::Integer(_), n2) => Err(numerical_type_error(ValidType::Integer, n2, stub_gen)),
         (Number::Fixnum(_), n2) => Err(numerical_type_error(ValidType::Integer, n2, stub_gen)),
         (n1, _) => Err(numerical_type_error(ValidType::Integer, n1, stub_gen)),
@@ -718,9 +703,9 @@ pub(crate) fn shl(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
             let n1 = Integer::from(n1_i);
 
             if let Ok(n2) = usize::try_from(n2_i) {
-                return Ok(Number::arena_from(n1 << n2, arena));
+                Ok(Number::arena_from(n1 << n2, arena))
             } else {
-                return Ok(Number::arena_from(n1 << usize::max_value(), arena));
+                Ok(Number::arena_from(n1 << usize::max_value(), arena))
             }
         }
         (Number::Fixnum(n1), Number::Integer(n2)) => {
@@ -730,10 +715,8 @@ pub(crate) fn shl(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
                 Ok(n2) => {
                     let n1: u64 = n1.try_into().unwrap();
                     Ok(Number::arena_from(n1 << n2, arena))
-                },
-                _ => {
-			        Ok(Number::arena_from(n1 << usize::max_value(), arena))
-		        }
+                }
+                _ => Ok(Number::arena_from(n1 << usize::max_value(), arena)),
             }
         }
         (Number::Integer(n1), Number::Fixnum(n2)) => match usize::try_from(n2.get_num()) {
@@ -747,10 +730,11 @@ pub(crate) fn shl(n1: Number, n2: Number, arena: &mut Arena) -> Result<Number, M
             Ok(n2) => {
                 let n1: u64 = (&*n1).try_into().unwrap();
                 Ok(Number::arena_from(Integer::from(n1 << n2), arena))
-            },
-            _ => {
-		        Ok(Number::arena_from(Integer::from(&*n1 << usize::max_value()),arena))
-	        }
+            }
+            _ => Ok(Number::arena_from(
+                Integer::from(&*n1 << usize::max_value()),
+                arena,
+            )),
         },
         (Number::Integer(_), n2) => Err(numerical_type_error(ValidType::Integer, n2, stub_gen)),
         (Number::Fixnum(_), n2) => Err(numerical_type_error(ValidType::Integer, n2, stub_gen)),
@@ -882,7 +866,7 @@ pub(crate) fn modulus(x: Number, y: Number, arena: &mut Arena) -> Result<Number,
                 Err(zero_divisor_eval_error(stub_gen))
             } else {
                 let n1 = Integer::from(n1.get_num());
-                Ok(Number::arena_from(ibig_rem_floor(&n1, &*n2), arena))
+                Ok(Number::arena_from(ibig_rem_floor(&n1, &n2), arena))
             }
         }
         (Number::Integer(n1), Number::Fixnum(n2)) => {
@@ -892,14 +876,14 @@ pub(crate) fn modulus(x: Number, y: Number, arena: &mut Arena) -> Result<Number,
                 Err(zero_divisor_eval_error(stub_gen))
             } else {
                 let n2 = Integer::from(n2_i);
-                Ok(Number::arena_from(ibig_rem_floor(&*n1, &n2), arena))
+                Ok(Number::arena_from(ibig_rem_floor(&n1, &n2), arena))
             }
         }
         (Number::Integer(n1), Number::Integer(n2)) => {
             if n2.is_zero() {
                 Err(zero_divisor_eval_error(stub_gen))
             } else {
-                Ok(Number::arena_from(ibig_rem_floor(&*n1, &*n2), arena))
+                Ok(Number::arena_from(ibig_rem_floor(&n1, &n2), arena))
             }
         }
         (Number::Integer(_), n2) | (Number::Fixnum(_), n2) => {
@@ -1145,7 +1129,7 @@ impl MachineState {
                 &mut self.interms[i - 1],
                 Number::Fixnum(Fixnum::build_with(0)),
             )),
-            &ArithmeticTerm::Number(n) => Ok(n),
+            ArithmeticTerm::Number(n) => Ok(*n),
         }
     }
 
@@ -1167,8 +1151,8 @@ impl MachineState {
         value: HeapCellValue,
     ) -> Result<Number, MachineStub> {
         let stub_gen = || functor_stub(atom!("is"), 2);
-        let mut iter = stackful_post_order_iter::<NonListElider>
-            (&mut self.heap, &mut self.stack, value);
+        let mut iter =
+            stackful_post_order_iter::<NonListElider>(&mut self.heap, &mut self.stack, value);
 
         while let Some(value) = iter.next() {
             if value.get_forwarding_bit() {

--- a/src/machine/attributed_variables.rs
+++ b/src/machine/attributed_variables.rs
@@ -133,8 +133,8 @@ impl MachineState {
         let mut seen_set = IndexSet::new();
         let mut seen_vars = vec![];
 
-        let mut iter = stackful_preorder_iter::<NonListElider>
-            (&mut self.heap, &mut self.stack, cell);
+        let mut iter =
+            stackful_preorder_iter::<NonListElider>(&mut self.heap, &mut self.stack, cell);
 
         while let Some(value) = iter.next() {
             read_heap_cell!(value,

--- a/src/machine/copier.rs
+++ b/src/machine/copier.rs
@@ -174,7 +174,7 @@ impl<T: CopierTarget> CopyTermState<T> {
 
     fn copy_attr_var_lists(&mut self) {
         while !self.attr_var_list_locs.is_empty() {
-            let iter = mem::replace(&mut self.attr_var_list_locs, vec![]);
+            let iter = std::mem::take(&mut self.attr_var_list_locs);
 
             for (threshold, list_loc) in iter {
                 self.target[threshold] = list_loc_as_cell!(self.target.threshold());

--- a/src/machine/cycle_detection.rs
+++ b/src/machine/cycle_detection.rs
@@ -73,7 +73,7 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
     fn traverse_subterm(&mut self, h: usize, arity: usize) -> Option<usize> {
         let mut last_cell_loc = h + arity - 1;
 
-        for idx in (h .. h + arity).rev() {
+        for idx in (h..h + arity).rev() {
             if self.heap[idx].get_forwarding_bit() {
                 if self.cycle_detection_active() {
                     self.cycle_found = true;
@@ -93,8 +93,8 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
 
     #[inline]
     fn continue_forwarding(&self) -> bool {
-        self.heap[self.current].get_mark_bit() != self.mark_phase ||
-            self.heap[self.current].get_forwarding_bit()
+        self.heap[self.current].get_mark_bit() != self.mark_phase
+            || self.heap[self.current].get_forwarding_bit()
     }
 
     fn forward(&mut self) -> Option<HeapCellValue> {
@@ -150,7 +150,7 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
                         }
 
                         if self.cycle_detection_active() {
-                            for idx in (h + 1 .. last_cell_loc).rev() {
+                            for idx in (h + 1..last_cell_loc).rev() {
                                 if self.heap[idx].get_forwarding_bit() {
                                     self.cycle_found = true;
                                     return None;
@@ -176,7 +176,7 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
                         };
 
                         if self.cycle_detection_active() {
-                            for idx in (self.next as usize .. last_cell_loc).rev() {
+                            for idx in (self.next as usize..last_cell_loc).rev() {
                                 if self.heap[idx].get_forwarding_bit() {
                                     self.cycle_found = true;
                                     return None;
@@ -309,19 +309,19 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
             HeapCellValueTag::Str => {
                 let mut new_str_back_link = self.current;
 
-                for idx in (0 .. self.current).rev() {
-                    if self.heap[idx].get_tag() == HeapCellValueTag::Atom {
-                        if cell_as_atom_cell!(self.heap[idx]).get_arity() > 0 {
-                            new_str_back_link = idx;
-                            break;
-                        }
+                for idx in (0..self.current).rev() {
+                    if self.heap[idx].get_tag() == HeapCellValueTag::Atom
+                        && cell_as_atom_cell!(self.heap[idx]).get_arity() > 0
+                    {
+                        new_str_back_link = idx;
+                        break;
                     }
 
-                    if self.heap[idx].get_mark_bit() != self.mark_phase {
-                        if !self.heap[idx].get_forwarding_bit() {
-                            new_str_back_link = idx;
-                            break;
-                        }
+                    if self.heap[idx].get_mark_bit() != self.mark_phase
+                        && !self.heap[idx].get_forwarding_bit()
+                    {
+                        new_str_back_link = idx;
+                        break;
                     }
                 }
 
@@ -402,7 +402,7 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
         self.next = self.heap[self.start].get_value();
         self.current = self.start;
 
-        while let Some(_) = self.forward() {}
+        while self.forward().is_some() {}
     }
 }
 
@@ -414,7 +414,6 @@ impl<'a, const STOP_AT_CYCLES: bool> Iterator for CycleDetectingIter<'a, STOP_AT
         self.forward()
     }
 }
-
 
 impl<'a, const STOP_AT_CYCLES: bool> Drop for CycleDetectingIter<'a, STOP_AT_CYCLES> {
     fn drop(&mut self) {

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -313,8 +313,8 @@ impl MachineState {
 impl Machine {
     pub(super) fn find_living_dynamic_else(&self, mut p: usize) -> Option<(usize, usize)> {
         loop {
-            match &self.code[p] {
-                &Instruction::DynamicElse(birth, death, NextOrFail::Next(i)) => {
+            match self.code[p] {
+                Instruction::DynamicElse(birth, death, NextOrFail::Next(i)) => {
                     if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death {
                         return Some((p, i));
                     } else if i > 0 {
@@ -323,14 +323,14 @@ impl Machine {
                         return None;
                     }
                 }
-                &Instruction::DynamicElse(birth, death, NextOrFail::Fail(_)) => {
+                Instruction::DynamicElse(birth, death, NextOrFail::Fail(_)) => {
                     if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death {
                         return Some((p, 0));
                     } else {
                         return None;
                     }
                 }
-                &Instruction::DynamicInternalElse(birth, death, NextOrFail::Next(i)) => {
+                Instruction::DynamicInternalElse(birth, death, NextOrFail::Next(i)) => {
                     if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death {
                         return Some((p, i));
                     } else if i > 0 {
@@ -339,14 +339,14 @@ impl Machine {
                         return None;
                     }
                 }
-                &Instruction::DynamicInternalElse(birth, death, NextOrFail::Fail(_)) => {
+                Instruction::DynamicInternalElse(birth, death, NextOrFail::Fail(_)) => {
                     if birth < self.machine_st.cc && Death::Finite(self.machine_st.cc) <= death {
                         return Some((p, 0));
                     } else {
                         return None;
                     }
                 }
-                &Instruction::RevJmpBy(i) => {
+                Instruction::RevJmpBy(i) => {
                     p -= i;
                 }
                 _ => {
@@ -395,25 +395,14 @@ impl Machine {
     fn execute_switch_on_term(&mut self) {
         #[inline(always)]
         fn dynamic_external_of_clause_is_valid(machine: &mut Machine, p: usize) -> bool {
-            match &machine.code[p] {
-                Instruction::DynamicInternalElse(..) => {
-                    machine.machine_st.dynamic_mode = FirstOrNext::First;
-                    return true;
-                }
-                _ => {}
+            if let Instruction::DynamicInternalElse(..) = machine.code[p] {
+                machine.machine_st.dynamic_mode = FirstOrNext::First;
+                return true;
             }
 
-            match &machine.code[p - 1] {
-                &Instruction::DynamicInternalElse(birth, death, _) => {
-                    if birth < machine.machine_st.cc
-                        && Death::Finite(machine.machine_st.cc) <= death
-                    {
-                        return true;
-                    } else {
-                        return false;
-                    }
-                }
-                _ => {}
+            if let Instruction::DynamicInternalElse(birth, death, _) = machine.code[p - 1] {
+                return birth < machine.machine_st.cc
+                    && Death::Finite(machine.machine_st.cc) <= death;
             }
 
             true
@@ -1896,7 +1885,7 @@ impl Machine {
                             self.machine_st.backtrack();
                         }
                     }
-                    &Instruction::CallNumberLessThanOrEqual(ref at_1, ref at_2) => {
+                    Instruction::CallNumberLessThanOrEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -1910,7 +1899,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::ExecuteNumberLessThanOrEqual(ref at_1, ref at_2) => {
+                    Instruction::ExecuteNumberLessThanOrEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -1924,7 +1913,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::CallNumberEqual(ref at_1, ref at_2) => {
+                    Instruction::CallNumberEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -1938,7 +1927,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::ExecuteNumberEqual(ref at_1, ref at_2) => {
+                    Instruction::ExecuteNumberEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -1952,7 +1941,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::CallNumberNotEqual(ref at_1, ref at_2) => {
+                    Instruction::CallNumberNotEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -1966,7 +1955,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::ExecuteNumberNotEqual(ref at_1, ref at_2) => {
+                    Instruction::ExecuteNumberNotEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -1980,7 +1969,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::CallNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
+                    Instruction::CallNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -1994,7 +1983,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::ExecuteNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
+                    Instruction::ExecuteNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2008,7 +1997,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::CallNumberGreaterThan(ref at_1, ref at_2) => {
+                    Instruction::CallNumberGreaterThan(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2022,7 +2011,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::ExecuteNumberGreaterThan(ref at_1, ref at_2) => {
+                    Instruction::ExecuteNumberGreaterThan(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2036,7 +2025,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::CallNumberLessThan(ref at_1, ref at_2) => {
+                    Instruction::CallNumberLessThan(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2050,7 +2039,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::ExecuteNumberLessThan(ref at_1, ref at_2) => {
+                    Instruction::ExecuteNumberLessThan(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2064,7 +2053,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultCallNumberLessThanOrEqual(ref at_1, ref at_2) => {
+                    Instruction::DefaultCallNumberLessThanOrEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2077,7 +2066,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultExecuteNumberLessThanOrEqual(ref at_1, ref at_2) => {
+                    Instruction::DefaultExecuteNumberLessThanOrEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2090,7 +2079,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultCallNumberNotEqual(ref at_1, ref at_2) => {
+                    Instruction::DefaultCallNumberNotEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2103,7 +2092,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultExecuteNumberNotEqual(ref at_1, ref at_2) => {
+                    Instruction::DefaultExecuteNumberNotEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2116,7 +2105,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultCallNumberEqual(ref at_1, ref at_2) => {
+                    Instruction::DefaultCallNumberEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2129,7 +2118,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultExecuteNumberEqual(ref at_1, ref at_2) => {
+                    Instruction::DefaultExecuteNumberEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2142,7 +2131,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultCallNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
+                    Instruction::DefaultCallNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2155,7 +2144,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultExecuteNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
+                    Instruction::DefaultExecuteNumberGreaterThanOrEqual(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2168,7 +2157,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultCallNumberGreaterThan(ref at_1, ref at_2) => {
+                    Instruction::DefaultCallNumberGreaterThan(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2181,7 +2170,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultExecuteNumberGreaterThan(ref at_1, ref at_2) => {
+                    Instruction::DefaultExecuteNumberGreaterThan(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2194,7 +2183,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultCallNumberLessThan(ref at_1, ref at_2) => {
+                    Instruction::DefaultCallNumberLessThan(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2207,7 +2196,7 @@ impl Machine {
                             }
                         }
                     }
-                    &Instruction::DefaultExecuteNumberLessThan(ref at_1, ref at_2) => {
+                    Instruction::DefaultExecuteNumberLessThan(ref at_1, ref at_2) => {
                         let n1 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_1));
                         let n2 = try_or_throw!(self.machine_st, self.machine_st.get_number(at_2));
 
@@ -2955,7 +2944,7 @@ impl Machine {
 
                         self.machine_st.p += 1;
                     }
-                    &Instruction::IndexingCode(ref indexing_lines) => {
+                    Instruction::IndexingCode(ref indexing_lines) => {
                         match &indexing_lines[self.machine_st.oip as usize] {
                             IndexingLine::Indexing(_) => {
                                 self.execute_switch_on_term();
@@ -2965,22 +2954,22 @@ impl Machine {
                                 }
                             }
                             IndexingLine::IndexedChoice(ref indexed_choice) => {
-                                match &indexed_choice[self.machine_st.iip as usize] {
-                                    &IndexedChoiceInstruction::Try(offset) => {
+                                match indexed_choice[self.machine_st.iip as usize] {
+                                    IndexedChoiceInstruction::Try(offset) => {
                                         self.indexed_try(offset);
                                     }
-                                    &IndexedChoiceInstruction::Retry(l) => {
+                                    IndexedChoiceInstruction::Retry(l) => {
                                         self.retry(l);
                                         increment_call_count!(self.machine_st);
                                     }
-                                    &IndexedChoiceInstruction::DefaultRetry(l) => {
+                                    IndexedChoiceInstruction::DefaultRetry(l) => {
                                         self.retry(l);
                                     }
-                                    &IndexedChoiceInstruction::Trust(l) => {
+                                    IndexedChoiceInstruction::Trust(l) => {
                                         self.trust(l);
                                         increment_call_count!(self.machine_st);
                                     }
-                                    &IndexedChoiceInstruction::DefaultTrust(l) => {
+                                    IndexedChoiceInstruction::DefaultTrust(l) => {
                                         self.trust(l);
                                     }
                                 }
@@ -5089,16 +5078,13 @@ impl Machine {
                             .get_predicate_skeleton_mut(&compilation_target, &key)
                             .unwrap();
 
-                        match skeleton.target_pos_of_clause_clause_loc(l) {
-                            Some(n) => {
-                                let r = self
-                                    .machine_st
-                                    .store(self.machine_st.deref(self.machine_st.registers[5]));
+                        if let Some(n) = skeleton.target_pos_of_clause_clause_loc(l) {
+                            let r = self
+                                .machine_st
+                                .store(self.machine_st.deref(self.machine_st.registers[5]));
 
-                                self.machine_st
-                                    .unify_fixnum(Fixnum::build_with(n as i64), r);
-                            }
-                            None => {}
+                            self.machine_st
+                                .unify_fixnum(Fixnum::build_with(n as i64), r);
                         }
 
                         self.machine_st.call_at_index(2, p);
@@ -5135,16 +5121,13 @@ impl Machine {
                             .get_predicate_skeleton_mut(&compilation_target, &key)
                             .unwrap();
 
-                        match skeleton.target_pos_of_clause_clause_loc(l) {
-                            Some(n) => {
-                                let r = self
-                                    .machine_st
-                                    .store(self.machine_st.deref(self.machine_st.registers[5]));
+                        if let Some(n) = skeleton.target_pos_of_clause_clause_loc(l) {
+                            let r = self
+                                .machine_st
+                                .store(self.machine_st.deref(self.machine_st.registers[5]));
 
-                                self.machine_st
-                                    .unify_fixnum(Fixnum::build_with(n as i64), r);
-                            }
-                            None => {}
+                            self.machine_st
+                                .unify_fixnum(Fixnum::build_with(n as i64), r);
                         }
 
                         self.machine_st.execute_at_index(2, p);
@@ -5226,7 +5209,7 @@ impl Machine {
                         // So we only have access to a runtime handle in here and can't shut it down.
                         // Since I'm not aware of the consequences of deactivating this new code which came in while PR 1880
                         // was not merged, I'm only deactivating it for now.
-                        
+
                         //#[cfg(not(target_arch = "wasm32"))]
                         //let runtime = tokio::runtime::Runtime::new().unwrap();
                         //#[cfg(target_arch = "wasm32")]

--- a/src/machine/heap.rs
+++ b/src/machine/heap.rs
@@ -169,7 +169,7 @@ pub(crate) fn allocate_pstr(heap: &mut Heap, mut src: &str, atom_tbl: &AtomTable
     let orig_h = heap.len();
 
     loop {
-        if src == "" {
+        if src.is_empty() {
             return if orig_h == heap.len() {
                 None
             } else {
@@ -199,7 +199,7 @@ pub(crate) fn allocate_pstr(heap: &mut Heap, mut src: &str, atom_tbl: &AtomTable
 
         heap.push(string_as_pstr_cell!(pstr));
 
-        if rest_src != "" {
+        if !rest_src.is_empty() {
             heap.push(pstr_loc_as_cell!(h + 2));
             src = rest_src;
         } else {
@@ -249,7 +249,7 @@ pub(crate) fn to_local_code_ptr(heap: &Heap, addr: HeapCellValue) -> Option<usiz
             Ok(Number::Integer(n)) => {
                 let value: usize = (&*n).try_into().unwrap();
                 Some(value)
-            },
+            }
             _ => None,
         }
     };

--- a/src/machine/machine_indices.rs
+++ b/src/machine/machine_indices.rs
@@ -118,18 +118,12 @@ impl IndexPtr {
 
     #[inline(always)]
     pub(crate) fn is_undefined(&self) -> bool {
-        match self.tag() {
-            IndexPtrTag::Undefined => true,
-            _ => false,
-        }
+        matches!(self.tag(), IndexPtrTag::Undefined)
     }
 
     #[inline(always)]
     pub(crate) fn is_dynamic_undefined(&self) -> bool {
-        match self.tag() {
-            IndexPtrTag::DynamicUndefined => true,
-            _ => false,
-        }
+        matches!(self.tag(), IndexPtrTag::DynamicUndefined)
     }
 }
 
@@ -231,6 +225,7 @@ pub enum VarKey {
 }
 
 impl VarKey {
+    #[allow(clippy::inherent_to_string)]
     #[inline]
     pub(crate) fn to_string(&self) -> String {
         match self {
@@ -241,11 +236,7 @@ impl VarKey {
 
     #[inline(always)]
     pub(crate) fn is_anon(&self) -> bool {
-        if let VarKey::AnonVar(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, VarKey::AnonVar(_))
     }
 }
 
@@ -429,9 +420,9 @@ impl IndexStore {
         match compilation_target {
             CompilationTarget::User => self.meta_predicates.get(&(name, arity)),
             CompilationTarget::Module(ref module_name) => match self.modules.get(module_name) {
-                Some(ref module) => module
+                Some(module) => module
                     .meta_predicates
-                    .get(&(name.clone(), arity))
+                    .get(&(name, arity))
                     .or_else(|| self.meta_predicates.get(&(name, arity))),
                 None => self.meta_predicates.get(&(name, arity)),
             },
@@ -446,7 +437,7 @@ impl IndexStore {
                 .map(|skeleton| skeleton.core.is_dynamic)
                 .unwrap_or(false),
             _ => match self.modules.get(&module_name) {
-                Some(ref module) => module
+                Some(module) => module
                     .extensible_predicates
                     .get(&key)
                     .map(|skeleton| skeleton.core.is_dynamic)

--- a/src/machine/mock_wam.rs
+++ b/src/machine/mock_wam.rs
@@ -82,6 +82,12 @@ impl MockWAM {
     }
 }
 
+impl Default for MockWAM {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 pub struct TermCopyingMockWAM<'a> {
     pub wam: &'a mut MockWAM,
@@ -109,14 +115,14 @@ impl<'a> Deref for TermCopyingMockWAM<'a> {
     type Target = MockWAM;
 
     fn deref(&self) -> &Self::Target {
-        &self.wam
+        self.wam
     }
 }
 
 #[cfg(test)]
 impl<'a> DerefMut for TermCopyingMockWAM<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.wam
+        self.wam
     }
 }
 
@@ -165,9 +171,8 @@ impl<'a> CopierTarget for TermCopyingMockWAM<'a> {
 #[cfg(test)]
 pub fn all_cells_marked_and_unforwarded(heap: &[HeapCellValue]) {
     for (idx, cell) in heap.iter().enumerate() {
-        assert_eq!(
+        assert!(
             cell.get_mark_bit(),
-            true,
             "cell {:?} at index {} is not marked",
             cell,
             idx
@@ -230,20 +235,16 @@ impl Machine {
             &mut self.machine_st.arena,
         );
 
-        self.load_file(file.into(), stream);
+        self.load_file(file, stream);
         self.user_output.bytes().map(|b| b.unwrap()).collect()
     }
 
     pub fn test_load_string(&mut self, code: &str) -> Vec<u8> {
-        let stream = Stream::from_owned_string(
-            code.to_owned(),
-            &mut self.machine_st.arena,
-        );
+        let stream = Stream::from_owned_string(code.to_owned(), &mut self.machine_st.arena);
 
-        self.load_file("<stdin>".into(), stream);
+        self.load_file("<stdin>", stream);
         self.user_output.bytes().map(|b| b.unwrap()).collect()
     }
-
 }
 
 #[cfg(test)]

--- a/src/machine/preprocessor.rs
+++ b/src/machine/preprocessor.rs
@@ -100,7 +100,7 @@ fn setup_module_export(
 }
 
 pub(crate) fn build_rule_body(vars: &[Term], body_term: Term) -> Term {
-    let head_term = Term::Clause(Cell::default(), atom!(""), vars.iter().cloned().collect());
+    let head_term = Term::Clause(Cell::default(), atom!(""), vars.to_vec());
     let rule = vec![head_term, body_term];
 
     Term::Clause(Cell::default(), atom!(":-"), rule)
@@ -238,7 +238,7 @@ fn setup_meta_predicate<'a, LS: LoadState<'a>>(
     ) -> Result<(Atom, Vec<MetaSpec>), CompilationError> {
         let mut meta_specs = vec![];
 
-        for meta_spec in terms.into_iter() {
+        for meta_spec in terms.iter_mut() {
             match meta_spec {
                 Term::Literal(_, Literal::Atom(meta_spec)) => {
                     let meta_spec = match meta_spec {
@@ -310,11 +310,11 @@ pub(super) fn setup_declaration<'a, LS: LoadState<'a>>(
             }
             (atom!("module"), 2) => {
                 let atom_tbl = &mut LS::machine_st(&mut loader.payload).atom_tbl;
-                Ok(Declaration::Module(setup_module_decl(terms, &atom_tbl)?))
+                Ok(Declaration::Module(setup_module_decl(terms, atom_tbl)?))
             }
             (atom!("op"), 3) => {
                 let atom_tbl = &mut LS::machine_st(&mut loader.payload).atom_tbl;
-                Ok(Declaration::Op(setup_op_decl(terms, &atom_tbl)?))
+                Ok(Declaration::Op(setup_op_decl(terms, atom_tbl)?))
             }
             (atom!("non_counted_backtracking"), 1) => {
                 let (name, arity) = setup_predicate_indicator(&mut terms.pop().unwrap())?;
@@ -323,7 +323,7 @@ pub(super) fn setup_declaration<'a, LS: LoadState<'a>>(
             (atom!("use_module"), 1) => Ok(Declaration::UseModule(setup_use_module_decl(terms)?)),
             (atom!("use_module"), 2) => {
                 let atom_tbl = &mut LS::machine_st(&mut loader.payload).atom_tbl;
-                let (name, exports) = setup_qualified_import(terms, &atom_tbl)?;
+                let (name, exports) = setup_qualified_import(terms, atom_tbl)?;
 
                 Ok(Declaration::UseQualifiedModule(name, exports))
             }

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -56,7 +56,7 @@ impl Index<usize> for AndFrame {
         let index_offset = (index - 1) * mem::size_of::<HeapCellValue>();
 
         unsafe {
-            let ptr = mem::transmute::<&AndFrame, *const u8>(self);
+            let ptr = self as *const crate::machine::stack::AndFrame as *const u8;
             let ptr = ptr as usize + prelude_offset + index_offset;
 
             &*(ptr as *const HeapCellValue)
@@ -70,7 +70,7 @@ impl IndexMut<usize> for AndFrame {
         let index_offset = (index - 1) * mem::size_of::<HeapCellValue>();
 
         unsafe {
-            let ptr = mem::transmute::<&mut AndFrame, *const u8>(self);
+            let ptr = self as *mut crate::machine::stack::AndFrame as *const u8;
             let ptr = ptr as usize + prelude_offset + index_offset;
 
             &mut *(ptr as *mut HeapCellValue)
@@ -129,7 +129,7 @@ impl Index<usize> for OrFrame {
         let index_offset = index * mem::size_of::<HeapCellValue>();
 
         unsafe {
-            let ptr = mem::transmute::<&OrFrame, *const u8>(self);
+            let ptr = self as *const crate::machine::stack::OrFrame as *const u8;
             let ptr = ptr as usize + prelude_offset + index_offset;
 
             &*(ptr as *const HeapCellValue)
@@ -144,7 +144,7 @@ impl IndexMut<usize> for OrFrame {
         let index_offset = index * mem::size_of::<HeapCellValue>();
 
         unsafe {
-            let ptr = mem::transmute::<&mut OrFrame, *const u8>(self);
+            let ptr = self as *mut crate::machine::stack::OrFrame as *const u8;
             let ptr = ptr as usize + prelude_offset + index_offset;
 
             &mut *(ptr as *mut HeapCellValue)

--- a/src/parser/macros.rs
+++ b/src/parser/macros.rs
@@ -77,7 +77,7 @@ macro_rules! cut_char {
 #[macro_export]
 macro_rules! decimal_digit_char {
     ($c: expr) => {
-        ('0'..='9').contains(&$c)
+        $c.is_ascii_digit()
     };
 }
 
@@ -125,7 +125,7 @@ macro_rules! graphic_token_char {
 #[macro_export]
 macro_rules! hexadecimal_digit_char {
     ($c: expr) => {
-        ('0'..='9').contains(&$c) || ('A'..='F').contains(&$c) || ('a'..='f').contains(&$c)
+        $c.is_ascii_digit() || ('A'..='F').contains(&$c) || ('a'..='f').contains(&$c)
     };
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11,4 +11,5 @@ pub mod ast;
 #[macro_use]
 pub mod macros;
 pub mod lexer;
+#[allow(clippy::module_inception)]
 pub mod parser;

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -28,6 +28,7 @@ impl<T: RawBlockTraits> RawBlock<T> {
         }
     }
 
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let mut block = Self::empty_block();
 
@@ -71,7 +72,7 @@ impl<T: RawBlockTraits> RawBlock<T> {
             } else {
                 let allocated = (*self.ptr.get()) as usize - self.base as usize;
                 self.base.copy_to(new_block.base.cast_mut(), allocated);
-                *new_block.ptr.get_mut() = new_block.base.offset(allocated as isize).cast_mut();
+                *new_block.ptr.get_mut() = new_block.base.add(allocated).cast_mut();
                 Some(new_block)
             }
         }

--- a/src/rcu.rs
+++ b/src/rcu.rs
@@ -6,7 +6,7 @@ use std::{
     ptr::NonNull,
     sync::{
         atomic::{AtomicPtr, AtomicU8},
-        Arc, Weak, RwLock
+        Arc, RwLock, Weak,
     },
 };
 
@@ -52,7 +52,7 @@ impl<T> Rcu<T> {
                 // register the current threads epoch counter on init
                 EPOCH_COUNTERS
                     .write()
-		    .unwrap()
+                    .unwrap()
                     .push(Arc::downgrade(&epoch_counter));
                 epoch_counter
             });

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -64,10 +64,7 @@ impl<'a> CompilationTarget<'a> for FactInstruction {
     }
 
     fn is_void_instr(instr: &Instruction) -> bool {
-        match instr {
-            &Instruction::UnifyVoid(_) => true,
-            _ => false,
-        }
+        matches!(instr, &Instruction::UnifyVoid(_))
     }
 
     fn to_pstr(lvl: Level, string: Atom, r: RegType, has_tail: bool) -> Instruction {
@@ -75,9 +72,8 @@ impl<'a> CompilationTarget<'a> for FactInstruction {
     }
 
     fn incr_void_instr(instr: &mut Instruction) {
-        match instr {
-            &mut Instruction::UnifyVoid(ref mut incr) => *incr += 1,
-            _ => {}
+        if let &mut Instruction::UnifyVoid(ref mut incr) = instr {
+            *incr += 1
         }
     }
 
@@ -146,16 +142,12 @@ impl<'a> CompilationTarget<'a> for QueryInstruction {
     }
 
     fn is_void_instr(instr: &Instruction) -> bool {
-        match instr {
-            &Instruction::SetVoid(_) => true,
-            _ => false,
-        }
+        matches!(instr, &Instruction::SetVoid(_))
     }
 
     fn incr_void_instr(instr: &mut Instruction) {
-        match instr {
-            &mut Instruction::SetVoid(ref mut incr) => *incr += 1,
-            _ => {}
+        if let &mut Instruction::SetVoid(ref mut incr) = instr {
+            *incr += 1
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -194,6 +194,7 @@ pub enum TrailRef {
     BlackboardOffset(Atom, HeapCellValue), // key atom, key value
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(BitfieldSpecifier, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[bits = 6]
 pub(crate) enum TrailEntryTag {
@@ -331,7 +332,7 @@ impl From<ConsPtr> for HeapCellValue {
     }
 }
 
-impl<'a> From<(Number, &mut Arena)> for HeapCellValue {
+impl From<(Number, &mut Arena)> for HeapCellValue {
     #[inline(always)]
     fn from((n, arena): (Number, &mut Arena)) -> HeapCellValue {
         use ordered_float::OrderedFloat;
@@ -393,16 +394,16 @@ impl HeapCellValue {
 
     #[inline]
     pub fn is_ref(self) -> bool {
-        match self.get_tag() {
+        matches!(
+            self.get_tag(),
             HeapCellValueTag::Str
-            | HeapCellValueTag::Lis
-            | HeapCellValueTag::Var
-            | HeapCellValueTag::StackVar
-            | HeapCellValueTag::AttrVar
-            | HeapCellValueTag::PStrLoc
-            | HeapCellValueTag::PStrOffset => true,
-            _ => false,
-        }
+                | HeapCellValueTag::Lis
+                | HeapCellValueTag::Var
+                | HeapCellValueTag::StackVar
+                | HeapCellValueTag::AttrVar
+                | HeapCellValueTag::PStrLoc
+                | HeapCellValueTag::PStrOffset
+        )
     }
 
     #[inline]
@@ -491,7 +492,7 @@ impl HeapCellValue {
 
     #[inline]
     pub fn get_value(self) -> u64 {
-        self.val() as u64
+        self.val()
     }
 
     #[inline]
@@ -739,10 +740,7 @@ impl UntypedArenaPtr {
 
     #[inline]
     pub fn payload_offset(self) -> *const u8 {
-        unsafe {
-            self.get_ptr()
-                .offset(mem::size_of::<ArenaHeader>() as isize)
-        }
+        unsafe { self.get_ptr().add(mem::size_of::<ArenaHeader>()) }
     }
 
     #[inline]
@@ -806,7 +804,7 @@ impl Sub<i64> for HeapCellValue {
                 | tag @ HeapCellValueTag::PStrLoc
                 | tag @ HeapCellValueTag::Var
                 | tag @ HeapCellValueTag::AttrVar => {
-                    HeapCellValue::build_with(tag, self.get_value() + rhs.abs() as u64)
+                    HeapCellValue::build_with(tag, self.get_value() + rhs.unsigned_abs())
                 }
                 _ => self,
             }

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -69,7 +69,7 @@ fn handle_residual_goal() {
 #[test]
 fn occurs_check_flag() {
     run_top_level_test_with_args(
-        &["tests-pl/issue841-occurs-check.pl"],
+        ["tests-pl/issue841-occurs-check.pl"],
         "\
          f(X, X).\n\
          halt.\n\
@@ -102,14 +102,14 @@ fn occurs_check_flag2() {
 // issue #839
 #[test]
 fn op3() {
-    run_top_level_test_with_args(&["tests-pl/issue839-op3.pl", "-g", "halt"], "", "")
+    run_top_level_test_with_args(["tests-pl/issue839-op3.pl", "-g", "halt"], "", "")
 }
 
 // issue #820
 #[test]
 fn multiple_goals() {
     run_top_level_test_with_args(
-        &["-g", "test", "-g", "halt", "tests-pl/issue820-goals.pl"],
+        ["-g", "test", "-g", "halt", "tests-pl/issue820-goals.pl"],
         "",
         "helloworld\n",
     );
@@ -119,7 +119,7 @@ fn multiple_goals() {
 #[test]
 fn compound_goal() {
     run_top_level_test_with_args(
-        &["-g", "test,halt", "tests-pl/issue820-goals.pl"],
+        ["-g", "test,halt", "tests-pl/issue820-goals.pl"],
         "",
         "helloworld\n",
     )

--- a/tests/scryer/src_tests.rs
+++ b/tests/scryer/src_tests.rs
@@ -58,7 +58,7 @@ fn setup_call_cleanup_load() {
 #[test]
 fn setup_call_cleanup_process() {
     run_top_level_test_with_args(
-        &["src/tests/setup_call_cleanup.pl", "-f", "-g", "halt"],
+        ["src/tests/setup_call_cleanup.pl", "-f", "-g", "halt"],
         "",
         "1+21+31+2>A+B1+G1+2>41+2>B1+2>31+2>31+2>4ba",
     );
@@ -79,7 +79,7 @@ fn iso_conformity_tests() {
 #[test]
 fn dif_tests() {
     run_top_level_test_with_args(
-        &["src/tests/dif.pl", "-f", "-g", "main_quiet"],
+        ["src/tests/dif.pl", "-f", "-g", "main_quiet"],
         "",
         "All tests passed",
     );
@@ -88,7 +88,7 @@ fn dif_tests() {
 #[test]
 fn ground_tests() {
     run_top_level_test_with_args(
-        &["src/tests/ground.pl", "-f", "-g", "main_quiet"],
+        ["src/tests/ground.pl", "-f", "-g", "main_quiet"],
         "",
         "All tests passed",
     );
@@ -97,7 +97,7 @@ fn ground_tests() {
 #[test]
 fn term_variables_tests() {
     run_top_level_test_with_args(
-        &["src/tests/term_variables.pl", "-f", "-g", "main_quiet"],
+        ["src/tests/term_variables.pl", "-f", "-g", "main_quiet"],
         "",
         "All tests passed",
     );
@@ -106,7 +106,7 @@ fn term_variables_tests() {
 #[test]
 fn acyclic_term_tests() {
     run_top_level_test_with_args(
-        &["src/tests/acyclic_term.pl", "-f", "-g", "main_quiet"],
+        ["src/tests/acyclic_term.pl", "-f", "-g", "main_quiet"],
         "",
         "All tests passed",
     );


### PR DESCRIPTION
This PR resolves all clippy lints and formats the codebase. It also splits the formatting and clippy CI checks into a separate job and makes them 'mandatory'; really this means that the clippy/fmt check may show as failed but the regular build-test jobs will continue as normal, and you can choose to merge with outstanding clippy/formatting issues if you want.

My goal here is to make clippy suggestions and autoformatting actually useful during development if you have it set up. It's very good at finding better ways to represent something for new and experienced rust devs alike, but it's not very useful if the suggestion you need is buried under a pile of 400+ other suggestions. Hence this PR: rip off the bandaid once so the suggestions become useful again.

I intentionally tried to avoid making behavioral changes, and our test suite backs us up here. To give a flavor of applied changes here are some common lints that were fixed:

* Unnecessarily taking the address of or dereferencing a variable
* Using `if let` construct instead of `match` for single match arms
* Using `matches!()` macro instead of `match` when all match arms return true and the default arm returns false
* Adding annotations to allow a clippy pattern in a particular location where it's reasonable or doesn't have a clear fix (you could see these as TODOs, just search for `allow(clippy::` to see the list)
* Using specialized methods instead of a method + expression
* Removing elidable lifetimes
* Using `assert!()` instead of `assert_eq!(_, bool)`
* Switching to a simpler iteration method (from `while` to `for` etc)
* Deriving the default trait instead of implementing it manually
* Removing unnecessary return

---

This basically touches all rust files which could result in shadowing potentially useful historical context when viewing the history or blame of a file. To mitigate this issue I added the lint/formatting commit id to a new `.git-blame-ignore-revs` file which is a list of commits that both git and github.com can use to skip commits that make bulk changes to a repo. See [GitHub docs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view).

---

There are a lot of changes here, and I understand that not coordinating a change like this ahead of time could make accepting this pr complicated and may require extra work to make ready to merge.