### PR TITLE
Revert "Add '%' to the list of graphic_chars (#2199)"

### DIFF
--- a/src/parser/macros.rs
+++ b/src/parser/macros.rs
@@ -112,7 +112,7 @@ macro_rules! exponent_char {
 #[macro_export]
 macro_rules! graphic_char {
     ($c: expr) => ($crate::char_class!($c, ['#', '$', '&', '*', '+', '-', '.', '/', ':',
-                                            '<', '=', '>', '?', '@', '^', '~', '%']))
+                                            '<', '=', '>', '?', '@', '^', '~']))
 }
 
 #[macro_export]


### PR DESCRIPTION
Reverts mthom/scryer-prolog#2200

My mistake, apparently this does not conform to the standard: https://github.com/mthom/scryer-prolog/issues/2199#issuecomment-1837892004