### PR TITLE
Fixing run_query()

### DIFF
--- a/src/machine/lib_machine.rs
+++ b/src/machine/lib_machine.rs
@@ -422,9 +422,8 @@ mod tests {
         );
     }
 
-    #[ignore = "fails on windows"]
     #[test]
-    fn stress_integration_test() {
+    fn integration_test() {
         let mut machine = Machine::new_lib();
 
         // File with test commands, i.e. program code to consult and queries to run


### PR DESCRIPTION
After https://github.com/mthom/scryer-prolog/pull/1880 got merged and 0.9.3 released, we've switched over to that new version and are now running into the following panic, which is reproducible with the integration tests we've already had for `run_query()` but which were deactivated in our branch because they failed on windows and blocked CI.

```
FATAL PANIC PanicInfo {
    payload: Any { .. },

    message: Some(
        index out of bounds: the len is 16 but the index is 4571,
    ),
    location: Location
 {
        file: "C:\\Users\\fayee\\
dev\\mthom\\scryer-prolog\\src\\
heap_iter.rs",
        line: 299,
        col: 
17,
    },
    can_unwind: true,
}
```

This panic occurs in the printer for the first test case from the integration script, which runs the following program:

```Prolog
:- discontiguous(triple/3).
:- discontiguous(link/5).
:- discontiguous(reachable/2).
reachable(A,B) :- triple(A,_,B).
reachable(A,B) :- triple(A,_,X), reachable(X,B).
:- discontiguous(hiddenExpression/1).
:- discontiguous(languageAddress/2).
:- discontiguous(languageName/2).
:- discontiguous(expressionAddress/2).
:- discontiguous(register_sdna_flow/2).
:- discontiguous(flowable/2).
:- discontiguous(flow_state/3).
:- discontiguous(start_action/2).
:- discontiguous(action/4).
:- discontiguous(subject_class/2).
:- discontiguous(constructor/2).
:- discontiguous(destructor/2).
:- discontiguous(instance/2).
:- discontiguous(property/2).
:- discontiguous(property_getter/4).
:- discontiguous(property_setter/3).
:- discontiguous(property_resolve/2).
:- discontiguous(property_resolve_language/3).
:- discontiguous(property_named_option/4).
:- discontiguous(collection/2).
:- discontiguous(collection_getter/4).
:- discontiguous(collection_setter/3).
:- discontiguous(collection_remover/3).
:- discontiguous(collection_adder/3).
:- discontiguous(p3_class_icon/2).
:- discontiguous(p3_class_color/2).
:- discontiguous(p3_instance_color/3).
```

with query:
```Prolog
subject_class(X, _).
```

The printer tries to print values for X, which don't exist because there is no solution.

My suspicion is that our code in `run_query()` doesn't detect the case that we don't have a solution because of the use of `discontiguous` here.
