### PR TITLE
Adds SHA1 to crypto.pl and a macOS specific file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 src/static_atoms.rs
 target/
-
+/.DS_Store
 
 

--- a/src/lib/crypto.pl
+++ b/src/lib/crypto.pl
@@ -296,6 +296,7 @@ functor_hash_options(F, Hash, Options0, [Option|Options]) :-
         ).
 
 hash_algorithm(ripemd160).
+hash_algorithm(sha1_deprecated).
 hash_algorithm(sha256).
 hash_algorithm(sha512).
 hash_algorithm(sha384).

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -7382,6 +7382,7 @@ impl Machine {
             _ => {
                 let ints = digest::digest(
                     match algorithm {
+                        atom!("sha1_deprecated") => &digest::SHA1_FOR_LEGACY_USE_ONLY,
                         atom!("sha256") => &digest::SHA256,
                         atom!("sha384") => &digest::SHA384,
                         atom!("sha512") => &digest::SHA512,


### PR DESCRIPTION
Adds SHA1 to `crypto.pl` and a macOS specific file to `.gitignore`.

I know that SHA1 is deprecated (it also says so in the definition from `ring`), however, it's still useful to have this here for non-security purposes, e.g. its use in [websockets](https://datatracker.ietf.org/doc/html/rfc6455#section-10.8). I also figured I'd suffix it with `_deprecated` to make it obvious it shouldn't be typically used.