### PR TITLE
Emit warnings as Prolog comments

### DIFF
--- a/src/loader.pl
+++ b/src/loader.pl
@@ -112,7 +112,7 @@ success_or_warning(Goal) :-
     (   call(Goal) ->
         true
     ;   %% initialization goals can fail without thwarting the load.
-        write('Warning: initialization/1 failed for: '),
+        write('% Warning: initialization/1 failed for: '),
         writeq(Goal),
         nl
     ).
@@ -188,7 +188,7 @@ warn_about_singletons([], _).
 warn_about_singletons([Singleton|Singletons], LinesRead) :-
     (  filter_anonymous_vars([Singleton|Singletons], VarEqs),
        VarEqs \== [] ->
-       write('Warning: singleton variables '),
+       write('% Warning: singleton variables '),
        print_comma_separated_list(VarEqs),
        write(' at line '),
        write(LinesRead),
@@ -286,7 +286,7 @@ module_expanded_head_variables(Head, HeadVars) :-
 
 print_goal_expansion_warning(Pred) :-
     nl,
-    write('Warning: clause body goal expansion failed because '),
+    write('% Warning: clause body goal expansion failed because '),
     writeq(Pred),
     write(' is not callable.'),
     nl.

--- a/src/machine/compile.rs
+++ b/src/machine/compile.rs
@@ -1208,7 +1208,7 @@ fn print_overwrite_warning(
     }
 
     println!(
-        "Warning: overwriting {}/{} because the clauses are discontiguous",
+        "% Warning: overwriting {}/{} because the clauses are discontiguous",
         key.0.as_str(),
         key.1
     );
@@ -2179,7 +2179,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             if is_cross_module_clause && !local_predicate_info.is_extensible {
                 if predicate_info.is_multifile {
                     println!(
-                        "Warning: overwriting multifile predicate {}:{}/{} because \
+                        "% Warning: overwriting multifile predicate {}:{}/{} because \
                               it was not locally declared multifile.",
                         self.payload.predicates.compilation_target,
                         key.0.as_str(),

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -1130,7 +1130,7 @@ impl Machine {
             }
             Unknown::Warn => {
                 println!(
-                    "warning: predicate {}/{} is undefined",
+                    "% Warning: predicate {}/{} is undefined",
                     name.as_str(),
                     arity
                 );

--- a/src/read.rs
+++ b/src/read.rs
@@ -130,7 +130,7 @@ impl ReadlineStream {
             if let Some(mut path) = dirs_next::home_dir() {
                 path.push(HISTORY_FILE);
                 if path.exists() && rl.load_history(&path).is_err() {
-                    println!("Warning: loading history failed");
+                    println!("% Warning: loading history failed");
                 }
             }
 
@@ -213,10 +213,10 @@ impl ReadlineStream {
             path.push(HISTORY_FILE);
             if path.exists() {
                 if self.rl.append_history(&path).is_err() {
-                    println!("Warning: couldn't append history (existing file)");
+                    println!("% Warning: couldn't append history (existing file)");
                 }
             } else if self.rl.save_history(&path).is_err() {
-                println!("Warning: couldn't save history (new file)");
+                println!("% Warning: couldn't save history (new file)");
             }
         }
     }

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -134,7 +134,7 @@ run_goals([g(Gs0)|Goals]) :- !,
                   write_term(Exception, [double_quotes(DQ)]), nl % halt?
               )
         ) -> true
-    ;   write('Warning: initialization failed for: '),
+    ;   write('% Warning: initialization failed for: '),
         write_term(Goal, [variable_names(VNs),double_quotes(DQ)]), nl
     ),
     run_goals(Goals).

--- a/tests/scryer/cli/issues/singleton_warning.stdout
+++ b/tests/scryer/cli/issues/singleton_warning.stdout
@@ -1,2 +1,2 @@
-Warning: singleton variables X at line 4 of singleton_example.pl
+% Warning: singleton variables X at line 4 of singleton_example.pl
    true.


### PR DESCRIPTION
Following the discussion at #2253, this makes warnings be emitted as Prolog comments, meaning that they can be read back as valid Prolog. Example:

```prolog
?- [user].                                                                                                                                                                                         
test :- X = _.                                                                                                                                                                                     
% Warning: singleton variables X at line 1 of user
```