### PR TITLE
Initial Miri support

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -821,9 +821,9 @@ impl AllocSlab {
     }
 
     fn payload_offset<T>(&self) -> *mut T {
-        let mut ptr = (self as *const AllocSlab) as usize;
-        ptr += mem::size_of::<AllocSlab>();
-        ptr as *mut T
+        // This looks really scary, should this method be marked as unsafe?
+        // Also, this seems to cause UB.
+        unsafe { (self as *const AllocSlab).add(1) as *mut T }
     }
 }
 
@@ -864,6 +864,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn heap_cell_value_const_cast() {
         let mut wam = MockWAM::new();
         #[cfg(target_pointer_width = "32")]
@@ -907,6 +908,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn heap_put_literal_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -239,6 +239,7 @@ impl Atom {
         } else if let Some(ptr) = self.as_ptr() {
             AtomString::Dynamic(AtomTableRef::map(ptr, |ptr| {
                 let header =
+                    // Miri seems to hit this line a lot
                     unsafe { ptr::read::<AtomHeader>(ptr as *const u8 as *const AtomHeader) };
                 let len = header.len() as usize;
                 let buf = unsafe { (ptr as *const u8).add(mem::size_of::<AtomHeader>()) };
@@ -265,7 +266,7 @@ impl Atom {
 
 unsafe fn write_to_ptr(string: &str, ptr: *mut u8) {
     ptr::write(ptr as *mut _, AtomHeader::build_with(string.len() as u64));
-    let str_ptr = (ptr as usize + mem::size_of::<AtomHeader>()) as *mut u8;
+    let str_ptr = ptr.add(mem::size_of::<AtomHeader>());
     ptr::copy_nonoverlapping(string.as_ptr(), str_ptr, string.len());
 }
 

--- a/src/heap_iter.rs
+++ b/src/heap_iter.rs
@@ -685,6 +685,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "it takes too long to run")]
     fn heap_stackless_iter_tests() {
         let mut wam = MockWAM::new();
 
@@ -1756,6 +1757,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on atom_table.rs UB")]
     fn heap_stackful_iter_tests() {
         let mut wam = MockWAM::new();
 
@@ -2348,6 +2350,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on atom_table.rs UB")]
     fn heap_stackful_post_order_iter() {
         let mut wam = MockWAM::new();
 
@@ -2831,6 +2834,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on atom_table.rs UB")]
     fn heap_stackless_post_order_iter() {
         let mut wam = MockWAM::new();
 

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -1835,6 +1835,7 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn term_printing_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -1423,6 +1423,7 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn arith_eval_by_metacall_tests() {
         let mut wam = MachineState::new();
         let mut op_dir = default_op_dir();

--- a/src/machine/copier.rs
+++ b/src/machine/copier.rs
@@ -398,6 +398,7 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on atom_table.rs UB")]
     fn copier_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/machine/gc.rs
+++ b/src/machine/gc.rs
@@ -369,6 +369,7 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn heap_marking_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/machine/lib_machine.rs
+++ b/src/machine/lib_machine.rs
@@ -236,6 +236,7 @@ mod tests {
     use crate::machine::{QueryMatch, QueryResolution, Value};
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn programatic_query() {
         let mut machine = Machine::new_lib();
 
@@ -275,6 +276,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn failing_query() {
         let mut machine = Machine::new_lib();
         let query = String::from(r#"triple("a",P,"b")."#);
@@ -288,6 +290,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn complex_results() {
         let mut machine = Machine::new_lib();
         machine.load_module_string(
@@ -344,6 +347,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn empty_predicate() {
         let mut machine = Machine::new_lib();
         machine.load_module_string(
@@ -359,6 +363,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn list_results() {
         let mut machine = Machine::new_lib();
         machine.load_module_string(
@@ -387,6 +392,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn consult() {
         let mut machine = Machine::new_lib();
 
@@ -445,6 +451,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn integration_test() {
         let mut machine = Machine::new_lib();
 
@@ -486,6 +493,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn findall() {
         let mut machine = Machine::new_lib();
 

--- a/src/machine/mock_wam.rs
+++ b/src/machine/mock_wam.rs
@@ -260,6 +260,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn unify_tests() {
         let mut wam = MachineState::new();
         let mut op_dir = default_op_dir();
@@ -481,6 +482,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn test_unify_with_occurs_check() {
         let mut wam = MachineState::new();
         let mut op_dir = default_op_dir();

--- a/src/machine/partial_string.rs
+++ b/src/machine/partial_string.rs
@@ -785,6 +785,7 @@ mod test {
     use crate::machine::mock_wam::*;
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
     fn pstr_iter_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -189,7 +189,7 @@ impl Stack {
 
             for idx in 0..num_cells {
                 ptr::write(
-                    (new_ptr as usize + offset) as *mut HeapCellValue,
+                    new_ptr.add(offset) as *mut HeapCellValue,
                     stack_loc_as_cell!(AndFrame, e, idx + 1),
                 );
 
@@ -242,7 +242,8 @@ impl Stack {
     #[inline(always)]
     pub(crate) fn index_and_frame_mut(&mut self, e: usize) -> &mut AndFrame {
         unsafe {
-            let ptr = self.buf.base as usize + e;
+            // This is doing alignment wrong
+            let ptr = self.buf.base.add(e);
             &mut *(ptr as *mut AndFrame)
         }
     }
@@ -280,6 +281,7 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn stack_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -469,6 +469,7 @@ macro_rules! arena_allocated_impl_for_stream {
             #[inline]
             fn copy_to_arena(self, dst: *mut Self) -> Self::PtrToAllocated {
                 unsafe {
+                    // Miri seems to hit this a lot
                     ptr::write(dst, self);
                     TypedArenaPtr::new(dst as *mut Self)
                 }

--- a/src/parser/char_reader.rs
+++ b/src/parser/char_reader.rs
@@ -377,6 +377,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
+    #[cfg_attr(miri, ignore = "slow and not very relevant")]
     fn plain_string() {
         let mut read_string = CharReader::new(Cursor::new("a string"));
 
@@ -389,6 +390,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "slow and not very relevant")]
     fn greek_string() {
         let mut read_string = CharReader::new(Cursor::new("λέξη"));
 
@@ -401,6 +403,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "slow and not very relevant")]
     fn russian_string() {
         let mut read_string = CharReader::new(Cursor::new("слово"));
 
@@ -413,6 +416,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "slow and not very relevant")]
     fn greek_lorem_ipsum() {
         let lorem_ipsum = "Λορεμ ιπσθμ δολορ σιτ αμετ, οφφενδιτ
     εφφιcιενδι σιτ ει, ηαρθμ λεγερε qθαερενδθμ ιθσ νε. Ηασ νο εροσ
@@ -484,6 +488,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "slow and not very relevant")]
     fn armenian_lorem_ipsum() {
         let lorem_ipsum = "լոռեմ իպսում դոլոռ սիթ ամեթ, նովում գռաեծո
         սեա եա, աբհոռռեանթ դիսպութանդո եի քուի. իդ քուոդ ինդոծթում
@@ -557,6 +562,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "slow and not very relevant")]
     fn russian_lorem_ipsum() {
         let lorem_ipsum = "Лорем ипсум долор сит амет, атяуи дицам еи
         сит, ид сеа фацилис елаборарет. Меа еу яуас алияуид, те яуи

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -43,7 +43,7 @@ impl<T: RawBlockTraits> RawBlock<T> {
         let layout = alloc::Layout::from_size_align_unchecked(cap, T::align());
 
         self.base = alloc::alloc(layout) as *const _;
-        self.top = (self.base as usize + cap) as *const _;
+        self.top = self.base.add(cap);
         *self.ptr.get_mut() = self.base as *mut _;
     }
 
@@ -98,7 +98,7 @@ impl<T: RawBlockTraits> RawBlock<T> {
     pub unsafe fn alloc(&self, size: usize) -> *mut u8 {
         if self.free_space() >= size {
             let ptr = *self.ptr.get();
-            *self.ptr.get() = (ptr as usize + size) as *mut _;
+            *self.ptr.get() = ptr.add(size) as *mut _;
             ptr
         } else {
             ptr::null_mut()

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -4,6 +4,7 @@ use serial_test::serial;
 // issue #831
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn call_0() {
     load_module_test(
         "tests-pl/issue831-call0.pl",

--- a/tests/scryer/main.rs
+++ b/tests/scryer/main.rs
@@ -13,6 +13,7 @@ mod src_tests;
 /// to re-generate all reference output files run `TRYCMD=overwrite cargo test -- cli_test`
 /// then check that the changes are as expected e.g. by looking at the `git diff`
 #[test]
+#[cfg_attr(miri, ignore = "blocked on crossbeam UB")]
 fn cli_tests() {
     trycmd::TestCases::new()
         .default_bin_name("scryer-prolog")

--- a/tests/scryer/src_tests.rs
+++ b/tests/scryer/src_tests.rs
@@ -3,30 +3,35 @@ use serial_test::serial;
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn builtins() {
     load_module_test("src/tests/builtins.pl", "");
 }
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn call_with_inference_limit() {
     load_module_test("src/tests/call_with_inference_limit.pl", "");
 }
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn facts() {
     load_module_test("src/tests/facts.pl", "");
 }
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn hello_world() {
     load_module_test("src/tests/hello_world.pl", "Hello World!\n");
 }
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn syntax_error() {
     load_module_test(
         "tests-pl/syntax_error.pl",
@@ -36,18 +41,21 @@ fn syntax_error() {
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn predicates() {
     load_module_test("src/tests/predicates.pl", "");
 }
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn rules() {
     load_module_test("src/tests/rules.pl", "");
 }
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn setup_call_cleanup_load() {
     load_module_test(
         "src/tests/setup_call_cleanup.pl",
@@ -57,12 +65,14 @@ fn setup_call_cleanup_load() {
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn clpz_load() {
     load_module_test("src/tests/clpz/test_clpz.pl", "");
 }
 
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn iso_conformity_tests() {
     load_module_test("tests-pl/iso-conformity-tests.pl", "All tests passed");
 }


### PR DESCRIPTION
Scryer has a lot of unsafe code, so running it through Miri to find UB (Undefined Behavior) is very obvious. Running the actual program is blocked on _at least_ (there may be more requirements) Miri implementing `pipe2`. I ignored enough tests so that `cargo miri test` can actually run without errors, and fixed some pointer-integer-pointer casts so that it runs with no warnings and more accurate errors. I documented in each ignored test more or less where the UB blocking it was found.

It seems that the most important UB is in `streams.rs`, as it blocks most tests. Solving these issues is really important, because with UB in the code even if it works fine _now_ it can change behavior when changing compiler versions and completely break everything with very subtle and elusive bugs. However, unsafe Rust is hard, so it's probably gonna take a while.

Actually solving the errors Miri found here is out of scope for this PR, this is just making the first steps for it to actually run and to have some idea of what needs to be done in the future.