### PR TITLE
Heap memory limit

### DIFF
--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -607,6 +607,10 @@ enum SystemClauseType {
     #[strum_discriminants(strum(props(Arity = "1", Name = "$argv")))]
     Argv,
     REPL(REPLCodePtr),
+    #[strum_discriminants(strum(props(Arity = "1", Name = "$set_heap_limit")))]
+    SetHeapLimit,
+    #[strum_discriminants(strum(props(Arity = "1", Name = "$get_heap_limit")))]
+    GetHeapLimit,
 }
 
 #[allow(dead_code)]
@@ -1872,6 +1876,8 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::CallAddNonCountedBacktracking |
                     &Instruction::CallPopCount |
                     &Instruction::CallArgv |
+                    &Instruction::CallSetHeapLimit |
+                    &Instruction::CallGetHeapLimit |
                     &Instruction::CallEd25519SignRaw |
                     &Instruction::CallEd25519VerifyRaw |
                     &Instruction::CallEd25519SeedToPublicKey => {
@@ -2108,6 +2114,8 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::ExecuteAddNonCountedBacktracking |
                     &Instruction::ExecutePopCount |
                     &Instruction::ExecuteArgv |
+                    &Instruction::ExecuteSetHeapLimit |
+                    &Instruction::ExecuteGetHeapLimit |
                     &Instruction::ExecuteEd25519SignRaw |
                     &Instruction::ExecuteEd25519VerifyRaw |
                     &Instruction::ExecuteEd25519SeedToPublicKey => {

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -4155,6 +4155,22 @@ impl Machine {
                         try_or_throw!(self.machine_st, self.argv());
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }
+                    &Instruction::CallSetHeapLimit => {
+                        try_or_throw!(self.machine_st, self.set_heap_limit());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteSetHeapLimit => {
+                        try_or_throw!(self.machine_st, self.set_heap_limit());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
+                    &Instruction::CallGetHeapLimit => {
+                        try_or_throw!(self.machine_st, self.get_heap_limit());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
+                    &Instruction::ExecuteGetHeapLimit => {
+                        try_or_throw!(self.machine_st, self.get_heap_limit());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
                     &Instruction::CallCurrentTime => {
                         self.current_time();
                         step_or_fail!(self, self.machine_st.p += 1);

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -5202,6 +5202,11 @@ impl Machine {
                 }
             }
 
+            // Not sure if this is the best place to put this
+            if let Err(()) = self.machine_st.check_heap_limit() {
+                continue;
+            }
+
             let interrupted = INTERRUPT.load(std::sync::atomic::Ordering::Relaxed);
 
             match INTERRUPT.compare_exchange(

--- a/src/machine/machine_errors.rs
+++ b/src/machine/machine_errors.rs
@@ -322,10 +322,10 @@ impl MachineState {
                     atom!("resource_error"),
                     [atom(atom!("finite_memory")), cell(size_requested)]
                 )
-            },
+            }
             ResourceError::OutOfFiles => {
                 functor!(atom!("resource_error"), [atom(atom!("file_descriptors"))])
-            },
+            }
             ResourceError::HeapLimit => {
                 functor!(
                     atom!("resource_error"),
@@ -334,7 +334,7 @@ impl MachineState {
                         fixnum(self.heap_limit.expect("should have heap limit"))
                     ]
                 )
-            },
+            }
         };
 
         MachineError {

--- a/src/machine/machine_errors.rs
+++ b/src/machine/machine_errors.rs
@@ -330,7 +330,7 @@ impl MachineState {
                 functor!(
                     atom!("resource_error"),
                     [
-                        atom(AtomTable::build_with(&self.atom_tbl, "heap_limit")),
+                        atom(atom!("heap_limit")),
                         fixnum(self.heap_limit.expect("should have heap limit"))
                     ]
                 )

--- a/src/machine/machine_errors.rs
+++ b/src/machine/machine_errors.rs
@@ -331,7 +331,7 @@ impl MachineState {
                     atom!("resource_error"),
                     [
                         atom(AtomTable::build_with(&self.atom_tbl, "heap_limit")),
-                        fixnum(self.heap_limit)
+                        fixnum(self.heap_limit.expect("should have heap limit"))
                     ]
                 )
             },

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -74,7 +74,7 @@ pub struct MachineState {
     pub(super) attr_var_init: AttrVarInitializer,
     pub(super) fail: bool,
     pub heap: Heap,
-    pub(super) heap_limit: usize,
+    pub(super) heap_limit: Option<usize>,
     pub(super) mode: MachineMode,
     pub(crate) stack: Stack,
     pub(super) registers: Registers,

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -74,6 +74,7 @@ pub struct MachineState {
     pub(super) attr_var_init: AttrVarInitializer,
     pub(super) fail: bool,
     pub heap: Heap,
+    pub(super) heap_limit: usize,
     pub(super) mode: MachineMode,
     pub(crate) stack: Stack,
     pub(super) registers: Registers,

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -1725,7 +1725,7 @@ impl MachineState {
         self.throw_exception(err);
     }
 
-    pub fn check_heap_limit(&mut self) -> Result<(),()> {
+    pub fn check_heap_limit(&mut self) -> Result<(), ()> {
         if let Some(heap_limit) = self.heap_limit {
             let h = self.heap.len();
             if h > heap_limit / 8 {

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -39,6 +39,7 @@ impl MachineState {
             attr_var_init: AttrVarInitializer::new(0),
             fail: false,
             heap: Heap::with_capacity(256 * 256),
+            heap_limit: 1 * (1 << (10 * 2)), // 100MB
             mode: MachineMode::Write,
             stack: Stack::new(),
             registers: [heap_loc_as_cell!(0); MAX_ARITY + 1], // self.registers[0] is never used.
@@ -1722,5 +1723,29 @@ impl MachineState {
         let err = self.error_form(err, src);
 
         self.throw_exception(err);
+    }
+
+    pub fn check_heap_limit(&mut self) -> Result<(),()> {
+        let h = self.heap.len();
+        println!("Current heap length: {h}");
+        if h > self.heap_limit / 8 {
+            let error = self.resource_error(ResourceError::HeapLimit);
+
+            let mut stub = vec![
+                atom_as_cell!(atom!("error"), 2),
+                str_loc_as_cell!(h + 3),
+                heap_loc_as_cell!(h + 2),
+            ];
+            stub.extend(error.into_iter(3));
+            //let functor_stub = functor_stub(atom!("error"), 2);
+            //let stub = self.error_form(error, functor_stub);
+
+            println!("Throwing exception!!!");
+            self.throw_exception(stub);
+            self.backtrack();
+            Err(())
+        } else {
+            Ok(())
+        }
     }
 }

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4972,6 +4972,34 @@ impl Machine {
     }
 
     #[inline(always)]
+    pub(crate) fn set_heap_limit(&mut self) -> CallResult {
+        let value = self.deref_register(1);
+
+        let stub = functor_stub(atom!("$set_heap_limit"), 1);
+        let error = stub.type_error(&mut self.machine_st, ValidType::Integer);
+
+        value.to_fixnum()
+            .ok_or(self.machine_st.error_form(error, stub))
+            .map(|fixnum| {
+                self.machine_st.heap_limit = Some(fixnum.get_num() as usize);
+            })
+    }
+
+    #[inline(always)]
+    pub(crate) fn get_heap_limit(&mut self) -> CallResult {
+        let value = self.deref_register(1);
+
+        let cell = self.machine_st.heap_limit
+            .map(|limit| fixnum_as_cell!(Fixnum::build_with(limit as i64)))
+            .unwrap_or(atom_as_cell!(atom!("no_limit")));
+        self.machine_st.heap.push(cell);
+
+        let cell_loc = heap_loc_as_cell!(self.machine_st.heap.len() - 1);
+        unify!(self.machine_st, value, cell_loc);
+        Ok(())
+    }
+
+    #[inline(always)]
     pub(crate) fn current_time(&mut self) {
         let timestamp = self.systemtime_to_timestamp(SystemTime::now());
         self.machine_st

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4978,7 +4978,8 @@ impl Machine {
         let stub = functor_stub(atom!("$set_heap_limit"), 1);
         let error = stub.type_error(&mut self.machine_st, ValidType::Integer);
 
-        value.to_fixnum()
+        value
+            .to_fixnum()
             .ok_or(self.machine_st.error_form(error, stub))
             .map(|fixnum| {
                 self.machine_st.heap_limit = Some(fixnum.get_num() as usize);
@@ -4989,7 +4990,9 @@ impl Machine {
     pub(crate) fn get_heap_limit(&mut self) -> CallResult {
         let value = self.deref_register(1);
 
-        let cell = self.machine_st.heap_limit
+        let cell = self
+            .machine_st
+            .heap_limit
             .map(|limit| fixnum_as_cell!(Fixnum::build_with(limit as i64)))
             .unwrap_or(atom_as_cell!(atom!("no_limit")));
         self.machine_st.heap.push(cell);


### PR DESCRIPTION
Adds a simple check for the size of the heap that is done every once in a while, as described in #2294. I haven't implemented the cli argument yet, but it should be possible with this. Example usage:

```prolog
?- [user].
get_heap_limit(Lim) :- '$get_heap_limit'(Lim).
set_heap_limit(Lim) :- '$set_heap_limit'(Lim).

?- get_heap_limit(Lim).
   % No limit by default.
   Lim = no_limit.
?- get_heap_limit(no_limit).
   true.
?- set_heap_limit(100000).
   true.
?- get_heap_limit(Lim).
   Lim = 100000.
?- get_heap_limit(no_limit).
   false.
?- set_heap_limit(not_integer).
   error(type_error(integer,'$set_heap_limit'/1),'$set_heap_limit'/1).
?- set_heap_limit(no_limit).
   % I have not implemented this, so there is no way to "unset" the limit.
   % Should this be implemented?
   error(type_error(integer,'$set_heap_limit'/1),'$set_heap_limit'/1).
?- M is 10^6, length(L, M).
   % Clean resource error. I'm not sure what to put in the second argument,
   % so I made it a variable. I would appreciate suggestions.
   error(resource_error(heap_limit,100000),_42).
?- 
```