### PR TITLE
Fix backslash docs

### DIFF
--- a/src/lib/clpb.pl
+++ b/src/lib/clpb.pl
@@ -189,18 +189,18 @@ A _Boolean expression_ is one of:
 | `1`                | true                                 |
 | _variable_         | unknown truth value                  |
 | _atom_             | universally quantified variable      |
-| ~ _Expr_           | logical NOT                          |
-| _Expr_ + _Expr_    | logical OR                           |
-| _Expr_ * _Expr_    | logical AND                          |
-| _Expr_ # _Expr_    | exclusive OR                         |
-| _Var_ ^ _Expr_     | existential quantification           |
-| _Expr_ =:= _Expr_  | equality                             |
-| _Expr_ =\= _Expr_  | disequality (same as #)              |
-| _Expr_ =< _Expr_   | less or equal (implication)          |
-| _Expr_ >= _Expr_   | greater or equal                     |
-| _Expr_ < _Expr_    | less than                            |
-| _Expr_ > _Expr_    | greater than                         |
-| card(Is,Exprs)     | cardinality constraint (_see below_) |
+| `~` _Expr_           | logical NOT                          |
+| _Expr_ `+` _Expr_    | logical OR                           |
+| _Expr_ `*` _Expr_    | logical AND                          |
+| _Expr_ `#` _Expr_    | exclusive OR                         |
+| _Var_ `^` _Expr_     | existential quantification           |
+| _Expr_ `=:=` _Expr_  | equality                             |
+| _Expr_ `=\=` _Expr_  | disequality (same as #)              |
+| _Expr_ `=<` _Expr_   | less or equal (implication)          |
+| _Expr_ `>=` _Expr_   | greater or equal                     |
+| _Expr_ `<` _Expr_    | less than                            |
+| _Expr_ `>` _Expr_    | greater than                         |
+| `card(Is,Exprs)`     | cardinality constraint (_see below_) |
 | `+(Exprs)`         | n-fold disjunction (_see below_)     |
 | `*(Exprs)`         | n-fold conjunction (_see below_)     |
 

--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -1735,7 +1735,7 @@ intervals_to_domain(Is, D) :-
 %           _Lower_ must be an integer or the atom *inf*, which
 %           denotes negative infinity. _Upper_ must be an integer or
 %           the atom *sup*, which denotes positive infinity.
-%         * Domain1 \/ Domain2
+%         * Domain1 `\/` Domain2
 %           The union of Domain1 and Domain2.
 
 Var in Dom :- clpz_in(Var, Dom).


### PR DESCRIPTION
That syntax must be in a code block, so escaping functionality is disabled.

https://github.com/mthom/scryer-prolog/issues/2228
and
https://github.com/mthom/scryer-prolog/issues/2206