### PR TITLE
re-add CI job to test Cargo.toml rust-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
           - { os: ubuntu-22.04,   rust-version: stable,  target: 'i686-unknown-linux-gnu',   publish: true }
           # FIXME(issue #2138): run wasm tests, failing to run since https://github.com/mthom/scryer-prolog/pull/2137 removed wasm-pack
           - { os: ubuntu-22.04,   rust-version: nightly, target: 'wasm32-unknown-unknown',   publish: true, args: '--no-default-features' , test-args: '--no-run --no-default-features' }
+          # Cargo.toml rust-version
+          - { os: ubuntu-22.04,   rust-version: "1.77",  target: 'x86_64-unknown-linux-gnu'}
           # rust versions
           - { os: ubuntu-22.04,   rust-version: beta,    target: 'x86_64-unknown-linux-gnu'}
           - { os: ubuntu-22.04,   rust-version: nightly, target: 'x86_64-unknown-linux-gnu'}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - { os: ubuntu-22.04,   rust-version: stable,  target: 'x86_64-unknown-linux-gnu', publish: true }
           - { os: ubuntu-22.04,   rust-version: stable,  target: 'i686-unknown-linux-gnu',   publish: true }
           # FIXME(issue #2138): run wasm tests, failing to run since https://github.com/mthom/scryer-prolog/pull/2137 removed wasm-pack
-          - { os: ubuntu-22.04,   rust-version: nightly, target: 'wasm32-unknown-unknown',   publish: true, args: '--no-default-features' , test-args: '--no-run --no-default-features' }
+          - { os: ubuntu-22.04,   rust-version: nightly, target: 'wasm32-unknown-unknown',   publish: true, args: '--no-default-features' , test-args: '--no-run --no-default-features', use_swap: true }
           # Cargo.toml rust-version
           - { os: ubuntu-22.04,   rust-version: "1.77",  target: 'x86_64-unknown-linux-gnu'}
           # rust versions
@@ -56,6 +56,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v3
+      - uses: actionhippie/swap-space@v1
+        if: matrix.use_swap
+        with:
+          size: 10G
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -24,7 +24,6 @@ use std::io;
 #[cfg(feature = "http")]
 use std::io::BufRead;
 use std::io::{Cursor, ErrorKind, Read, Seek, SeekFrom, Write};
-use std::mem;
 use std::net::{Shutdown, TcpStream};
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
@@ -296,9 +295,9 @@ impl Read for HttpReadStream {
 #[cfg(feature = "http")]
 pub struct HttpWriteStream {
     status_code: u16,
-    headers: mem::ManuallyDrop<hyper::HeaderMap>,
+    headers: std::mem::ManuallyDrop<hyper::HeaderMap>,
     response: TypedArenaPtr<HttpResponse>,
-    buffer: mem::ManuallyDrop<Vec<u8>>,
+    buffer: std::mem::ManuallyDrop<Vec<u8>>,
 }
 
 #[cfg(feature = "http")]
@@ -325,8 +324,8 @@ impl Write for HttpWriteStream {
 #[cfg(feature = "http")]
 impl HttpWriteStream {
     fn drop(&mut self) {
-        let headers = unsafe { mem::ManuallyDrop::take(&mut self.headers) };
-        let buffer = unsafe { mem::ManuallyDrop::take(&mut self.buffer) };
+        let headers = unsafe { std::mem::ManuallyDrop::take(&mut self.headers) };
+        let buffer = unsafe { std::mem::ManuallyDrop::take(&mut self.buffer) };
 
         let (ready, response, cvar) = &**self.response;
 
@@ -1228,8 +1227,8 @@ impl Stream {
             StreamLayout::new(CharReader::new(HttpWriteStream {
                 response,
                 status_code,
-                headers: mem::ManuallyDrop::new(headers),
-                buffer: mem::ManuallyDrop::new(Vec::new()),
+                headers: std::mem::ManuallyDrop::new(headers),
+                buffer: std::mem::ManuallyDrop::new(Vec::new()),
             })),
             arena
         ))

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -109,7 +109,7 @@ pub(crate) fn as_partial_string(
                 tail_ref = succ;
             }
             Term::PartialString(_, pstr, tail) => {
-                string += &pstr;
+                string += pstr;
                 tail_ref = tail;
             }
             Term::CompleteString(_, cstr) => {


### PR DESCRIPTION
was removed in #2393 instead of being updated, see

- https://github.com/mthom/scryer-prolog/pull/2393#discussion_r1585963855 and
- https://github.com/mthom/scryer-prolog/commit/79bc2d9c68da2257a94eb22ef8717a304173e344#commitcomment-141790142