### PR TITLE
Upgrade to macOS 13 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         include:
           # operating systems
           - { os: windows-latest, rust-version: stable,  target: 'x86_64-pc-windows-msvc',   publish: true }
-          - { os: macos-11,       rust-version: stable,  target: 'x86_64-apple-darwin',      publish: true }
+          - { os: macos-13,       rust-version: stable,  target: 'x86_64-apple-darwin',      publish: true }
           - { os: ubuntu-20.04,   rust-version: stable,  target: 'x86_64-unknown-linux-gnu', publish: true }
           # architectures
           - { os: ubuntu-22.04,   rust-version: stable,  target: 'x86_64-unknown-linux-gnu', publish: true }
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/download-artifact@v3
       - name: Zip binaries for release
         run: |
-          zip scryer-prolog_macos-11.zip ./scryer-prolog_macos-11_x86_64-apple-darwin/scryer-prolog
+          zip scryer-prolog_macos-13.zip ./scryer-prolog_macos-13_x86_64-apple-darwin/scryer-prolog
           zip scryer-prolog_ubuntu-20.04.zip ./scryer-prolog_ubuntu-20.04_x86_64-unknown-linux-gnu/scryer-prolog
           zip scryer-prolog_ubuntu-22.04.zip ./scryer-prolog_ubuntu-22.04_x86_64-unknown-linux-gnu/scryer-prolog
           zip scryer-prolog_windows-latest.zip ./scryer-prolog_windows-latest_x86_64-pc-windows-msvc/scryer-prolog.exe
@@ -196,7 +196,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            scryer-prolog_macos-11.zip
+            scryer-prolog_macos-13.zip
             scryer-prolog_ubuntu-20.04.zip
             scryer-prolog_ubuntu-22.04.zip
             scryer-prolog_windows-latest.zip


### PR DESCRIPTION
macOS 11 is deprecated and it's going to be be removed on June 28th: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners

macOS 13 is the last version for x86-64 processors. It could be interesting to add macOS 14 for ARM too, but I prefer someone that has that hardware to do it.