### PR TITLE
Special case for `(^)/2`

### DIFF
--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -5454,6 +5454,7 @@ run_propagator(pexp(X,Y,Z,Morph), MState) -->
             morph_into_propagator(MState, [Y,Z], reified_eq(1,Y,1,0,[],Z), Morph)
         ;   Y == 0 -> kill(MState), Z = 1
         ;   Y == 1 -> kill(MState), Z = X
+        ;   Y == Z -> kill(MState), X = Y, queue_goal(X in -1\/1)
         ;   nonvar(X) ->
             (   nonvar(Y) ->
                 (   Y >= 0 -> true ; X =:= -1 ),


### PR DESCRIPTION
The only solutions for `Z #= X^Z` are `X = Z, X in -1\/1`. Also helps avoid big numbers.