### PR TITLE
WIP: Add jit_compile/1, very basic JIT1, skeleton of JIT2

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -1,0 +1,18 @@
+name: Test JIT
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-jit:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          rust-version: nightly
+          targets: x86_64-unknown-linux-gnu      
+      - name: Test with JIT
+        run: cargo +nightly test --features jit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8964676f9a0165edbdb7650344acb73d4decd590685f0964b6109b3691fff8"
+checksum = "9c23938094c74206f455ac334e8166a2f3e78cfa604933c97925f159621e6061"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -504,18 +504,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d5521e2abca66bbb1ddeecbb6f6965c79160352ae1579b39f8c86183895c24"
+checksum = "29daf137addc15da6bab6eae2c4a11e274b1d270bf2759508e62f6145e863ef6"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef40a4338a47506e832ac3e53f7f1375bc59351f049a8379ff736dd02565bd95"
+checksum = "de619867d5de4c644b7fd9904d6e3295269c93d8a71013df796ab338681222d4"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -528,45 +528,46 @@ dependencies = [
  "hashbrown 0.14.3",
  "log",
  "regalloc2",
+ "rustc-hash",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24cd5d85985c070f73dfca07521d09086362d1590105ba44b0932bf33513b61"
+checksum = "29f5cf277490037d8dae9513d35e0ee8134670ae4a964a5ed5b198d4249d7c10"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0584c4363e3aa0a3c7cb98a778fbd5326a3709f117849a727da081d4051726c"
+checksum = "8c3e22ecad1123343a3c09ac6ecc532bb5c184b6fcb7888df0ea953727f79924"
 
 [[package]]
 name = "cranelift-control"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25ecede098c6553fdba362a8e4c9ecb8d40138363bff47f9712db75be7f0571"
+checksum = "53ca3ec6d30bce84ccf59c81fead4d16381a3ef0ef75e8403bc1e7385980da09"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea081a42f25dc4c5b248b87efdd87dcd3842a1050a37524ec5391e6172058cb"
+checksum = "7eabb8d36b0ca8906bec93c78ea516741cac2d7e6b266fa7b0ffddcc09004990"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9796e712f5af797e247784f7518e6b0a83a8907d73d51526982d86ecb3a58b68"
+checksum = "44b42630229e49a8cfcae90bdc43c8c4c08f7a7aa4618b67f79265cd2f996dd2"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -576,15 +577,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a66ccad5782f15c80e9dd5af0df4acfe6e3eee98e8f7354a2e5c8ec3104bdd"
+checksum = "918d1e36361805dfe0b6cdfd5a5ffdb5d03fa796170c5717d2727cbe623b93a0"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabad94c317b89a8300e9c48ee4715ffc0c1235ec94cf6bb71aa12511cb1afe8"
+checksum = "399bad3a10a12c475f812dd889b5a5d296eaacc22d4c9652cdefb25dfb9ae56c"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -602,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4f782914c709b021e76475516358e64287d17e950113e051468ccf9ca8ff43"
+checksum = "1ed398b2df2a409a189dbe7950d365b50aa61380cec1f53d9891d4ad8374edb7"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -613,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.105.3"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285e80df1d9b79ded9775b285df68b920a277b84f88a7228d2f5bc31fcdc58eb"
+checksum = "75aea85a0d7e1800b14ce9d3f53adf8ad4d1ee8a9e23b0269bdc50285e93b9b3"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -3792,10 +3793,11 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "18.0.3"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866634605089b4632b32226b54aa3670d72e1849f9fc425c7e50b3749c2e6df3"
+checksum = "afe088f9b56bb353adaf837bf7e10f1c2e1676719dd5be4cac8e37f2ba1ee5bc"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "libc",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +493,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ad1c9f3eb965e6f7af65524ca625f2800c7951a213ee7336e808dd42808262"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ec790dbba3970f5dc1fb615e81167adbe90a81b6d5ce53d1d7f97d1da0c816"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aff1e6625920ec73a0a222bf8f9e5b7fc6a765ccef47e0a010fe327f07eb430a"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.3",
+ "log",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1b92f1d526daa2b1878f0171d3a216a70e3f05d2fe6786a5469299c6919a0a"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3333fb7671c8b6a8d24fd05dced0a4940773d9cdddeeb38b1f99260eba2c50e9"
+
+[[package]]
+name = "cranelift-control"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf07b47de593bc43b7bc25a66c509469fd02c2ad850833c6a2dff45e81980c3b"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfd988176a86d6985dd75ac0762033b36d134c4af8b806b605e8542c489fe1c2"
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214f216d2288f695bf0e0c2775d4e58759cd6ad5a118852fb5cc26d817e3cdcc"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf4dd3bc4bd4d594180a4db16b0b411a9c3a6757a4d13c5ede1177a0131fc80"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bb8f1189dd81ed989b2cbd62371d67d35afb8977239d4a917a05b7e22e0692"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "region",
+ "target-lexicon",
+ "wasmtime-jit-icache-coherence",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecedd1fec01db9760f94dc2abca90975ef5e90746be5aa0041dbba99268ac23"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ddcb8ffe184e9aaf941387f9bcd016236fe1bedc29a84af0771d98443a71aea"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1201,11 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.1.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "git-version"
@@ -1110,6 +1263,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1538,6 +1700,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "maplit"
@@ -2313,6 +2484,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d813022b2e00774a48eaf43caaa3c20b45f040ba8cbf398e2e8911a06668dbe6"
 
 [[package]]
+name = "regalloc2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+dependencies = [
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hash",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,6 +2530,18 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "region"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach",
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -2448,6 +2644,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -2561,6 +2763,9 @@ dependencies = [
  "chrono",
  "console_error_panic_hook",
  "cpu-time",
+ "cranelift",
+ "cranelift-jit",
+ "cranelift-module",
  "criterion",
  "crossterm",
  "crrl",
@@ -2856,6 +3061,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
 name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,6 +3277,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "tempfile"
@@ -3572,6 +3789,17 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c87783a70d3b7602834118f42e73ed8979f1b75a01e0fc4bf311cc6dc31f8fc"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ad1c9f3eb965e6f7af65524ca625f2800c7951a213ee7336e808dd42808262"
+checksum = "6d8964676f9a0165edbdb7650344acb73d4decd590685f0964b6109b3691fff8"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -504,18 +504,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ec790dbba3970f5dc1fb615e81167adbe90a81b6d5ce53d1d7f97d1da0c816"
+checksum = "16d5521e2abca66bbb1ddeecbb6f6965c79160352ae1579b39f8c86183895c24"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff1e6625920ec73a0a222bf8f9e5b7fc6a765ccef47e0a010fe327f07eb430a"
+checksum = "ef40a4338a47506e832ac3e53f7f1375bc59351f049a8379ff736dd02565bd95"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -534,39 +534,39 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1b92f1d526daa2b1878f0171d3a216a70e3f05d2fe6786a5469299c6919a0a"
+checksum = "d24cd5d85985c070f73dfca07521d09086362d1590105ba44b0932bf33513b61"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3333fb7671c8b6a8d24fd05dced0a4940773d9cdddeeb38b1f99260eba2c50e9"
+checksum = "e0584c4363e3aa0a3c7cb98a778fbd5326a3709f117849a727da081d4051726c"
 
 [[package]]
 name = "cranelift-control"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf07b47de593bc43b7bc25a66c509469fd02c2ad850833c6a2dff45e81980c3b"
+checksum = "f25ecede098c6553fdba362a8e4c9ecb8d40138363bff47f9712db75be7f0571"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfd988176a86d6985dd75ac0762033b36d134c4af8b806b605e8542c489fe1c2"
+checksum = "6ea081a42f25dc4c5b248b87efdd87dcd3842a1050a37524ec5391e6172058cb"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214f216d2288f695bf0e0c2775d4e58759cd6ad5a118852fb5cc26d817e3cdcc"
+checksum = "9796e712f5af797e247784f7518e6b0a83a8907d73d51526982d86ecb3a58b68"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -576,15 +576,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf4dd3bc4bd4d594180a4db16b0b411a9c3a6757a4d13c5ede1177a0131fc80"
+checksum = "f4a66ccad5782f15c80e9dd5af0df4acfe6e3eee98e8f7354a2e5c8ec3104bdd"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bb8f1189dd81ed989b2cbd62371d67d35afb8977239d4a917a05b7e22e0692"
+checksum = "dabad94c317b89a8300e9c48ee4715ffc0c1235ec94cf6bb71aa12511cb1afe8"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecedd1fec01db9760f94dc2abca90975ef5e90746be5aa0041dbba99268ac23"
+checksum = "7d4f782914c709b021e76475516358e64287d17e950113e051468ccf9ca8ff43"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.105.0"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ddcb8ffe184e9aaf941387f9bcd016236fe1bedc29a84af0771d98443a71aea"
+checksum = "285e80df1d9b79ded9775b285df68b920a277b84f88a7228d2f5bc31fcdc58eb"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -3792,9 +3792,9 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "18.0.0"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c87783a70d3b7602834118f42e73ed8979f1b75a01e0fc4bf311cc6dc31f8fc"
+checksum = "866634605089b4632b32226b54aa3670d72e1849f9fc425c7e50b3749c2e6df3"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,6 +2765,7 @@ dependencies = [
  "console_error_panic_hook",
  "cpu-time",
  "cranelift",
+ "cranelift-codegen",
  "cranelift-jit",
  "cranelift-module",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.70"
 crate-type = ["cdylib", "rlib", "staticlib"]
 
 [features]
-default = ["ffi", "repl", "hostname", "tls", "http", "crypto-full"]
+default = ["ffi", "repl", "hostname", "tls", "http", "crypto-full", "jit"]
 ffi = ["dep:libffi"]
 repl = ["dep:crossterm", "dep:ctrlc", "dep:rustyline"]
 hostname = ["dep:hostname"]
@@ -84,9 +84,9 @@ native-tls = { version = "0.2.4", optional = true }
 warp = { version = "=0.3.5", features = ["tls"], optional = true }
 reqwest = { version = "0.11.18", optional = true }
 tokio = { version = "1.28.2", features = ["full"] }
-cranelift = { version = "0.105.3", optional = true }
-cranelift-jit = { version = "0.105.3", optional = true }
-cranelift-module = { version = "0.105.3", optional = true }
+cranelift = { version = "0.108.1", optional = true }
+cranelift-jit = { version = "0.108.1", optional = true }
+cranelift-module = { version = "0.108.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.10", features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tls = ["dep:native-tls"]
 http = ["dep:warp", "dep:reqwest"]
 rust_beta_channel = []
 crypto-full = []
+jit = ["dep:cranelift", "dep:cranelift-jit", "dep:cranelift-module"]
 
 [build-dependencies]
 indexmap = "1.0.2"
@@ -83,9 +84,9 @@ native-tls = { version = "0.2.4", optional = true }
 warp = { version = "=0.3.5", features = ["tls"], optional = true }
 reqwest = { version = "0.11.18", optional = true }
 tokio = { version = "1.28.2", features = ["full"] }
-cranelift = "0.105.3"
-cranelift-jit = "0.105.3"
-cranelift-module = "0.105.3"
+cranelift = { version = "0.105.3", optional = true }
+cranelift-jit = { version = "0.105.3", optional = true }
+cranelift-module = { version = "0.105.3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.10", features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.70"
 crate-type = ["cdylib", "rlib", "staticlib"]
 
 [features]
-default = ["ffi", "repl", "hostname", "tls", "http", "crypto-full", "jit"]
+default = ["ffi", "repl", "hostname", "tls", "http", "crypto-full"]
 ffi = ["dep:libffi"]
 repl = ["dep:crossterm", "dep:ctrlc", "dep:rustyline"]
 hostname = ["dep:hostname"]
@@ -24,7 +24,7 @@ tls = ["dep:native-tls"]
 http = ["dep:warp", "dep:reqwest"]
 rust_beta_channel = []
 crypto-full = []
-jit = ["dep:cranelift", "dep:cranelift-jit", "dep:cranelift-module"]
+jit = ["dep:cranelift", "dep:cranelift-jit", "dep:cranelift-module", "dep:cranelift-codegen"]
 
 [build-dependencies]
 indexmap = "1.0.2"
@@ -87,6 +87,7 @@ tokio = { version = "1.28.2", features = ["full"] }
 cranelift = { version = "0.108.1", optional = true }
 cranelift-jit = { version = "0.108.1", optional = true }
 cranelift-module = { version = "0.108.1", optional = true }
+cranelift-codegen = { version = "0.108.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.10", features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build/main.rs"
 rust-version = "1.70"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib", "staticlib"]
 
 [features]
 default = ["ffi", "repl", "hostname", "tls", "http", "crypto-full"]
@@ -83,6 +83,9 @@ native-tls = { version = "0.2.4", optional = true }
 warp = { version = "=0.3.5", features = ["tls"], optional = true }
 reqwest = { version = "0.11.18", optional = true }
 tokio = { version = "1.28.2", features = ["full"] }
+cranelift = "0.105.0"
+cranelift-jit = "0.105.0"
+cranelift-module = "0.105.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.10", features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,9 @@ native-tls = { version = "0.2.4", optional = true }
 warp = { version = "=0.3.5", features = ["tls"], optional = true }
 reqwest = { version = "0.11.18", optional = true }
 tokio = { version = "1.28.2", features = ["full"] }
-cranelift = "0.105.0"
-cranelift-jit = "0.105.0"
-cranelift-module = "0.105.0"
+cranelift = "0.105.3"
+cranelift-jit = "0.105.3"
+cranelift-module = "0.105.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.10", features = ["js"] }

--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -606,6 +606,8 @@ enum SystemClauseType {
     InferenceLimitExceeded,
     #[strum_discriminants(strum(props(Arity = "1", Name = "$argv")))]
     Argv,
+    #[strum_discriminants(strum(props(Arity = "3", Name = "$jit_compile")))]
+    JitCompile,
     REPL(REPLCodePtr),
 }
 
@@ -1902,6 +1904,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::CallAddNonCountedBacktracking |
                     &Instruction::CallPopCount |
                     &Instruction::CallArgv |
+		    &Instruction::CallJitCompile |
                     &Instruction::CallEd25519SignRaw |
                     &Instruction::CallEd25519VerifyRaw |
                     &Instruction::CallEd25519SeedToPublicKey => {
@@ -2138,6 +2141,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::ExecuteAddNonCountedBacktracking |
                     &Instruction::ExecutePopCount |
                     &Instruction::ExecuteArgv |
+		    &Instruction::ExecuteJitCompile |
                     &Instruction::ExecuteEd25519SignRaw |
                     &Instruction::ExecuteEd25519VerifyRaw |
                     &Instruction::ExecuteEd25519SeedToPublicKey => {

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -674,6 +674,12 @@ impl Ord for Number {
     }
 }
 
+impl Number {
+    pub extern "C" fn jit_try_from(value: HeapCellValue) -> Number {
+	Number::try_from(value).unwrap()
+    }
+}
+
 impl TryFrom<HeapCellValue> for Number {
     type Error = ();
 

--- a/src/lib/jit.pl
+++ b/src/lib/jit.pl
@@ -1,0 +1,11 @@
+:- module(jit, [jit_compile/1]).
+
+jit_compile(Clause) :-
+    (  nonvar(Clause) ->
+       (  Clause = Name / Arity ->
+	  '$jit_compile'(user, Name, Arity)
+       ;  Clause = Module : (Name / Arity) ->
+	  '$jit_compile'(Module, Name, Arity)
+       )
+    ;  throw(error(instantiation_error, jit_compile/1))
+    ).

--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -128,6 +128,11 @@ fn isize_gcd(n1: isize, n2: isize) -> Option<isize> {
     Some(n1 << shift as isize)
 }
 
+// TODO: Error handling
+pub extern "C" fn add_jit(lhs: Number, rhs: Number, arena: &mut Arena) -> Number {
+    add(lhs, rhs, &mut Arena::new()).unwrap()
+}
+
 pub(crate) fn add(lhs: Number, rhs: Number, arena: &mut Arena) -> Result<Number, EvalError> {
     match (lhs, rhs) {
         (Number::Fixnum(n1), Number::Fixnum(n2)) => Ok(

--- a/src/machine/compile.rs
+++ b/src/machine/compile.rs
@@ -1355,8 +1355,6 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             index_ptr,
         );
 
-	dbg!(&code);
-	
         self.wam_prelude.code.extend(code);
         Ok(code_index)
     }

--- a/src/machine/compile.rs
+++ b/src/machine/compile.rs
@@ -1355,6 +1355,8 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             index_ptr,
         );
 
+	dbg!(&code);
+	
         self.wam_prelude.code.extend(code);
         Ok(code_index)
     }

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -4164,6 +4164,14 @@ impl Machine {
                         try_or_throw!(self.machine_st, self.argv());
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }
+		    &Instruction::CallJitCompile => {
+			try_or_throw!(self.machine_st, self.jit_compile());
+			step_or_fail!(self, self.machine_st.p += 1);
+		    }
+		    &Instruction::ExecuteJitCompile => {
+			try_or_throw!(self.machine_st, self.jit_compile());
+			step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+		    }
                     &Instruction::CallCurrentTime => {
                         self.current_time();
                         step_or_fail!(self, self.machine_st.p += 1);

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -187,6 +187,19 @@ impl MachineState {
         Ok(())
     }
 
+    pub extern "C" fn unify_num_jit(&mut self, n: Number, n1: HeapCellValue) {
+	match n {
+            Number::Fixnum(n) => self.unify_fixnum(n, n1),
+            Number::Float(n) => {
+                let n = float_alloc!(n.into_inner(), self.arena);
+                self.unify_f64(n, n1)
+            }
+            Number::Integer(n) => self.unify_big_int(n, n1),
+            Number::Rational(n) => self.unify_rational(n, n1),
+
+	}
+    }
+
     #[inline(always)]
     pub(crate) fn select_switch_on_term_index(
         &self,

--- a/src/machine/jit.rs
+++ b/src/machine/jit.rs
@@ -14,16 +14,22 @@ struct CompileOutput {
 }
 
 #[derive(Debug, PartialEq)]
-enum JitCompileError {
+pub enum JitCompileError {
     UndefinedPredicate,
     InstructionNotImplemented,
 }
 
-struct JitMachine {
+pub struct JitMachine {
     modules: HashMap<String, CompileOutput>,
     machine_state: *const u8,
     registers: *const u8,
     write_literal_to_var: *const u8,
+}
+
+impl std::fmt::Debug for JitMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JitMachine")
+    }
 }
 
 impl JitMachine {
@@ -124,12 +130,13 @@ impl JitMachine {
 	Ok(())
     }
 
-    pub fn exec(&self, name: &str) {
+    pub fn exec(&self, name: &str) -> Result<(), ()> {
 	if let Some(output) = self.modules.get(name) {
 	    let code_ptr = unsafe { std::mem::transmute::<_, extern "C" fn() -> ()>(output.code_ptr) };
 	    code_ptr();
+	    Ok(())
 	} else {
-	    panic!("Can't find function");
+	    Err(())
 	}
     }
 }

--- a/src/machine/jit.rs
+++ b/src/machine/jit.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+
+use crate::instructions::*;
+use crate::machine::*;
+
+use cranelift::prelude::*;
+use cranelift::prelude::codegen::ir::immediates::Offset32;
+use cranelift_jit::{JITBuilder, JITModule};
+use cranelift_module::{Linkage, Module};
+
+struct CompileOutput {
+    module: JITModule,
+    code_ptr: *const u8,
+}
+
+#[derive(Debug, PartialEq)]
+enum JitCompileError {
+    UndefinedPredicate,
+    InstructionNotImplemented,
+}
+
+struct JitMachine {
+    modules: HashMap<String, CompileOutput>,
+    machine_state: *const u8,
+    registers: *const u8,
+    write_literal_to_var: *const u8,
+}
+
+impl JitMachine {
+    pub fn new(machine_st: &MachineState) -> Self {
+
+	JitMachine {
+	    modules: HashMap::new(),
+	    machine_state: machine_st as *const MachineState as *const u8,
+	    registers: machine_st.registers.as_ptr() as *const u8,
+	    write_literal_to_var: MachineState::write_literal_to_var as *const u8,
+	}
+    }
+
+    // For now, one module = one predicate
+    // Functions must take N parameters (arity)
+    // Access to MachineState via global pointer
+    // MachineState Registers + ShadowRegisters??
+    // Use TAIL call convention
+    pub fn compile(&mut self, name: &str, code: Code) -> Result<(), JitCompileError>{
+        let mut builder = JITBuilder::with_flags(&[("preserve_frame_pointers", "true")], cranelift_module::default_libcall_names()).unwrap();
+	builder.symbols(self.modules.iter().map(|(k, v)| (k,v.code_ptr)));
+	
+	let mut module = JITModule::new(builder);
+	let mut ctx = module.make_context();
+	let mut func_ctx = FunctionBuilderContext::new();
+
+	let mut sig = module.make_signature();
+	// Set arguments/returns
+	sig.call_conv = isa::CallConv::Tail;
+	ctx.func.signature = sig.clone();
+
+	let mut func = module.declare_function(name, Linkage::Local, &sig).unwrap();
+
+	let mut fn_builder = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
+	let block = fn_builder.create_block();
+	fn_builder.switch_to_block(block);
+	for wam_instr in code {
+	    match wam_instr {
+		Instruction::Proceed => {
+		    fn_builder.ins().return_(&[]);
+		    fn_builder.seal_all_blocks();
+		    fn_builder.finalize();
+		    break;
+		}
+		Instruction::ExecuteNamed(arity, pred_name, ..) => {
+		    let mut callee_func_sig = module.make_signature();
+		    callee_func_sig.call_conv = isa::CallConv::Tail;
+		    // right now, all predicates have 0 arguments. In the future with shadow registers, we could improve this
+		    if let Ok(callee_func) = module.declare_function(&format!("{}/{}", pred_name.as_str(), arity), Linkage::Import, &callee_func_sig) {
+			let func_ref = module.declare_func_in_func(callee_func, fn_builder.func);
+			fn_builder.ins().return_call(func_ref, &[]);
+			fn_builder.seal_all_blocks();
+			fn_builder.finalize();
+			break;
+		    } else {
+			return Err(JitCompileError::UndefinedPredicate);
+		    }
+		}
+		Instruction::GetConstant(_, c, reg) => {
+		    let reg_ptr = fn_builder.ins().iconst(types::I64, self.registers as i64); // TODO: call deref
+		    let reg_num = reg.reg_num();
+		    let reg_value = fn_builder.ins().load(types::I64, MemFlags::new(), reg_ptr, Offset32::new((reg_num as i32)*8));
+		    let c = unsafe { std::mem::transmute::<u64, i64>(u64::from(c)) };		    
+		    let c_value = fn_builder.ins().iconst(types::I64, c);
+		    let machine_state_value = fn_builder.ins().iconst(types::I64, self.machine_state as i64);
+		    let mut sig = module.make_signature();
+		    sig.call_conv = isa::CallConv::SystemV;
+		    sig.params.push(AbiParam::new(types::I64));
+		    sig.params.push(AbiParam::new(types::I64));
+		    sig.params.push(AbiParam::new(types::I64));
+		    let sig_ref = fn_builder.import_signature(sig);
+		    let write_literal_to_var = fn_builder.ins().iconst(types::I64, self.write_literal_to_var as i64);
+		    fn_builder.ins().call_indirect(sig_ref, write_literal_to_var, &[machine_state_value, reg_value, c_value]);
+		}
+		Instruction::PutConstant(_, c, reg) => {
+		    let reg_ptr = fn_builder.ins().iconst(types::I64, self.registers as i64);
+		    let reg_num = reg.reg_num();
+		    let c = unsafe { std::mem::transmute::<u64, i64>(u64::from(c)) };
+		    let c_value = fn_builder.ins().iconst(types::I64, c);
+		    fn_builder.ins().store(MemFlags::new(), c_value, reg_ptr, Offset32::new((reg_num as i32)*8));
+		}
+		_ => {
+		    return Err(JitCompileError::InstructionNotImplemented);
+		}
+	    }
+	}
+	module.define_function(func, &mut ctx).unwrap();
+	module.clear_context(&mut ctx);
+
+	module.finalize_definitions().unwrap();
+
+	let code_ptr = unsafe { std::mem::transmute(module.get_finalized_function(func)) };
+	self.modules.insert(name.to_string(), CompileOutput {
+	    module,
+	    code_ptr
+	});
+
+	Ok(())
+    }
+
+    pub fn exec(&self, name: &str) {
+	if let Some(output) = self.modules.get(name) {
+	    let code_ptr = unsafe { std::mem::transmute::<_, extern "C" fn() -> ()>(output.code_ptr) };
+	    code_ptr();
+	} else {
+	    panic!("Can't find function");
+	}
+    }
+}
+
+// basic.
+#[test]
+fn jit_test_proceed() {
+    let machine_st = MachineState::new();
+    let code = vec![Instruction::Proceed];
+    let name = "basic/0";
+
+    let mut jit = JitMachine::new(&machine_st);
+    assert_eq!(jit.compile(name, code), Ok(()));
+    jit.exec(name);
+}
+
+// basic.
+// simple :- basic.
+#[test]
+fn jit_test_execute_named() {
+    let machine_st = MachineState::new();
+    let mut jit = JitMachine::new(&machine_st);
+    let code = vec![Instruction::Proceed];
+    let name = "basic/0";
+    assert_eq!(jit.compile(name, code), Ok(()));
+
+    let code = vec![Instruction::ExecuteNamed(0, atom!("basic"), CodeIndex::default(&mut Arena::new()))];
+    let name = "simple/0";
+    assert_eq!(jit.compile(name, code), Ok(()));
+    jit.exec(name);
+}
+
+// a(5).
+// b :- a(5).
+#[test]
+fn jit_test_get_constant() {
+    let machine_st = MachineState::new();
+    let mut jit = JitMachine::new(&machine_st);
+    let code = vec![Instruction::GetConstant(Level::Shallow, fixnum_as_cell!(Fixnum::build_with(5)), RegType::Temp(1)), Instruction::Proceed];
+    let name = "a/1";
+    assert_eq!(jit.compile(name, code), Ok(()));
+
+    let code = vec![Instruction::PutConstant(Level::Shallow, fixnum_as_cell!(Fixnum::build_with(5)), RegType::Temp(1)), Instruction::ExecuteNamed(1, atom!("a"), CodeIndex::default(&mut Arena::new()))];
+    let name = "b/0";
+    assert_eq!(jit.compile(name, code), Ok(()));
+    jit.exec(name);
+    assert_eq!(machine_st.fail, false);
+}
+
+// a(5).
+// b :- a(6).
+#[test]
+fn jit_test_get_constant_fail() {
+    let machine_st = MachineState::new();
+    let machine_st = Box::pin(MachineState::new());
+    let mut jit = JitMachine::new(&machine_st);
+    let code = vec![Instruction::GetConstant(Level::Shallow, fixnum_as_cell!(Fixnum::build_with(5)), RegType::Temp(1)), Instruction::Proceed];
+    let name = "a/1";
+    assert_eq!(jit.compile(name, code), Ok(()));
+
+    let code = vec![Instruction::PutConstant(Level::Shallow, fixnum_as_cell!(Fixnum::build_with(6)), RegType::Temp(1)), Instruction::ExecuteNamed(1, atom!("a"), CodeIndex::default(&mut Arena::new()))];
+    let name = "b/0";
+    assert_eq!(jit.compile(name, code), Ok(()));
+    jit.exec(name);
+    assert_eq!(machine_st.fail, true);
+}

--- a/src/machine/jit.rs
+++ b/src/machine/jit.rs
@@ -294,7 +294,7 @@ impl JitMachine {
 	    }
 	}
 	module.define_function(func, &mut ctx).unwrap();
-	println!("{}", ctx.func.display());	
+	// println!("{}", ctx.func.display());	
 	module.clear_context(&mut ctx);
 
 	module.finalize_definitions().unwrap();

--- a/src/machine/jit.rs
+++ b/src/machine/jit.rs
@@ -294,16 +294,15 @@ impl JitMachine {
 	    }
 	}
 	module.define_function(func, &mut ctx).unwrap();
+	println!("{}", ctx.func.display());	
 	module.clear_context(&mut ctx);
 
 	module.finalize_definitions().unwrap();
-
 	let code_ptr = unsafe { std::mem::transmute(module.get_finalized_function(func)) };
 	self.modules.insert(name.to_string(), CompileOutput {
 	    module,
 	    code_ptr
 	});
-
 	Ok(())
     }
     

--- a/src/machine/jit2.rs
+++ b/src/machine/jit2.rs
@@ -1,0 +1,134 @@
+// This is another implementation of the JIT compiler
+// In this implementation we do not share data between the interpreter and the compiled code
+// We do copies before and after the execution
+
+use crate::instructions::*;
+use crate::machine::*;
+use crate::parser::ast::*;
+
+use cranelift::prelude::*;
+use cranelift_jit::{JITBuilder, JITModule};
+use cranelift_module::{Linkage, Module};
+use cranelift_codegen::Context;
+use cranelift::prelude::codegen::ir::immediates::Offset32;
+
+#[derive(Debug, PartialEq)]
+pub enum JitCompileError {
+    UndefinedPredicate,
+    InstructionNotImplemented,
+}
+
+
+pub struct JitMachine {
+    trampolines: Vec<*const u8>,
+    module: JITModule,
+    ctx: Context,
+    func_ctx: FunctionBuilderContext,
+}
+
+impl std::fmt::Debug for JitMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JitMachine")
+    }
+}
+
+
+impl JitMachine {
+    pub fn new() -> Self {
+	let builder = JITBuilder::with_flags(&[
+	    ("preserve_frame_pointers", "true"),
+	    ("enable_llvm_abi_extensions", "1")],
+					     cranelift_module::default_libcall_names()
+	).unwrap();
+	let mut module = JITModule::new(builder);
+	let pointer_type = module.isa().pointer_type();
+	let call_conv = module.isa().default_call_conv();
+
+	let mut ctx = module.make_context();
+	let mut func_ctx = FunctionBuilderContext::new();
+	
+	let mut sig = module.make_signature();
+	sig.params.push(AbiParam::new(pointer_type));
+	sig.params.push(AbiParam::new(pointer_type));
+	sig.call_conv = call_conv;
+
+	let mut trampolines = vec![];
+
+	// Should be MAX_ARITY
+	for n in 0..4 {
+	    ctx.func.signature = sig.clone();
+	    let mut fn_builder = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
+	    let block = fn_builder.create_block();
+	    fn_builder.append_block_params_for_function_params(block);
+	    fn_builder.switch_to_block(block);
+	    let func_addr = fn_builder.block_params(block)[0];
+	    let registers = fn_builder.block_params(block)[1];
+	    let mut jump_sig = module.make_signature();
+	    jump_sig.call_conv = isa::CallConv::Tail;
+	    let mut params = vec![];
+	    for i in 1..n+1 {
+		jump_sig.params.push(AbiParam::new(types::I64));
+		let reg_value = fn_builder.ins().load(types::I64, MemFlags::new(), registers, Offset32::new((i as i32)*8));
+		params.push(reg_value);
+	    }
+	    let jump_sig_ref = fn_builder.import_signature(jump_sig);
+	    fn_builder.ins().call_indirect(jump_sig_ref, func_addr, &params);
+	    fn_builder.ins().return_(&[]);
+	    fn_builder.seal_block(block);
+	    fn_builder.finalize();
+
+	    let func = module.declare_function(&format!("$trampoline/{}", n), Linkage::Local, &sig).unwrap();
+	    module.define_function(func, &mut ctx).unwrap();
+	    println!("{}", ctx.func.display());
+	    module.finalize_definitions().unwrap();	    
+	    module.clear_context(&mut ctx);
+	    let code_ptr: *const u8 = unsafe { std::mem::transmute(module.get_finalized_function(func)) };	    
+	    trampolines.push(code_ptr);
+	}
+
+
+	JitMachine {
+	    trampolines,
+	    module,
+	    ctx,
+	    func_ctx,
+	}
+    }
+
+    // TODO: Compile taking into account arity
+    pub fn compile(&mut self, name: &str, code: Code) -> Result<(), JitCompileError> {
+	let mut fn_builder = FunctionBuilder::new(&mut self.ctx.func, &mut self.func_ctx);
+	let block = fn_builder.create_block();
+	fn_builder.append_block_params_for_function_params(block);
+	fn_builder.switch_to_block(block);
+
+	for wam_instr in code {
+	    match wam_instr {
+		Instruction::Proceed => {
+		    fn_builder.ins().return_(&[]);
+		    break;
+	        },
+	        _ => {
+		    fn_builder.finalize();
+	            self.module.clear_context(&mut self.ctx);	
+		    return Err(JitCompileError::InstructionNotImplemented);
+	        }
+	    }
+	}
+	fn_builder.seal_all_blocks();
+	fn_builder.finalize();
+
+	let mut sig = self.module.make_signature();
+	sig.call_conv = isa::CallConv::Tail;
+
+	let func = self.module.declare_function(name, Linkage::Local, &sig).unwrap();
+	self.module.define_function(func, &mut self.ctx).unwrap();
+	println!("{}", self.ctx.func.display());
+	self.module.clear_context(&mut self.ctx);
+	Ok(())
+    }
+
+    pub fn exec(&self, name: &str, machine_st: &mut MachineState) -> Result<(), ()> {
+	Ok(())
+    }
+}

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -21,7 +21,6 @@ use indexmap::IndexMap;
 
 use std::convert::TryFrom;
 use std::fmt;
-use std::pin::*;
 use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -21,6 +21,7 @@ use indexmap::IndexMap;
 
 use std::convert::TryFrom;
 use std::fmt;
+use std::pin::*;
 use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -19,6 +19,7 @@ use indexmap::IndexSet;
 
 use std::cmp::Ordering;
 use std::convert::TryFrom;
+use std::pin::*;
 
 impl MachineState {
     pub(crate) fn new() -> Self {
@@ -79,7 +80,7 @@ impl MachineState {
     }
 
     #[inline]
-    pub fn deref(&self, mut addr: HeapCellValue) -> HeapCellValue {
+    pub extern "C" fn deref(&self, mut addr: HeapCellValue) -> HeapCellValue {
         loop {
             let value = self.store(addr);
 
@@ -1012,7 +1013,7 @@ impl MachineState {
         }
     }
 
-    pub(super) fn write_literal_to_var(&mut self, deref_v: HeapCellValue, lit: HeapCellValue) {
+    pub(super) extern "C" fn write_literal_to_var(&mut self, deref_v: HeapCellValue, lit: HeapCellValue) {
         let store_v = self.store(deref_v);
 
         read_heap_cell!(lit,

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -470,7 +470,7 @@ impl Machine {
             ),
         };
 
-	let jit_machine = JitMachine::new(&machine_st);
+	let jit_machine = JitMachine::new();
 
         let mut wam = Machine {
             machine_st,

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -61,6 +61,7 @@ use std::cmp::Ordering;
 use std::env;
 use std::io::Read;
 use std::path::PathBuf;
+use std::pin::*;
 use std::sync::atomic::AtomicBool;
 
 use self::config::MachineConfig;
@@ -1152,16 +1153,8 @@ impl Machine {
     fn try_execute(&mut self, name: Atom, arity: usize, idx: IndexPtr) -> CallResult {
         let compiled_tl_index = idx.p() as usize;
 
-	if name == atom!("a") {
-	    self.machine_st.p = self.machine_st.cp;
-	    self.machine_st.oip = 0;
-	    self.machine_st.iip = 0;
-	    self.machine_st.num_of_args = arity;
-	    self.machine_st.b0 = self.machine_st.b;
-	}
-
-	if let Ok(_) = self.jit_machine.exec(&format!("{}/{}", name.as_str(), arity)) {
-	    println!("Executed JIT predicate");
+	if let Ok(_) = self.jit_machine.exec(&format!("{}/{}", name.as_str(), arity), &mut self.machine_st) {
+	    println!("jit_compiler: executed JIT predicate");
 	    return Ok(());
 	}
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -12,6 +12,7 @@ pub mod disjuncts;
 pub mod dispatch;
 pub mod gc;
 pub mod heap;
+pub mod jit;
 pub mod lib_machine;
 pub mod load_state;
 pub mod machine_errors;
@@ -1139,6 +1140,8 @@ impl Machine {
 
         Ok(())
     }
+
+    
 
     #[inline(always)]
     fn try_execute(&mut self, name: Atom, arity: usize, idx: IndexPtr) -> CallResult {

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -19,6 +19,7 @@ use crate::machine;
 use crate::machine::code_walker::*;
 use crate::machine::copier::*;
 use crate::machine::heap::*;
+#[cfg(feature = "jit")]
 use crate::machine::jit::*;
 use crate::machine::machine_errors::*;
 use crate::machine::machine_indices::*;
@@ -4972,9 +4973,16 @@ impl Machine {
         Ok(())
     }
 
+    #[cfg(not(feature = "jit"))]
+    #[inline(always)]
+    pub(crate) fn jit_compile(&mut self) -> CallResult {
+	Ok(())
+    }
+
     // Tries to compile an existing predicate into native code
     // For this to work: the predicate must be loaded, must use the subset of Prolog supported by the JIT
     // and every call to a predicate must have been compiled previously
+    #[cfg(feature = "jit")]
     #[inline(always)]
     pub(crate) fn jit_compile(&mut self) -> CallResult {
         let module_name = cell_as_atom!(self.deref_register(1));

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -19,6 +19,7 @@ use crate::machine;
 use crate::machine::code_walker::*;
 use crate::machine::copier::*;
 use crate::machine::heap::*;
+use crate::machine::jit::*;
 use crate::machine::machine_errors::*;
 use crate::machine::machine_indices::*;
 use crate::machine::machine_state::*;
@@ -4968,6 +4969,79 @@ impl Machine {
         ));
 
         unify!(self.machine_st, args, cell);
+        Ok(())
+    }
+
+    // Tries to compile an existing predicate into native code
+    // For this to work: the predicate must be loaded, must use the subset of Prolog supported by the JIT
+    // and every call to a predicate must have been compiled previously
+    #[inline(always)]
+    pub(crate) fn jit_compile(&mut self) -> CallResult {
+        let module_name = cell_as_atom!(self.deref_register(1));
+        let name = cell_as_atom!(self.deref_register(2));
+        let arity = self.deref_register(3);
+
+        let arity = match Number::try_from(arity) {
+            Ok(Number::Fixnum(n)) => n.get_num() as usize,
+            Ok(Number::Integer(n)) => {
+                let value: usize = (&*n).try_into().unwrap();
+                value
+            }
+            _ => {
+                unreachable!()
+            }
+        };
+
+        let key = (name, arity);
+
+        let first_idx = match module_name {
+            atom!("user") => self.indices.code_dir.get(&key),
+            _ => match self.indices.modules.get(&module_name) {
+                Some(module) => module.code_dir.get(&key),
+                None => {
+                    let stub = functor_stub(key.0, key.1);
+                    let err = self.machine_st.session_error(SessionError::from(
+                        CompilationError::InvalidModuleResolution(module_name),
+                    ));
+
+                    return Err(self.machine_st.error_form(err, stub));
+                }
+            },
+        };
+
+        let first_idx = match first_idx {
+            Some(idx) if idx.local().is_some() => {
+                if let Some(idx) = idx.local() {
+                    idx
+                } else {
+                    unreachable!()
+                }
+            }
+            _ => {
+                let stub = functor_stub(name, arity);
+                let err = self
+                    .machine_st
+                    .existence_error(ExistenceError::Procedure(name, arity));
+
+                return Err(self.machine_st.error_form(err, stub));
+            }
+        };
+
+	let mut code = vec![];
+	walk_code(&self.code, first_idx, |instr| code.push(instr.clone()));
+
+	match self.jit_machine.compile(&format!("{}/{}", name.as_str(), arity), code) {
+	    Err(JitCompileError::UndefinedPredicate) => {
+		eprintln!("jit_compiler: undefined_predicate");
+		self.machine_st.fail = true;
+	    }
+	    Err(JitCompileError::InstructionNotImplemented) => {
+		eprintln!("jit_compiler: instruction not implemented");
+		self.machine_st.fail = true;
+	    }
+	    _ => {}
+	}
+
         Ok(())
     }
 

--- a/src/tests/jit_test.pl
+++ b/src/tests/jit_test.pl
@@ -2,9 +2,12 @@
 
 a(X) :- b(X).
 b(X) :- X is 1 + 1 + 1 + 1.
+c(X, Y) :- X is Y + 1.
 
 test :-
     jit_compile(b/1),
     jit_compile(a/1),
     a(X),
-    X = 4.
+    X = 4,
+    jit_compile(c/2),
+    c(2, 1).

--- a/src/tests/jit_test.pl
+++ b/src/tests/jit_test.pl
@@ -1,0 +1,10 @@
+:- use_module(library(jit)).
+
+a(X) :- b(X).
+b(X) :- X is 1 + 1 + 1 + 1.
+
+test :-
+    jit_compile(b/1),
+    jit_compile(a/1),
+    a(X),
+    X = 4.

--- a/tests/scryer/cli/src_tests/jit.stdout
+++ b/tests/scryer/cli/src_tests/jit.stdout
@@ -1,2 +1,0 @@
-jit_compiler: executed JIT predicate
-jit_compiler: executed JIT predicate

--- a/tests/scryer/cli/src_tests/jit.stdout
+++ b/tests/scryer/cli/src_tests/jit.stdout
@@ -1,1 +1,2 @@
 jit_compiler: executed JIT predicate
+jit_compiler: executed JIT predicate

--- a/tests/scryer/cli/src_tests/jit.stdout
+++ b/tests/scryer/cli/src_tests/jit.stdout
@@ -1,0 +1,1 @@
+jit_compiler: executed JIT predicate

--- a/tests/scryer/cli/src_tests/jit.toml
+++ b/tests/scryer/cli/src_tests/jit.toml
@@ -1,0 +1,1 @@
+args = ["-f", "--no-add-history", "src/tests/jit_test.pl", "-f", "-g", "test"]


### PR DESCRIPTION
I open this PR as I think it's good to have some code merged to not diverge a lot from the master branch.

All the JIT code is under the `jit` feature which is not enabled by default, so you shouldn't expect any change if you don't enable it (apart from an extra predicate, `jit_compile/1`, that does nothing).

There are two JITs right now:
- JIT1 was my first attempt. It tries to share all the data structures with the interpreter. I saw some problems with this approach so I stopped it.
- JIT2 is a new approach. I try to learn from the JIT1, it will manage more things on its own.

I also added a JIT CI test