### PR TITLE
Improve use of unsafe Rust in arena.rs (#2391)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
           # FIXME(issue #2138): run wasm tests, failing to run since https://github.com/mthom/scryer-prolog/pull/2137 removed wasm-pack
           - { os: ubuntu-22.04,   rust-version: nightly, target: 'wasm32-unknown-unknown',   publish: true, args: '--no-default-features' , test-args: '--no-run --no-default-features' }
           # rust versions
-          - { os: ubuntu-22.04,   rust-version: "1.70",  target: 'x86_64-unknown-linux-gnu'}
           - { os: ubuntu-22.04,   rust-version: beta,    target: 'x86_64-unknown-linux-gnu'}
           - { os: ubuntu-22.04,   rust-version: nightly, target: 'x86_64-unknown-linux-gnu'}
     defaults:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 keywords = ["prolog", "prolog-interpreter", "prolog-system"]
 categories = ["command-line-utilities"]
 build = "build/main.rs"
-rust-version = "1.70"
+rust-version = "1.77"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -595,7 +595,7 @@ impl ArenaAllocated for IndexPtr {
 
     #[inline]
     fn ptr_to_allocated(slab: &mut AllocSlab) -> Self::PtrToAllocated {
-        TypedArenaPtr::new(unsafe { mem::transmute(slab.header) })
+        TypedArenaPtr::new(ptr::addr_of_mut!(slab.header) as *mut _)
     }
 
     #[inline]
@@ -608,7 +608,7 @@ impl ArenaAllocated for IndexPtr {
         let mut slab = Box::new(AllocSlab {
             next: arena.base.take(),
             #[cfg(target_pointer_width = "32")]
-            padding: 0,
+            _padding: 0,
             header: unsafe { mem::transmute(value) },
         });
 
@@ -666,7 +666,7 @@ unsafe fn drop_slab_in_place(value: &mut AllocSlab) {
     macro_rules! drop_typed_slab_in_place {
         ($payload: ty, $value: expr) => {
             let slab: &mut TypedAllocSlab<$payload> = mem::transmute($value);
-            ptr::drop_in_place(ptr::addr_of_mut!(slab.payload));
+            ptr::drop_in_place(&mut slab.payload);
         };
     }
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -24,10 +24,7 @@ use std::sync::RwLock;
 macro_rules! arena_alloc {
     ($e:expr, $arena:expr) => {{
         let result = $e;
-        #[allow(unused_unsafe)]
-        unsafe {
-            ArenaAllocated::alloc($arena, result)
-        }
+        ArenaAllocated::alloc($arena, result)
     }};
 }
 
@@ -35,10 +32,7 @@ macro_rules! arena_alloc {
 macro_rules! float_alloc {
     ($e:expr, $arena:expr) => {{
         let result = $e;
-        #[allow(unused_unsafe)]
-        unsafe {
-            $arena.f64_tbl.build_with(result).as_ptr()
-        }
+        unsafe { $arena.f64_tbl.build_with(result).as_ptr() }
     }};
 }
 
@@ -746,8 +740,6 @@ impl Drop for Arena {
                 ptr = slab.next;
             }
         }
-
-        self.base = None;
     }
 }
 

--- a/src/machine/machine_indices.rs
+++ b/src/machine/machine_indices.rs
@@ -298,9 +298,11 @@ impl IndexStore {
             _ => self
                 .get_meta_predicate_spec(key.0, key.1, &compilation_target)
                 .map(|meta_specs| {
-                    meta_specs.iter().find(|meta_spec| match meta_spec {
-                        MetaSpec::Colon | MetaSpec::RequiresExpansionWithArgument(_) => true,
-                        _ => false,
+                    meta_specs.iter().find(|meta_spec| {
+                        matches!(
+                            meta_spec,
+                            MetaSpec::Colon | MetaSpec::RequiresExpansionWithArgument(_)
+                        )
                     })
                 })
                 .map(|meta_spec_opt| meta_spec_opt.is_some())

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -455,24 +455,11 @@ macro_rules! arena_allocated_impl_for_stream {
         impl ArenaAllocated for StreamLayout<$stream_type> {
             type PtrToAllocated = TypedArenaPtr<StreamLayout<$stream_type>>;
 
+            gen_ptr_to_allocated!(StreamLayout<$stream_type>);
+
             #[inline]
             fn tag() -> ArenaHeaderTag {
                 ArenaHeaderTag::$stream_tag
-            }
-
-            #[inline]
-            fn size(&self) -> usize {
-                mem::size_of::<StreamLayout<$stream_type>>()
-            }
-
-            #[allow(clippy::not_unsafe_ptr_arg_deref)]
-            #[inline]
-            fn copy_to_arena(self, dst: *mut Self) -> Self::PtrToAllocated {
-                unsafe {
-                    // Miri seems to hit this a lot
-                    ptr::write(dst, self);
-                    TypedArenaPtr::new(dst as *mut Self)
-                }
             }
         }
     };

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -428,14 +428,12 @@ impl BrentAlgState {
 
                 pstr_chars = pstr.as_str_from(n).chars().count() - 1;
 
-                if heap[h].get_tag() == HeapCellValueTag::PStrOffset {
-                    if heap[h_offset].get_tag() == HeapCellValueTag::CStr {
-                        return if pstr_chars < max_steps {
-                            CycleSearchResult::ProperList(pstr_chars + 1)
-                        } else {
-                            let offset = max_steps as usize + n;
-                            CycleSearchResult::PStrLocation(max_steps, h_offset, offset)
-                        }
+                if heap[h].get_tag() == HeapCellValueTag::PStrOffset && heap[h_offset].get_tag() == HeapCellValueTag::CStr {
+                    return if pstr_chars < max_steps {
+                        CycleSearchResult::ProperList(pstr_chars + 1)
+                    } else {
+                        let offset = max_steps + n;
+                        CycleSearchResult::PStrLocation(max_steps, h_offset, offset)
                     }
                 }
 

--- a/src/parser/char_reader.rs
+++ b/src/parser/char_reader.rs
@@ -327,12 +327,11 @@ impl<R: Read> Read for CharReader<R> {
             return self.inner.read_vectored(bufs);
         }
 
-        let nread = {
-            self.refresh_buffer()?;
-            (&self.buf[self.pos..]).read_vectored(bufs)?
-        };
+        self.refresh_buffer()?;
 
+        let nread = (&self.buf[self.pos..]).read_vectored(bufs)?;
         self.consume(nread);
+
         Ok(nread)
     }
 }


### PR DESCRIPTION
The use of unsafe Rust is revised in arena.rs to answer some of the criticisms made in #2391, particularly regarding the misaligned allocation of some stream types. Explicit use of `alloc` is removed in favor of `Box`. `TypedAllocSlab<Payload>` is a type parameterized template over `AllocSlab` used to allow rustc to get value allocation right. As well, some new macros (like `mem::offset_of!`) are used to calculate byte offsets into structs. This requires bumping the Rust version in Cargo.toml to 1.77.