### PR TITLE
Implement $cpu_now in wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ console_error_panic_hook = "0.1"
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.5"
-web-sys = { version = "0.3", features = ["Document", "Window", "Element"] }
+web-sys = { version = "0.3", features = ["Document", "Window", "Element", "Performance"] }
 js-sys = "0.3"
 
 [target.'cfg(target_os = "wasi")'.dependencies]

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4191,7 +4191,14 @@ impl Machine {
     #[cfg(target_arch = "wasm32")]
     #[inline(always)]
     pub(crate) fn cpu_now(&mut self) {
-        // TODO
+        let millisecs = web_sys::window()
+            .expect("window global object should be available")
+            .performance()
+            .expect("performance property in window should be available")
+            .now();
+        let secs = float_alloc!(millisecs / 1000.0, self.machine_st.arena);
+
+        self.machine_st.unify_f64(secs, self.deref_register(1));
     }
 
     #[inline(always)]
@@ -4894,7 +4901,7 @@ impl Machine {
         let code = self.deref_register(1);
         let result_reg = self.deref_register(2);
         if let Some(code) = self.machine_st.value_to_str_like(code) {
-            let result = match js_sys::eval(&code.as_str()) {
+            match js_sys::eval(&code.as_str()) {
                 Ok(result) => self.unify_js_value(result, result_reg),
                 Err(result) => self.unify_js_value(result, result_reg),
             };


### PR DESCRIPTION
As shown [here](https://github.com/aarroyoc/scryer-playground/issues/11), $cpu_now/1 was missing an implementation for wasm32, making the time/1 predicate unusable. This adds an implementation for it.

![imagen (6)](https://github.com/mthom/scryer-prolog/assets/3681517/1bc9cfd5-19df-46f5-acb4-ec6e022c010e)
 