### PR TITLE
Add '%' to the list of graphic_chars (#2119)

### DIFF
--- a/src/parser/macros.rs
+++ b/src/parser/macros.rs
@@ -112,7 +112,7 @@ macro_rules! exponent_char {
 #[macro_export]
 macro_rules! graphic_char {
     ($c: expr) => ($crate::char_class!($c, ['#', '$', '&', '*', '+', '-', '.', '/', ':',
-                                            '<', '=', '>', '?', '@', '^', '~']))
+                                            '<', '=', '>', '?', '@', '^', '~', '%']))
 }
 
 #[macro_export]


### PR DESCRIPTION
Add '%' to `graphic_char` macro, to be consistent with `is_ascii_graphic`.

Fixes #2199 (Probably should have just opened the PR by itself)