### PR TITLE
Add checks permission to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     - cron: '0 0 * * 3' # At 12:00 AM, only on Wednesday
   workflow_dispatch:
 
+permissions:
+  checks: write
+
 jobs:
   style:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This should allow dependabot builds to complete, see #2159