### PR TITLE
Correct arithmetic disequalities accidentally broken in f5d9a67f3688ec9bb08dd3add05614552e082555

### DIFF
--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -2759,7 +2759,7 @@ geq(A, B) -->
             (   { fd_get(B, BD, _) } ->
                 { domain_supremum(BD, BS) },
                 (   { AI cis_geq BS } -> true
-                ;   propagator_init_trigger(pgeq(A,B))
+                ;   { propagator_init_trigger(pgeq(A,B)) }
                 )
             ;   (   { AI cis_geq n(B) } -> true
                 ;   { domain_remove_smaller_than(AD, B, AD1) },


### PR DESCRIPTION
Example:

    ?- X #>= Y.
    %@    clpz:(X#>=Y).