### PR TITLE
Goal expansion in lib reif

### DIFF
--- a/src/lib/memberbench.pl
+++ b/src/lib/memberbench.pl
@@ -1,3 +1,8 @@
+/*
+Direct copy from http://www.complang.tuwien.ac.at/ulrich/Prolog-inedit/sicstus/memberbench.pl
+only with minor modifications.
+*/
+
 :- module(memberbench,[run/0]).
 
 :- use_module(library(reif)).

--- a/src/lib/memberbench.pl
+++ b/src/lib/memberbench.pl
@@ -11,7 +11,10 @@
 
 % uwnportray(T) :- write_term(T,[quoted(true)]),nl.
 
-
+:- use_module(library(lists)).
+:- use_module(library(format)).
+:- use_module(library(dif)).
+statistics(_,[0]).
 
 uwnportray(T) :- portray_clause(T).  % Item#539
 
@@ -294,7 +297,7 @@ time(G_0, Tms) :-
 time(G_0) :-
    time(G_0, Tms),
    functor(G_0, F, N),
-   format('~q: t=~3ds~n',[F/N,Tms]).
+   format("~q: t=~3ds~n",[F/N,Tms]).
 
 ten.
 ten.
@@ -344,8 +347,8 @@ run :-
    time(en_memberd(N, E, Es)),
    time(en_memberd2(N, E, Es)),
    time(en_memberd3(N, E, Es)),
-%   time(en_memberdc(N, E, Es)),
-%   time(en_memberdo(N, E, Es)),
+   time(en_memberdc(N, E, Es)),
+   time(en_memberdo(N, E, Es)),
    time(en_memberd_fif(N, E, Es)),
    time(en_memberd_ifc(N, E, Es)),
    time(en_memberd_if1(N, E, Es)),
@@ -355,7 +358,7 @@ run :-
    time(en_memberd_if3bad2(N, E, Es)),
    time(en_memberd_if3bad3(N, E, Es)),
    time(en_memberd_if4(N, E, Es)),
-   time(en_memberd_ifopti(N, E, Es)),
+%  time(en_memberd_ifopti(N, E, Es)),
    time(en_memberd_ifperfect(N, E, Es)),
    time(en_memberd_ifperfect(N, E, Es)),
    K = c,
@@ -379,10 +382,3 @@ n_kvs(Len, KVs) :-
    length(Pre,Len),
    maplist(=(b-v),Pre),
    append(Pre,[c-w,d-e],KVs).
-
-maplist(_P_1, []).
-maplist(P_1, [E|Es]):-
-   call(P_1, E),
-   maplist(P_1, Es).
-
-

