### PR TITLE
Parse as much of a list as possible as a partial string 

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -97,7 +97,12 @@ pub(crate) fn as_partial_string(
                         string.push(*c);
                     }
                     _ => {
-                        return Err(Term::Cons(Cell::default(), Box::new(head), orig_tail));
+                        tail = Term::Cons(
+                            Cell::default(),
+                            Box::new((**prev).clone()),
+                            Box::new((**succ).clone()),
+                        );
+                        break;
                     }
                 }
 


### PR DESCRIPTION
```prolog
?- [user].
test1([a,b,_]).
test2([a,b,c,_,d,e,f,_]).

?- wam_instructions(test1/1, Ins), maplist(portray_clause, Ins).
% The list is parsed as a partial string starting with "ab".
get_partial_string(level(shallow),"ab",x(1),true).
unify_variable(x(2)).
get_list(level(deep),x(2)).
unify_void(1).
unify_constant([]).
proceed.
   ...
?- wam_instructions(test2/1, Ins), maplist(portray_clause, Ins).
% The list is parsed as a partial string starting with "abc".
get_partial_string(level(shallow),"abc",x(1),true).
unify_variable(x(2)).
get_list(level(deep),x(2)).
unify_void(1).
unify_variable(x(2)).
% Inside the tail of the first partial string there is another partial string
% starting with "def".
get_partial_string(level(deep),"def",x(2),true).
unify_variable(x(3)).
get_list(level(deep),x(3)).
unify_void(1).
unify_constant([]).
proceed.
   ...
```

I used `clone()` here because it seemed too hard to fight the borrow checker to be able to use `mem::replace()` like in the other match branch. I'm not sure if this has unwanted consequences, but everything seems to be working.

Closes #1404.