### PR TITLE
Update on Miri coverage

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -46,6 +46,7 @@ pub fn header_offset_from_payload<Payload: Sized>() -> usize {
 }
 
 pub fn ptr_to_allocated<Payload: ArenaAllocated>(slab: &mut AllocSlab) -> TypedArenaPtr<Payload> {
+    // Miri points UB here for all the tests currently marked as blocked by arena.rs UB.
     let typed_slab: &mut TypedAllocSlab<Payload> = unsafe { mem::transmute(slab) };
     typed_slab.to_typed_arena_ptr()
 }
@@ -781,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn heap_cell_value_const_cast() {
         let mut wam = MockWAM::new();
         #[cfg(target_pointer_width = "32")]

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -1841,7 +1841,7 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn term_printing_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -1420,7 +1420,7 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn arith_eval_by_metacall_tests() {
         let mut wam = MachineState::new();
         let mut op_dir = default_op_dir();

--- a/src/machine/gc.rs
+++ b/src/machine/gc.rs
@@ -369,7 +369,7 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn heap_marking_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/machine/lib_machine.rs
+++ b/src/machine/lib_machine.rs
@@ -238,7 +238,7 @@ mod tests {
     use crate::machine::{QueryMatch, QueryResolution, Value};
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn programatic_query() {
         let mut machine = Machine::new_lib();
 
@@ -278,7 +278,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn failing_query() {
         let mut machine = Machine::new_lib();
         let query = String::from(r#"triple("a",P,"b")."#);
@@ -349,7 +349,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn empty_predicate() {
         let mut machine = Machine::new_lib();
         machine.load_module_string(
@@ -365,7 +365,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn list_results() {
         let mut machine = Machine::new_lib();
         machine.load_module_string(
@@ -394,7 +394,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn consult() {
         let mut machine = Machine::new_lib();
 
@@ -453,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn integration_test() {
         let mut machine = Machine::new_lib();
 
@@ -500,7 +500,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn findall() {
         let mut machine = Machine::new_lib();
 

--- a/src/machine/lib_machine.rs
+++ b/src/machine/lib_machine.rs
@@ -533,6 +533,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn dont_return_partial_matches() {
         let mut machine = Machine::new_lib();
 
@@ -556,6 +557,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn dont_return_partial_matches_without_discountiguous() {
         let mut machine = Machine::new_lib();
 
@@ -587,6 +589,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn non_existent_predicate_should_not_cause_panic_when_other_predicates_are_defined() {
         let mut machine = Machine::new_lib();
 
@@ -611,6 +614,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn issue_2341() {
         let mut machine = Machine::new_lib();
 

--- a/src/machine/mock_wam.rs
+++ b/src/machine/mock_wam.rs
@@ -260,7 +260,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn unify_tests() {
         let mut wam = MachineState::new();
         let mut op_dir = default_op_dir();
@@ -482,7 +482,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
     fn test_unify_with_occurs_check() {
         let mut wam = MachineState::new();
         let mut op_dir = default_op_dir();

--- a/src/machine/partial_string.rs
+++ b/src/machine/partial_string.rs
@@ -801,7 +801,7 @@ mod test {
     use crate::machine::mock_wam::*;
 
     #[test]
-    #[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+    #[cfg_attr(miri, ignore = "blocked on atom_table.rs UB")]
     fn pstr_iter_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -281,7 +281,7 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore = "crashes Miri!??")]
     fn stack_tests() {
         let mut wam = MockWAM::new();
 

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -15,6 +15,7 @@ fn call_0() {
 // issue #2361
 #[serial]
 #[test]
+#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
 fn call_qualification() {
     load_module_test("tests-pl/issue2361-call-qualified.pl", "");
 }

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -4,7 +4,7 @@ use serial_test::serial;
 // issue #831
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn call_0() {
     load_module_test(
         "tests-pl/issue831-call0.pl",
@@ -15,7 +15,7 @@ fn call_0() {
 // issue #2361
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn call_qualification() {
     load_module_test("tests-pl/issue2361-call-qualified.pl", "");
 }

--- a/tests/scryer/src_tests.rs
+++ b/tests/scryer/src_tests.rs
@@ -3,35 +3,35 @@ use serial_test::serial;
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn builtins() {
     load_module_test("src/tests/builtins.pl", "");
 }
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn call_with_inference_limit() {
     load_module_test("src/tests/call_with_inference_limit.pl", "");
 }
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn facts() {
     load_module_test("src/tests/facts.pl", "");
 }
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn hello_world() {
     load_module_test("src/tests/hello_world.pl", "Hello World!\n");
 }
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn syntax_error() {
     load_module_test(
         "tests-pl/syntax_error.pl",
@@ -41,21 +41,21 @@ fn syntax_error() {
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn predicates() {
     load_module_test("src/tests/predicates.pl", "");
 }
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn rules() {
     load_module_test("src/tests/rules.pl", "");
 }
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn setup_call_cleanup_load() {
     load_module_test(
         "src/tests/setup_call_cleanup.pl",
@@ -65,14 +65,14 @@ fn setup_call_cleanup_load() {
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn clpz_load() {
     load_module_test("src/tests/clpz/test_clpz.pl", "");
 }
 
 #[serial]
 #[test]
-#[cfg_attr(miri, ignore = "blocked on streams.rs UB")]
+#[cfg_attr(miri, ignore = "blocked on arena.rs UB")]
 fn iso_conformity_tests() {
     load_module_test("tests-pl/iso-conformity-tests.pl", "All tests passed");
 }


### PR DESCRIPTION
Recently a lot of the unsafe code in Scryer was improved in #2393, so I did another pass with Miri on the tests that were previously blocked on `arena.rs` and `streams.rs` (which were improved since then). All tests that were previously blocked by UB in `streams.rs` are now blocked by UB in `arena.rs` instead (with the exception of `pstr_iter_tests` which is now blocked on `atom_table.rs` UB). All of the tests that are blocked on `arena.rs` UB are blocked on the transmute in the `ptr_to_allocated()` function, in every case trying to allocate a stream, usually when creating an instance of `Machine`.

This is good because if this is resolved then _all_ of those tests will go deeper and maybe even pass. I don't know what exactly is the reason for Miri pointing UB here, but it's probably because somewhere in all the transmutes and casts back and forth between `AllocSlab` and `TypedAllocSlab` it's losing provenance information. 

