### PR TITLE
restore ubuntu testing to ci.yml with rust version 1.77

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           # FIXME(issue #2138): run wasm tests, failing to run since https://github.com/mthom/scryer-prolog/pull/2137 removed wasm-pack
           - { os: ubuntu-22.04,   rust-version: nightly, target: 'wasm32-unknown-unknown',   publish: true, args: '--no-default-features' , test-args: '--no-run --no-default-features' }
           # rust versions
+          - { os: ubuntu-22.04, rust-version: "1.77", target: 'x86_64-unknown-linux-gnu'} 
           - { os: ubuntu-22.04,   rust-version: beta,    target: 'x86_64-unknown-linux-gnu'}
           - { os: ubuntu-22.04,   rust-version: nightly, target: 'x86_64-unknown-linux-gnu'}
     defaults:


### PR DESCRIPTION
In response to [@infogulch infogulch's comment](https://github.com/mthom/scryer-prolog/commit/79bc2d9c68da2257a94eb22ef8717a304173e344#commitcomment-141790142). In a PR because I was unsure it wouldn't break the build.