### PR TITLE
ADDED: term_si/1, true for terms

### DIFF
--- a/src/lib/si.pl
+++ b/src/lib/si.pl
@@ -37,6 +37,7 @@
                atomic_si/1,
                list_si/1,
                character_si/1,
+               term_si/1,
                chars_si/1,
                dif_si/2]).
 
@@ -67,6 +68,11 @@ character_si(Ch) :-
    functor(Ch,Ch,0),
    atom(Ch),
    atom_length(Ch,1).
+
+term_si(Term) :-
+   (   ground(Term) -> acyclic_term(Term)
+   ;   throw(error(instantiation_error, term_si/1))
+   ).
 
 chars_si(Chs0) :-
    '$skip_max_list'(_,_, Chs0,Chs),


### PR DESCRIPTION
One use case is to ensure that once/1 is safe to use:

    term_si(Goal),
    once(Goal)

In such cases, Goal is ground and can yield at most one solution, therefore once/1 does not remove any solutions.