--- a/src/lib/memberbench.pl
+++ b/src/lib/memberbench.pl
@@ -1,0 +1,388 @@
+:- module(memberbench,[run/0]).
+
+:- use_module(library(reif)).
+
+:- meta_predicate fif_(1,0,0).
+
+
+:- set_prolog_flag(double_quotes,chars).
+
+:- op(900, fy, [$]).
+
+% uwnportray(T) :- write_term(T,[quoted(true)]),nl.
+
+
+
+uwnportray(T) :- portray_clause(T).  % Item#539
+
+$(X) :- uwnportray(call-X),X,uwnportray(exit-X).
+
+
+en_memberchk(N, E, Es) :-
+  exptrue(N),
+  \+ memberchk(E, Es)
+; true.
+
+memberchk_once(E, Es) :-
+   once(member(E, Es)).
+
+en_memberchk_once(N, E, Es) :-
+  exptrue(N),
+  \+ memberchk_once(E, Es)
+; true.
+
+memberd(X, [X|_Es]).
+memberd(X, [E|Es]) :-
+   dif(X, E),
+   memberd(X, Es).
+
+en_memberd(N, E, Es) :-
+  exptrue(N),
+  \+ memberd(E, Es)
+; true.
+
+memberd2(X, [E|Es]) :-
+   (  X = E
+   ;  dif(X, E),
+      memberd2(X, Es)
+   ).
+
+en_memberd2(N, E, Es) :-
+  exptrue(N),
+  \+ memberd2(E, Es)
+; true.
+
+memberd3(X, [E|Es]) :-
+   memberd3(X, E, Es).
+
+memberd3(X, X, _Es).
+memberd3(X, E, Es) :-
+   dif(X, E),
+   Es = [F|Fs],
+   memberd3(X, F, Fs).
+
+en_memberd3(N, E, Es) :-
+  exptrue(N),
+  \+ memberd3(E, Es)
+; true.
+
+
+memberdc(X, [X|_Es]).
+memberdc(X, [E|Es]) :-
+   call(dif(X, E)),
+   memberdc(X, Es).
+
+en_memberdc(N, E, Es) :-
+  exptrue(N),
+  \+ memberdc(E, Es)
+; true.
+
+memberdo(X, [X|_Es]).
+memberdo(X, [E|Es]) :-
+   once((dif(X, E),(fail,true;true))),
+   memberdo(X, Es).
+
+en_memberdo(N, E, Es) :-
+  exptrue(N),
+  \+ memberdo(E, Es)
+; true.
+
+
+memberd_ifc(X, [E|Es]) :-
+   if_(X = E, true, memberd_ifc(X, Es) ).
+
+en_memberd_ifc(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_ifc(E, Es)
+; true.
+
+memberd_fif(X, [E|Es]) :-
+   fif_(X = E, true, memberd_fif(X, Es) ).
+
+en_memberd_fif(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_fif(E, Es)
+; true.
+
+
+memberd_if1(X, [E|Es]) :-
+   ( X == E -> true
+   ; X \= E -> memberd_if1(X, Es)
+   ; X = E
+   ; dif(X, E),
+     memberd_if1(X, Es)
+   ).
+
+en_memberd_if1(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_if1(E, Es)
+; true.
+
+memberd_if2(X, [E|Es]) :-
+   ( X \= E -> memberd_if2(X, Es)
+   ; X == E -> true
+   ; X = E
+   ; dif(X, E),
+     memberd_if2(X, Es)
+   ).
+
+en_memberd_if2(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_if2(E, Es)
+; true.
+
+% if3bad: This serves only to estimate the unnecessary overheads
+% currently created by \= compared to \==
+
+memberd_if3bad(X, [E|Es]) :-
+   ( X \== E -> memberd_if3bad(X, Es)  % actually wrong
+   ; X == E -> true
+   ; X = E
+   ; dif(X, E),
+     memberd_if3bad(X, Es)
+   ).
+
+en_memberd_if3bad(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_if3bad(E, Es)
+; true.
+
+memberd_if3bad2(X, [E|Es]) :-
+   memberd_if3bad2(X, E, Es).
+
+memberd_if3bad2(X, E, Es) :-
+   X \== E, % should be rather X \== E, ?=(X,E) -
+   !,
+	Es = [F|Fs],
+	memberd_if3bad2(X, F, Fs).
+memberd_if3bad2(X, E, _Es) :-
+   X == E,
+   !.
+memberd_if3bad2(X, E, Es) :-
+   (  X \= E
+	-> Es = [F|Fs],
+      memberd_if3bad2(X, F, Fs)
+   ;  X = E
+   ;  dif(X, E),
+      memberd_if3bad2(X, Es)
+   ).
+
+en_memberd_if3bad2(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_if3bad2(E, Es)
+; true.
+
+memberd_if3bad3(X, [E|Es]) :-
+   ( X \== E -> memberd_if3bad3(X, Es)  % actually wrong
+   ; X == E -> true
+   ; (  X \= E -> memberd_if3bad3(X, Es)
+     ;  X = E
+     ;  dif(X, E),
+        memberd_if3bad3(X, Es)
+     )
+   ).
+
+en_memberd_if3bad3(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_if3bad3(E, Es)
+; true.
+
+
+
+
+
+
+notequal(X,X) :- !, fail.
+notequal(_,_).
+
+memberd_if4(X, [E|Es]) :-
+   ( notequal(X,E) -> memberd_if4(X, Es)  % actually wrong
+   ; X == E -> true
+   ; X = E
+   ; dif(X, E),
+     memberd_if4(X, Es)
+   ).
+
+en_memberd_if4(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_if4(E, Es)
+; true.
+
+% ifopti: A version that might be best, provided X \== E, ?=(X, E) is one
+% efficient conditional built-in
+
+memberd_ifopti(X, [E|Es]) :-
+   ( X \== E, ?=(X,E) -> memberd_ifopti(X, Es)
+   ; X == E -> true
+	; X \= E -> memberd_ifopti(X, Es)
+   ; X = E
+   ; dif(X, E),
+     memberd_ifopti(X, Es)
+   ).
+
+en_memberd_ifopti(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_ifopti(E, Es)
+; true.
+
+
+% perfect: A compiler that is able to perfectly compile the disjunction,
+% thus not creating any CP in the beginning for simple tests
+
+memberd_ifperfect(X, [E|Es]) :-
+   ( X = E
+   ; dif(X, E),
+     memberd_ifperfect(X, Es)
+   ).
+
+en_memberd_ifperfect(N, E, Es) :-
+  exptrue(N),
+  \+ memberd_ifperfect(E, Es)
+; true.
+
+
+en_bassoc(N, K,KVs,V) :-
+   exptrue(N),
+   \+ get_bassoc(K, KVs, V)
+;  true.
+
+get_bassoc(K, KVs, V) :-
+   memberchk(K-V, KVs).
+
+en_lassoc(N, K,KVs,V) :-
+   exptrue(N),
+   \+ get_lassoc(K, KVs, V)
+;  true.
+
+get_lassoc(K, KVs, V) :-
+   once(member(K-V, KVs)).
+
+
+en_memberk(N, K,V, KVs) :-
+   exptrue(N),
+   \+ memberk(K, V, KVs)
+;  true.
+
+
+memberk(K0,V0, [K-V|KVs]) :-
+   if_(K0 = K, V0 = V, memberk(K0,V0, KVs)).
+
+en_fmemberk(N, K,V, KVs) :-
+   exptrue(N),
+   \+ fmemberk(K, V, KVs)
+;  true.
+
+
+fmemberk(K0,V0, [K-V|KVs]) :-
+   fif_(K0 = K, V0 = V, fmemberk(K0,V0, KVs)).
+
+fif_(If_1, Then_0, Else_0) :-
+   call(If_1, T),
+   (  T == true -> Then_0
+   ;  T == false -> Else_0
+   ;  nonvar(T) -> throw(error(type_error(boolean,T),
+                               type_error(call(If_1,T),2,boolean,T)))
+   ;  throw(error(instantiation_error,instantiation_error(call(If_1,T),2)))
+   ).
+
+time(G_0, Tms) :-
+   statistics(runtime, [T0|_]),
+   G_0,
+   statistics(runtime, [T1|_]),
+   Tms is T1-T0.
+
+time(G_0) :-
+   time(G_0, Tms),
+   functor(G_0, F, N),
+   format('~q: t=~3ds~n',[F/N,Tms]).
+
+ten.
+ten.
+ten.
+ten.
+ten.
+ten.
+ten.
+ten.
+ten.
+ten.
+
+exptrue(0).
+exptrue(1) :-
+  ten.
+exptrue(2) :-
+  ten,
+  ten.
+exptrue(3) :-
+  ten,
+  ten,
+  ten.
+exptrue(4) :-
+  ten,
+  ten,
+  ten,
+  ten.
+exptrue(5) :-
+  ten,
+  ten,
+  ten,
+  ten,
+  ten.
+exptrue(6) :-
+  ten,
+  ten,
+  ten,
+  ten,
+  ten,
+  ten.
+
+run :-
+   E = z, Es = "abcdefghijklmnopqrstuvwxyz ",
+   N = 5,
+   time(en_memberchk(N, E, Es)),
+   time(en_memberchk_once(N, E, Es)),
+   time(en_memberd(N, E, Es)),
+   time(en_memberd2(N, E, Es)),
+   time(en_memberd3(N, E, Es)),
+%   time(en_memberdc(N, E, Es)),
+%   time(en_memberdo(N, E, Es)),
+   time(en_memberd_fif(N, E, Es)),
+   time(en_memberd_ifc(N, E, Es)),
+   time(en_memberd_if1(N, E, Es)),
+   time(en_memberd_if2(N, E, Es)),
+   time(en_memberd_if4(N, E, Es)),
+   time(en_memberd_if3bad(N, E, Es)),
+   time(en_memberd_if3bad2(N, E, Es)),
+   time(en_memberd_if3bad3(N, E, Es)),
+   time(en_memberd_if4(N, E, Es)),
+   time(en_memberd_ifopti(N, E, Es)),
+   time(en_memberd_ifperfect(N, E, Es)),
+   time(en_memberd_ifperfect(N, E, Es)),
+   K = c,
+   \+ (  member(Len,[10,20,10,20]),
+         writeq(len=Len),nl,
+         n_kvs(Len,KVs),
+         \+ (
+            time(en_bassoc(N, K, KVs, _)),
+            time(en_lassoc(N, K, KVs, _)),
+            time(en_fmemberk(N, K,_,KVs)),
+            time(en_memberk(N, K,_,KVs)),
+            time(en_bassoc(N, K, KVs, _)),
+            time(en_lassoc(N, K, KVs, _)),
+            time(en_fmemberk(N, K,_,KVs)),
+            time(en_memberk(N, K,_,KVs))
+         )
+   ).
+
+
+n_kvs(Len, KVs) :-
+   length(Pre,Len),
+   maplist(=(b-v),Pre),
+   append(Pre,[c-w,d-e],KVs).
+
+maplist(_P_1, []).
+maplist(P_1, [E|Es]):-
+   call(P_1, E),
+   maplist(P_1, Es).
+
+

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -84,7 +84,7 @@ sameargs(0, _, _).
 % ```
 %
 % [2]: http://www.complang.tuwien.ac.at/ulrich/Prolog-inedit/sicstus/memberbench.pl
-goal_expansion(if_(If_1, Then_0, Else_0), G_0) :-
+user:goal_expansion(if_(If_1, Then_0, Else_0), G_0) :-
     ugoal_expansion(if_(If_1, Then_0, Else_0), G_0),
     % Dump expanded goals to the console for inspection.
     % TODO: Remove when fully debugged

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -1,14 +1,4 @@
 /** Predicates from [*Indexing dif/2*](https://arxiv.org/abs/1607.01590).
-
-Example:
-
-```
-?- tfilter(=(a), [X,Y], Es).
-   X = a, Y = a, Es = "aa"
-;  X = a, Es = "a", dif:dif(a,Y)
-;  Y = a, Es = "a", dif:dif(a,X)
-;  Es = [], dif:dif(a,X), dif:dif(a,Y).
-```
 */
 
 :- module(reif, [if_/3, (=)/3, (',')/3, (;)/3, cond_t/3, dif/3,
@@ -16,6 +6,142 @@ Example:
 		         tpartition/4]).
 
 :- use_module(library(dif)).
+
+% TODO: Remove when fully debugged
+:- use_module(library(debug)).
+:- use_module(library(format)).
+:- op(750, xfy, =>).
+
+goal_expanded(MG_0, MGx_0) :-
+   var(MG_0),
+   !,
+   MG_0 = MGx_0.
+goal_expanded(call(MG_1, X), MGx_0) :-
+   MG_1 = M:G_1, atom(M), callable(G_1), G_1 \= (_:_),
+   functor_(G_1, G_0, X),
+   \+ predicate_property(M:G_0, (meta_predicate _)),
+   !,
+   MGx_0 = M:G_0.
+goal_expanded(call(G_0), Gx_0) :-
+   acyclic_term(G_0),
+   nonvar(G_0),
+   % more conditions
+   !,
+   G_0 = Gx_0.
+goal_expanded(MG_0, MG_0).
+
+
+%% functor_(+T, ?TA, ?A).
+%
+% `TA` is `T` extended with additional parameter `A`
+%
+% ```
+% ?- functor_(a(b), X, c).
+%    X = a(b,c).
+% ```
+functor_(T, TA, A) :-
+   functor(T, F, N0),
+   N1 is N0+1,
+   functor(TA, F, N1),
+   arg(N1, TA, A),
+   sameargs(N0, T, TA).
+
+sameargs(N0, S, T) :-
+   N0 > 0,
+   N1 is N0-1,
+   arg(N0, S, A),
+   arg(N0, T, A),
+   sameargs(N1, S, T).
+sameargs(0, _, _).
+
+
+/* FIXME: What does this ↓ comment from the source mean? Is it a list of features, "to do" items or guidelines? */
+/*
+  no !s that cut outside.
+  no variables in place of goals
+  no malformed goals like integers
+*/
+
+
+/* FIXME: How can I reproduce this? ↓ */
+/* 2do: unqualified If_1: error
+*/
+
+
+goal_expansion(if_(If_1, Then_0, Else_0), G_0) :-
+    ugoal_expansion(if_(If_1, Then_0, Else_0), G_0),
+    % Dump expanded goals to the console for inspection.
+    % TODO: Remove when fully debugged
+    portray_clause((if_(If_1,Then_0,Else_0) => G_0)).
+
+
+%% ugoal_expansion(if_(+If_1, ?Then_0, ?Else_0), -Goal_0).
+%
+% Performance of if_/3 heavily relies on call/N, this predicates tries to unwrap
+% some terms for improved speed.
+%
+% Expansion rules:
+%
+% if_(A=B,Then_0,Else_0)
+% => if equality of A and B is satisfiable then expanded `Then_0`, otherwise
+%    expanded `Else_0`.
+%
+% if_((A_1;B_1), Then_0, Else_0)
+% => if_(A_1, Then_0, if_(B_1, Then_0, Else_0))
+%
+% if_((A_1,B_1), Then_0, Else_0)
+% => Goal_0 = if_(A_1, if_(B_1, Then_0, Else_0), Else_0).
+%
+% Otherwise it simply expands If_1, Then_0 and Else_0 using goal_expanded/2.
+% Read it's documentation to find out how it operates.
+ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
+    subsumes_term(M:(X=Y), If_1),
+    M:(X=Y) = If_1,
+    atom(M),
+    M == reif,
+    % FIXME: imported_from(_) key isn't implemented for predicate_property/2
+    % ( M == reif -> true ; predicate_property(M: =(_,_,_),imported_from(reif)) ),
+    goal_expanded(call(Then_0), Thenx_0),
+    goal_expanded(call(Else_0), Elsex_0),
+    !,
+    write('% =\n'),
+    Goal_0 =
+        ( X \= Y -> Elsex_0
+        ; X == Y -> Thenx_0
+        ; X = Y,    Thenx_0
+        ; dif(X,Y), Elsex_0
+        ).
+ugoal_expansion(if_(If_1, Then_0, Else_0), Goal) :-
+    subsumes_term(M:(A_1;B_1), If_1),
+    M:(A_1;B_1) = If_1,
+    atom(M),
+    M == reif,
+    % ( M == reif -> true ; predicate_property(M:;(_,_,_),imported_from(reif)) ),
+    !,
+    write('% ;\n'),
+    Goal = if_(A_1, Then_0, if_(B_1, Then_0, Else_0)).
+ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
+    subsumes_term(M:(A_1,B_1), If_1),
+    M:(A_1,B_1) = If_1,
+    atom(M),
+    M == reif,
+    % ( M == reif -> true ; predicate_property(M:','(_,_,_),imported_from(reif)) ),
+    !,
+    write('% ,\n'),
+    Goal_0 = if_(A_1, if_(B_1, Then_0, Else_0), Else_0).
+ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
+    write('% _\n'),
+    goal_expanded(call(If_1, T), Ifx_0),
+    goal_expanded(call(Then_0), Thenx_0),
+    goal_expanded(call(Else_0), Elsex_0),
+    Goal_0 =
+        (   Ifx_0,
+            (  T == true -> Thenx_0
+            ;  T == false -> Elsex_0
+            ;  nonvar(T) -> throw(error(type_error(boolean,T),_))
+            ;  throw(error(instantiation_error,_))
+            )
+        ).
 
 :- meta_predicate(if_(1, 0, 0)).
 
@@ -27,6 +153,10 @@ if_(If_1, Then_0, Else_0) :-
     ;  throw(error(instantiation_error, _))
     ).
 
+
+%% =(?X, ?Y, -T)
+%
+% Support predicate for the 1st argument of if_/3
 =(X, Y, T) :-
     (  X == Y -> T = true
     ;  X \= Y -> T = false
@@ -34,6 +164,11 @@ if_(If_1, Then_0, Else_0) :-
     ;  T = false, dif(X, Y)
     ).
 
+
+%% dif(?X, ?Y, -T)
+%
+% Reified version of dif/2, always succeeds and makes sure that T value
+% is `true` if X differs from Y. The only use case is in if_/3 meta-predicat.
 dif(X, Y, T) :-
   =(X, Y, NT),
   non(NT, T).
@@ -43,6 +178,17 @@ non(false, true).
 
 :- meta_predicate(tfilter(2, ?, ?)).
 
+%% tfilter(+Predicate, ?List, ?FilteredList).
+%
+% Example:
+%
+% ```
+% ?- tfilter(=(a), [X,Y], Es).
+%    X = a, Y = a, Es = "aa"
+% ;  X = a, Es = "a", dif:dif(a,Y)
+% ;  Y = a, Es = "a", dif:dif(a,X)
+% ;  Es = [], dif:dif(a,X), dif:dif(a,Y).
+% ```
 tfilter(_, [], []).
 tfilter(C_2, [E|Es], Fs0) :-
    if_(call(C_2, E), Fs0 = [E|Fs], Fs0 = Fs),
@@ -62,19 +208,31 @@ i_tpartition([X|Xs], P_2, Ts0, Fs0) :-
 
 :- meta_predicate(','(1, 1, ?)).
 
+%% ','(?A, ?B, -T).
+%
+% Support predicate for the 1st argument of if_/3
 ','(A_1, B_1, T) :-
     if_(A_1, call(B_1, T), T = false).
 
 :- meta_predicate(';'(1, 1, ?)).
 
+%% ';'(?A, ?B, -T).
+%
+% Support predicate for the 1st argument of if_/3
 ';'(A_1, B_1, T) :-
     if_(A_1, T = true, call(B_1, T)).
 
 :- meta_predicate(cond_t(1, 0, ?)).
 
+%% cond_t(?If_1, ?Then_0, -T).
+%
+% Support predicate for the 1st argument of if_/3
 cond_t(If_1, Then_0, T) :-
    if_(If_1, ( Then_0, T = true ), T = false ).
 
+%% memberd_t(?Element, ?List, -T).
+%
+% Support predicate for the 1st argument of if_/3
 memberd_t(E, Xs, T) :-
    i_memberd_t(Xs, E, T).
 
@@ -83,12 +241,142 @@ i_memberd_t([X|Xs], E, T) :-
    if_( X = E, T = true, i_memberd_t(Xs, E, T) ).
 
 :- meta_predicate(tmember(2, ?)).
-
 tmember(P_2, [X|Xs]) :-
    if_( call(P_2, X), true, tmember(P_2, Xs) ).
 
 :- meta_predicate(tmember_t(2, ?, ?)).
-
 tmember_t(_P_2, [], false).
 tmember_t(P_2, [X|Xs], T) :-
    if_( call(P_2, X), T = true, tmember_t(P_2, Xs, T) ).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Extras from the paper
+
+duplicate(X, Xs) :-
+    tfilter(=(X), Xs, [_,_|_]).
+
+firstduplicate(X, [E|Es]) :-
+    if_(memberd_t(E,Es), X=E, firstduplicate(X, Es)).
+
+treememberd_t(_, nil, false).
+treememberd_t(E, t(F,L,R), T) :-
+    call((E=F; treememberd_t(E,L); treememberd_t(E,R)), T).
+
+tree_non_member(_, nill).
+tree_non_member(E, t(F,L,R)) :-
+    dif(E,F),
+    tree_non_member(E, L),
+    tree_non_member(E, R).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Benchmark
+
+bench :- false.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Unit tests
+
+% indexing_dif_* tests are just sanity checks – examples from the paper, to
+% make sure I haven't messed up.
+t(true, (
+    indexing_dif_p6_e1 :-
+        findall(X-Fs, tfilter(=(X),[1,2,3,2,3,3],Fs), [1-[1], 2-[2,2], 3-[3,3,3], Y-[]]),
+        maplist(dif(Y), [1,2,3])
+)).
+t(true, (indexing_dif_p6_e2 :- findall(X, duplicate(X,[1,2,3,2,3,3]), [2,3]))).
+t(true, (indexing_dif_p7_e1 :- firstduplicate(1, [1,2,3,1]))).
+t(true, (indexing_dif_p7_e2 :- firstduplicate(X, [1,2,3,1]), X == 1)).
+t(true, (indexing_dif_p7_e3 :-
+    findall(Y-A-B-C, firstduplicate(Y,[A,B,C]), [X-X-X-_, X-X-B1-X, X-A2-X-X]),
+    dif(B1,X),
+    dif(A2,X)
+)).
+
+t(true, (functor_handles_unary_term :- functor_(a(b),G,c), G == a(b,c))).
+t(true, (functor_handles_atoms :- functor_(a,G,b), G == a(b))).
+t(true, (functor_handles_cyclic_terms :- X = a(b,X), functor_(X,G,c), G == a(b,X,c))).
+t(error(instantiation_error), (functor_refuses_free_variable :- functor_(_,a(b),b))).
+t(false, (functor_checks_for_correctness :- functor_(a,a,c))).
+
+t(true, (doesnt_modify_free_variables :- goal_expanded(A,B), A == B, var(A))).
+t(true, (expands_call1 :- goal_expanded(call(a), a))).
+t(true, (expands_call1_for_modules :- goal_expanded(call(a:b(1)), a:b(1)))).
+t(true, (expands_call2_for_modules :- goal_expanded(call(a:b,c), a:b(c)))).
+t(true, (doesnt_expand_call2 :- goal_expanded(call(b,c), call(b,c)))).
+t(true, (doesnt_expand_cyclic_terms :- X=a(X), goal_expanded(call(X), Y), call(X) == Y)).
+t(true, (doesnt_expand_higher_order_predicates :- X = maplist(=(1), _), goal_expanded(X, Y), X == Y)).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Unit test support (probably should be moved to another module)
+
+:- use_module(library(iso_ext)).
+:- use_module(library(lists)).
+
+:- dynamic([t/2]).
+
+%% testall.
+%
+% Fails if at least one test doesn't pass, but still executes all of them no
+% matter what while printing report line for each unit test.
+%
+% Report looks like the following:
+%
+% ```
+% true:[test_name,...]
+% false:test_name
+% skip:test_name
+% error(ErrorTerm):test_name
+% ```
+%
+% Test succeeds if it perfroms according to its expected outcome. Test may
+% succeed multiple times.
+%
+% Test definition looks like this:
+%
+% ```
+% t(ExpectedOutcome, (TestName :- TestBody)).
+% ```
+%
+% Where:
+%   `ExpectedOutcome` is either `true`, `false` or `error(ErrorTerm)` when an exception is expected.
+%   `TestName` is a term describing the test (usually an atom)
+%   `TestBody` is an actual test case
+%
+% TODO: Write tips for writting tests
+% FIXME: There some quirks when using inside modules, because of (:)/2.
+testall :- findall(C, testsingle(C), Cs), maplist(pass, Cs).
+
+pass(true).
+pass(skip).
+
+%% testsingle(-TestResult).
+%
+% Retrieves unit tests and executes it. Always succeeds.
+testsingle(C) :-
+    gettest(D, G),
+    asserta(D),
+    call_cleanup(runtest(G,C), retract(D)).
+
+%% gettest(-TestPredicate, -TestQuery).
+%
+% Retrieves unit test from the datebase, fails if no tests were found or test
+% definition is incorrect.
+%
+% TODO: Throw exception, don't fail.
+% FIXME: Handle modules correctly
+gettest((H:-B), G) :- t(E, (H:-B)), expectation_goal(E, H, G).
+expectation_goal(true, H, H).
+expectation_goal(false, H, \+reif:H).
+expectation_goal(error(E), H, catch(reif:H, error(E, _), true)).
+expectation_goal(skip, H, true(H)).
+true(_).
+
+%% runtest(+Goal, -ResultCode).
+%
+% Try to collect all solutions and print predicate outcome no matter what.
+% Always succeeds.
+runtest(G, C) :- catch(findall(G,G,S), E, S = x(E)), what_to_print(S, G, C:R), write(C:R), nl.
+what_to_print([],          G, false:G).
+what_to_print([true(H)|_], _,  skip:H).
+what_to_print([H|T],       _,  true:[H|T]) :- H \= true(_).
+what_to_print(x(E),        G,     E:G).

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -12,6 +12,8 @@
 :- use_module(library(format)).
 :- op(750, xfy, =>).
 
+%% goal_expanded(+Goal, -ExpandedGoal).
+%
 goal_expanded(MG_0, MGx_0) :-
    var(MG_0),
    !,

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -11,6 +11,9 @@
 :- use_module(library(debug)).
 :- use_module(library(format)).
 :- op(750, xfy, =>).
+:- op(950, fy, +).
++(A) :- call(A).
+%+(_).
 
 %% goal_expanded(+Goal, -ExpandedGoal).
 %
@@ -88,7 +91,7 @@ user:goal_expansion(if_(If_1, Then_0, Else_0), G_0) :-
     ugoal_expansion(if_(If_1, Then_0, Else_0), G_0),
     % Dump expanded goals to the console for inspection.
     % TODO: Remove when fully debugged
-  * portray_clause((if_(If_1,Then_0,Else_0) => G_0)).
+  + portray_clause((if_(If_1,Then_0,Else_0) => G_0)).
 
 
 %% ugoal_expansion(if_(+If_1, ?Then_0, ?Else_0), -Goal_0).
@@ -120,7 +123,7 @@ ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
     goal_expanded(call(Then_0), Thenx_0),
     goal_expanded(call(Else_0), Elsex_0),
     !,
-  * write('% =\n'),
+  + write('% =\n'),
     Goal_0 =
         ( X \= Y -> Elsex_0
         ; X == Y -> Thenx_0
@@ -134,7 +137,7 @@ ugoal_expansion(if_(If_1, Then_0, Else_0), Goal) :-
     ( M == reif -> true ; throw(error(existence_error(predicate_property,imported_from),_)) ),
   % ( M == reif -> true ; predicate_property(M:;(_,_,_),imported_from(reif)) ),
     !,
-  * write('% ;\n'),
+  + write('% ;\n'),
     Goal = if_(A_1, Then_0, if_(B_1, Then_0, Else_0)).
 ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
     subsumes_term(M:(A_1,B_1), If_1),
@@ -143,10 +146,10 @@ ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
     ( M == reif -> true ; throw(error(existence_error(predicate_property,imported_from),_)) ),
   % ( M == reif -> true ; predicate_property(M:','(_,_,_),imported_from(reif)) ),
     !,
-  * write('% ,\n'),
+  + write('% ,\n'),
     Goal_0 = if_(A_1, if_(B_1, Then_0, Else_0), Else_0).
 ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
-  * write('% _\n'),
+  + write('% _\n'),
     goal_expanded(call(If_1, T), Ifx_0),
     goal_expanded(call(Then_0), Thenx_0),
     goal_expanded(call(Else_0), Elsex_0),

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -90,7 +90,7 @@ goal_expansion(if_(If_1, Then_0, Else_0), G_0) :-
 % => if_(A_1, Then_0, if_(B_1, Then_0, Else_0))
 %
 % if_((A_1,B_1), Then_0, Else_0)
-% => Goal_0 = if_(A_1, if_(B_1, Then_0, Else_0), Else_0).
+% => if_(A_1, if_(B_1, Then_0, Else_0), Else_0).
 %
 % Otherwise it simply expands If_1, Then_0 and Else_0 using goal_expanded/2.
 % Read it's documentation to find out how it operates.

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -313,7 +313,23 @@ t(true, (expands_call1_for_modules :- goal_expanded(call(a:b(1)), a:b(1)))).
 t(true, (expands_call2_for_modules :- goal_expanded(call(a:b,c), a:b(c)))).
 t(true, (doesnt_expand_call2 :- goal_expanded(call(b,c), call(b,c)))).
 t(true, (doesnt_expand_cyclic_terms :- X=a(X), goal_expanded(call(X), Y), call(X) == Y)).
+t(true, (doesnt_expand_cyclic_call1 :- X=call(X), goal_expanded(X, Y), X == Y)).
 t(true, (doesnt_expand_higher_order_predicates :- X = maplist(=(1), _), goal_expanded(X, Y), X == Y)).
+
+% This test fails, and I don't know if goal_expanded/2 should be recursive or not,
+% and what properties it shall maintain (is idempotence even desirable?).
+t(skip, (second_expansion_doesnt_modify_goal :-
+    findall(G==Gxx, test_expand_goal_twice(G,Gxx), Goals), maplist(call, Goals)
+)).
+
+test_expand_goal_twice(G, Gxx) :-
+    test_goal(G), goal_expanded(G,Gx), goal_expanded(Gx, Gxx).
+test_goal(_).
+test_goal(call(a)).
+test_goal(call(a:b(1))).
+test_goal(call(a:b,c)).
+test_goal(call(call(a))).
+test_goal(call(call(a:b))).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Unit test support (probably should be moved to another module)

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -72,7 +72,7 @@ goal_expansion(if_(If_1, Then_0, Else_0), G_0) :-
     ugoal_expansion(if_(If_1, Then_0, Else_0), G_0),
     % Dump expanded goals to the console for inspection.
     % TODO: Remove when fully debugged
-    portray_clause((if_(If_1,Then_0,Else_0) => G_0)).
+  * portray_clause((if_(If_1,Then_0,Else_0) => G_0)).
 
 
 %% ugoal_expansion(if_(+If_1, ?Then_0, ?Else_0), -Goal_0).
@@ -104,7 +104,7 @@ ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
     goal_expanded(call(Then_0), Thenx_0),
     goal_expanded(call(Else_0), Elsex_0),
     !,
-    write('% =\n'),
+  * write('% =\n'),
     Goal_0 =
         ( X \= Y -> Elsex_0
         ; X == Y -> Thenx_0
@@ -118,7 +118,7 @@ ugoal_expansion(if_(If_1, Then_0, Else_0), Goal) :-
     M == reif,
     % ( M == reif -> true ; predicate_property(M:;(_,_,_),imported_from(reif)) ),
     !,
-    write('% ;\n'),
+  * write('% ;\n'),
     Goal = if_(A_1, Then_0, if_(B_1, Then_0, Else_0)).
 ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
     subsumes_term(M:(A_1,B_1), If_1),
@@ -127,10 +127,10 @@ ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
     M == reif,
     % ( M == reif -> true ; predicate_property(M:','(_,_,_),imported_from(reif)) ),
     !,
-    write('% ,\n'),
+  * write('% ,\n'),
     Goal_0 = if_(A_1, if_(B_1, Then_0, Else_0), Else_0).
 ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
-    write('% _\n'),
+  * write('% _\n'),
     goal_expanded(call(If_1, T), Ifx_0),
     goal_expanded(call(Then_0), Thenx_0),
     goal_expanded(call(Else_0), Elsex_0),

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -194,7 +194,14 @@ non(false, true).
 
 %% tfilter(+Predicate, ?List, ?FilteredList).
 %
-% Example:
+% `FilteredList` contains all elements of `List` that satisfy `Predicate`. Same
+% as more common `include/3` or `filter/3`, but more general and it doesn't
+% leave spurious choice points.
+%
+% `Predicate` is an incomplete goal that lacks two further arguments: one for
+% the element to be considered and one for the reified truth value.
+%
+% Take a note that in the following examples `=/3` will be used and not `=/2`:
 %
 % ```
 % ?- tfilter(=(a), [X,Y], Es).
@@ -202,6 +209,16 @@ non(false, true).
 % ;  X = a, Es = "a", dif:dif(a,Y)
 % ;  Y = a, Es = "a", dif:dif(a,X)
 % ;  Es = [], dif:dif(a,X), dif:dif(a,Y).
+% ```
+%
+% Another example to demonstrate generality:
+%
+% ```
+% ?- tfilter(=(X), [1,2,3,2,3,3], Fs).
+%    X = 1, Fs = [1]
+% ;  X = 2, Fs = [2,2]
+% ;  X = 3, Fs = [3,3,3]
+% ;  Fs = [], dif(X, 1), dif(X, 2), dif(X, 3).
 % ```
 tfilter(_, [], []).
 tfilter(C_2, [E|Es], Fs0) :-

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -114,9 +114,9 @@ ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
     subsumes_term(M:(X=Y), If_1),
     M:(X=Y) = If_1,
     atom(M),
-    M == reif,
     % FIXME: imported_from(_) key isn't implemented for predicate_property/2
-    % ( M == reif -> true ; predicate_property(M: =(_,_,_),imported_from(reif)) ),
+    ( M == reif -> true ; throw(error(existence_error(predicate_property,imported_from),_)) ),
+  % ( M == reif -> true ; predicate_property(M: =(_,_,_),imported_from(reif)) ),
     goal_expanded(call(Then_0), Thenx_0),
     goal_expanded(call(Else_0), Elsex_0),
     !,
@@ -131,8 +131,8 @@ ugoal_expansion(if_(If_1, Then_0, Else_0), Goal) :-
     subsumes_term(M:(A_1;B_1), If_1),
     M:(A_1;B_1) = If_1,
     atom(M),
-    M == reif,
-    % ( M == reif -> true ; predicate_property(M:;(_,_,_),imported_from(reif)) ),
+    ( M == reif -> true ; throw(error(existence_error(predicate_property,imported_from),_)) ),
+  % ( M == reif -> true ; predicate_property(M:;(_,_,_),imported_from(reif)) ),
     !,
   * write('% ;\n'),
     Goal = if_(A_1, Then_0, if_(B_1, Then_0, Else_0)).
@@ -140,8 +140,8 @@ ugoal_expansion(if_(If_1, Then_0, Else_0), Goal_0) :-
     subsumes_term(M:(A_1,B_1), If_1),
     M:(A_1,B_1) = If_1,
     atom(M),
-    M == reif,
-    % ( M == reif -> true ; predicate_property(M:','(_,_,_),imported_from(reif)) ),
+    ( M == reif -> true ; throw(error(existence_error(predicate_property,imported_from),_)) ),
+  % ( M == reif -> true ; predicate_property(M:','(_,_,_),imported_from(reif)) ),
     !,
   * write('% ,\n'),
     Goal_0 = if_(A_1, if_(B_1, Then_0, Else_0), Else_0).

--- a/src/lib/reif.pl
+++ b/src/lib/reif.pl
@@ -68,6 +68,20 @@ sameargs(0, _, _).
 */
 
 
+% FIXME: I did benchmarking from memberbench[2] using other Prolog
+% implementation because Scryer doesn't have statistics/2, and I didn't notice
+% any change in performance, with and without goal expansion. Also I have notice
+% that in practice only last clause of ugoal_expansion/2 is ever executed, and
+% expanded goals still have some duplicated call/N calls like so:
+%
+% ```
+% if_(call(A, B), C=[B|D], C=D) =>
+%    ( call(call(A, B), E),
+%    ...
+%    ).
+% ```
+%
+% [2]: http://www.complang.tuwien.ac.at/ulrich/Prolog-inedit/sicstus/memberbench.pl
 goal_expansion(if_(If_1, Then_0, Else_0), G_0) :-
     ugoal_expansion(if_(If_1, Then_0, Else_0), G_0),
     % Dump expanded goals to the console for inspection.
@@ -267,11 +281,6 @@ tree_non_member(E, t(F,L,R)) :-
     dif(E,F),
     tree_non_member(E, L),
     tree_non_member(E, R).
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Benchmark
-
-bench :- false.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Unit tests


### PR DESCRIPTION
I've searched for a task that is marked as "good first issue" and can be done purely in Prolog, and I think [issue 977](https://github.com/mthom/scryer-prolog/issues/977) was the only one, but it is already claimed. I've reached out to @sblaplace and it told that it is Ok, we can continue to work on it together or me alone, I'm open for any combination of work. 

Now, let me describe current state. Currently it is a draft and it has debug code which I will remove.

What was done:
  * `goal_expansion/2` and predicates that it relies upon were copied from the source[1].
  * Benchmark code was also copied from there[2] and slightly modified, there is a separate task for `statistics/2` predicate, but it also needs to be written in Rust and I don't know it. Benchmark can be run from command line:
    ```shell
    time scryer-prolog -g 'use_module(library(memberbench)),run,halt.'
    ```
    I will remove benchmarking code when task will be done.
  * Replaced not working `predicate_property/2` invocation with an exception and surprisingly it is never thrown! I don't know and I need some support here, do we really need that predicate?
  * Added comments for old and new predicates
  * Added unit tests to capture current behavior, so I can change it without worrying so much. Just call `reif:testall` to run them. I can remove them if they don't comply with module guidelines.
  * Added some debug prints to be able to inspect goal expansion, should be removed and replaced with unit tests.
  
  And now the most important point, after all of this I didn't observe any noticeable performance improvement? Am I doing something completely wrong?

[1]: http://www.complang.tuwien.ac.at/ulrich/Prolog-inedit/sicstus/reif.pl
[2]: http://www.complang.tuwien.ac.at/ulrich/Prolog-inedit/sicstus/memberbench.pl