### PR TITLE
Move argv/1 to library(os)

### DIFF
--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -604,6 +604,8 @@ enum SystemClauseType {
     KeySortWithConstantVarOrdering,
     #[strum_discriminants(strum(props(Arity = "0", Name = "$inference_limit_exceeded")))]
     InferenceLimitExceeded,
+    #[strum_discriminants(strum(props(Arity = "1", Name = "$argv")))]
+    Argv,
     REPL(REPLCodePtr),
 }
 
@@ -1869,6 +1871,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::CallRemoveModuleExports |
                     &Instruction::CallAddNonCountedBacktracking |
                     &Instruction::CallPopCount |
+                    &Instruction::CallArgv |
                     &Instruction::CallEd25519SignRaw |
                     &Instruction::CallEd25519VerifyRaw |
                     &Instruction::CallEd25519SeedToPublicKey => {
@@ -2104,6 +2107,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::ExecuteRemoveModuleExports |
                     &Instruction::ExecuteAddNonCountedBacktracking |
                     &Instruction::ExecutePopCount |
+                    &Instruction::ExecuteArgv |
                     &Instruction::ExecuteEd25519SignRaw |
                     &Instruction::ExecuteEd25519VerifyRaw |
                     &Instruction::ExecuteEd25519SeedToPublicKey => {

--- a/src/bin/scryer-prolog.rs
+++ b/src/bin/scryer-prolog.rs
@@ -23,6 +23,6 @@ fn main() -> std::process::ExitCode {
 
     runtime.block_on(async move {
         let mut wam = machine::Machine::new(Default::default());
-        wam.run_top_level(atom!("$toplevel"), (atom!("$repl"), 1))
+        wam.run_module_predicate(atom!("$toplevel"), (atom!("$repl"), 0))
     })
 }

--- a/src/lib/os.pl
+++ b/src/lib/os.pl
@@ -23,7 +23,9 @@ finding out the PID of the running system.
                unsetenv/1,
                shell/1,
                shell/2,
-               pid/1]).
+               pid/1,
+	       raw_argv/1,
+	       argv/1]).
 
 :- use_module(library(error)).
 :- use_module(library(charsio)).
@@ -110,3 +112,32 @@ permitted('_').
 must_be_chars(Cs) :-
         must_be(list, Cs),
         maplist(must_be(character), Cs).
+
+%% raw_argv(-Argv)
+%
+% True iff Argv is the list of arguments that this program was started with (usually passed via command line).
+% In contrast to `argv/1`, this version includes every argument, without any postprocessing, just as the operating
+% system reports it to the system. This includes-flags of Scryer itself, which are not needed in general.
+raw_argv(Argv) :-
+    can_be(list, Argv),
+    '$argv'(Argv).
+
+%% argv(-Argv)
+%
+% True if Argv is the list of arguments that this program was started with (usually passed via command line).
+% In this version, only arguments specific to the program are passed. To differentiate between the system
+% arguments and the program arguments, we use `--` as a separator.
+%
+% Example:
+% ```
+% % Call with scryer-prolog -f -- -t hello
+% ?- argv(X).
+%     X = ["-t", "hello"].
+% ```
+argv(Argv) :-
+    can_be(list, Argv),
+    '$argv'(Argv0),
+    (    append(_, ["--"|Argv], Argv0) ->
+	 true
+    ;    Argv = []
+    ).

--- a/src/loader.pl
+++ b/src/loader.pl
@@ -138,7 +138,7 @@ file_load_cleanup(Evacuable, Error) :-
     load_context(Module),
     abolish(Module:'$initialization_goals'/1),
     unload_evacuable(Evacuable),
-    (  clause('$toplevel':argv(_), _) ->
+    (  clause('$toplevel':started, _) ->
        % let the toplevel call loader:write_error/1
        throw(Error)
     ;  '$print_message_and_fail'(Error)

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -4147,6 +4147,14 @@ impl Machine {
                         try_or_throw!(self.machine_st, self.js_eval());
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }
+                    &Instruction::CallArgv => {
+                        try_or_throw!(self.machine_st, self.argv());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteArgv => {
+                        try_or_throw!(self.machine_st, self.argv());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
                     &Instruction::CallCurrentTime => {
                         self.current_time();
                         step_or_fail!(self, self.machine_st.p += 1);

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -228,7 +228,7 @@ impl Machine {
         self.machine_st.throw_exception(err);
     }
 
-    fn run_module_predicate(
+    pub fn run_module_predicate(
         &mut self,
         module_name: Atom,
         key: PredicateKey,
@@ -305,29 +305,6 @@ impl Machine {
                 self.machine_st.attr_var_init.verify_attrs_loc = code_index.local().unwrap();
             }
         }
-    }
-
-    pub fn run_top_level(
-        &mut self,
-        module_name: Atom,
-        key: PredicateKey,
-    ) -> std::process::ExitCode {
-        let mut arg_pstrs = vec![];
-
-        for arg in env::args() {
-            arg_pstrs.push(put_complete_string(
-                &mut self.machine_st.heap,
-                &arg,
-                &self.machine_st.atom_tbl,
-            ));
-        }
-
-        self.machine_st.registers[1] = heap_loc_as_cell!(iter_to_heap_list(
-            &mut self.machine_st.heap,
-            arg_pstrs.into_iter()
-        ));
-
-        self.run_module_predicate(module_name, key)
     }
 
     pub fn set_user_input(&mut self, input: String) {

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4951,6 +4951,27 @@ impl Machine {
     }
 
     #[inline(always)]
+    pub(crate) fn argv(&mut self) -> CallResult {
+        let args = self.deref_register(1);
+
+        let mut args_pstrs = vec![];
+        for arg in env::args() {
+            args_pstrs.push(put_complete_string(
+                &mut self.machine_st.heap,
+                &arg,
+                &self.machine_st.atom_tbl,
+            ));
+        }
+        let cell = heap_loc_as_cell!(iter_to_heap_list(
+            &mut self.machine_st.heap,
+            args_pstrs.into_iter()
+        ));
+
+        unify!(self.machine_st, args, cell);
+        Ok(())
+    }
+
+    #[inline(always)]
     pub(crate) fn current_time(&mut self) {
         let timestamp = self.systemtime_to_timestamp(SystemTime::now());
         self.machine_st


### PR DESCRIPTION
By moving `argv/1` to `library(os)`, this predicate can be found and documented just like any other predicate. In addition, special code to handle the arguments in the top-level has been simplified.