### PR TITLE
Export read_term_from_chars/2

### DIFF
--- a/src/lib/charsio.pl
+++ b/src/lib/charsio.pl
@@ -12,6 +12,7 @@ read and write chars.
                     get_n_chars/3,
                     get_line_to_chars/3,
                     read_from_chars/2,
+                    read_term_from_chars/2,
                     read_term_from_chars/3,
                     write_term_to_chars/3,
                     chars_base64/3]).


### PR DESCRIPTION
`read_term_from_chars/2` wasn't being exported in `library(charsio)`, even though it appears in the documentation. Maybe there are more cases like this in the standard library?