### PR TITLE
Fix at_end_of_stream/1 for http read stream

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,4 @@
-use std::io::BufRead;
+use bytes::{Bytes, buf::Reader};
 use std::sync::{Arc, Condvar, Mutex};
 
 use warp::http;
@@ -19,5 +19,5 @@ pub struct HttpRequestData {
     pub headers: http::HeaderMap,
     pub path: String,
     pub query: String,
-    pub body: Box<dyn BufRead + Send>,
+    pub body: Reader<Bytes>,
 }


### PR DESCRIPTION
Implements `position_relative_to_end` to HttpRead so we can know when the transmission has finished. It fixes: https://github.com/mthom/scryer-prolog/discussions/2437