### PR TITLE
Cleanup some string handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,12 +191,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1534,6 +1549,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2130,6 +2152,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bit-set 0.5.3",
+ "bit-vec 0.6.3",
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2239,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -2435,6 +2492,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "rustyline"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,7 +2613,7 @@ dependencies = [
  "arcu",
  "assert_cmd",
  "base64 0.22.1",
- "bit-set",
+ "bit-set 0.8.0",
  "bitvec",
  "blake2",
  "bytes",
@@ -2581,6 +2650,7 @@ dependencies = [
  "pprof",
  "predicates-core",
  "proc-macro2",
+ "proptest",
  "quote",
  "rand",
  "regex",
@@ -3320,6 +3390,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ js-sys = "0.3"
 maplit = "1.0.2"
 predicates-core = "1.0.8"
 serial_test = "3.1.1"
+proptest = "1.5.0"
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
 assert_cmd = "2.0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,13 +119,13 @@ js-sys = "0.3"
 maplit = "1.0.2"
 predicates-core = "1.0.8"
 serial_test = "3.1.1"
-proptest = "1.5.0"
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
 assert_cmd = "2.0.15"
 criterion = "0.5.1"
 iai-callgrind = "0.12.1"
 trycmd = "0.15.6"
+proptest = "1.5.0"
 
 [target.'cfg(not(any(target_os = "windows", all(target_arch = "wasm32", target_os = "unknown"))))'.dev-dependencies]
 pprof = { version = "0.13.0", features = ["criterion", "flamegraph"] }

--- a/benches/setup.rs
+++ b/benches/setup.rs
@@ -13,21 +13,21 @@ pub fn prolog_benches() -> BTreeMap<&'static str, PrologBenchmark> {
             "benches/edges.pl", // name of the prolog module file to load. use the same file in multiple benchmarks
             "independent_set_count(ky, Count).", // query to benchmark in the context of the loaded module. consider making the query adjustable to tune the run time to ~0.1s
             Strategy::Reuse,
-            btreemap! { "Count" => Value::try_from("2869176".to_string()).unwrap() },
+            btreemap! { "Count" => "2869176".parse().unwrap() },
         ),
         (
             "numlist",
             "benches/numlist.pl",
             "run_numlist(1000000, Head).",
             Strategy::Reuse,
-            btreemap! { "Head" => Value::try_from("1".to_string()).unwrap()},
+            btreemap! { "Head" => "1".parse().unwrap()},
         ),
         (
             "csv_codename",
             "benches/csv.pl",
             "get_codename(\"0020\",Name).",
             Strategy::Reuse,
-            btreemap! { "Name" => Value::try_from("SPACE".to_string()).unwrap()},
+            btreemap! { "Name" => "SPACE".parse().unwrap()},
         ),
     ]
     .map(|b| {

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -258,15 +258,15 @@ impl Atom {
     }
 
     pub fn defrock_brackets(&self, atom_tbl: &AtomTable) -> Self {
+        use crate::machine::parsed_results::strip_circumfix;
+
         let s = self.as_str();
 
-        let sub_str = if s.starts_with('(') && s.ends_with(')') {
-            &s['('.len_utf8()..s.len() - ')'.len_utf8()]
+        if let Some(unparenthesised) = strip_circumfix(&*s, '(', ')') {
+            AtomTable::build_with(atom_tbl, unparenthesised)
         } else {
-            return *self;
-        };
-
-        AtomTable::build_with(atom_tbl, sub_str)
+            *self
+        }
     }
 }
 

--- a/src/machine/lib_integration_test_commands.txt
+++ b/src/machine/lib_integration_test_commands.txt
@@ -965,11 +965,11 @@ subject_class("Todo", C), property_getter(C, "literal://string:construct%20test"
 =====query
 subject_class("Todo", C), collection_getter(C, "literal://string:construct%20test", "comments", Value).
 =====result
-[{"C":"c","Value":[""]}]
+[{"C":"c","Value":[]}]
 =====query
 subject_class("Todo", C), collection_getter(C, "literal://string:construct%20test", "comments", Value).
 =====result
-[{"C":"c","Value":[""]}]
+[{"C":"c","Value":[]}]
 =====consult
 :- discontiguous(triple/3).
 :- discontiguous(link/5).
@@ -1371,7 +1371,7 @@ collection_setter(c, "likedMessagess", '[{action: "collectionSetter", source: "t
 =====query
 subject_class("Todo", C), collection_getter(C, "literal://string:construct%20test", "comments", Value).
 =====result
-[{"C":"c","Value":[""]}]
+[{"C":"c","Value":[]}]
 =====consult
 :- discontiguous(triple/3).
 :- discontiguous(link/5).
@@ -2084,7 +2084,7 @@ false
 =====query
 subject_class("Todo", C), collection_getter(C, "literal://string:Decorated%20class%20construction%20test", "comments", Value).
 =====result
-[{"C":"c","Value":[""]}]
+[{"C":"c","Value":[]}]
 =====consult
 :- discontiguous(triple/3).
 :- discontiguous(link/5).
@@ -2232,7 +2232,7 @@ subject_class("Todo", C), property_getter(C, "literal://string:Decorated%20class
 =====query
 subject_class("Todo", C), collection_getter(C, "literal://string:Decorated%20class%20construction%20test", "comments", Value).
 =====result
-[{"C":"c","Value":[""]}]
+[{"C":"c","Value":[]}]
 =====consult
 :- discontiguous(triple/3).
 :- discontiguous(link/5).
@@ -4531,7 +4531,7 @@ property_getter(srksdbln, Base, "number", Value) :- triple(Base, "test://test_nu
 =====query
 subject_class("Todo", C), property_getter(C, "literal://string:Custom%20getter%20test", "isLiked", Value).
 =====result
-[{"C":"c","Value":true}]
+[{"C":"c","Value":"true"}]
 =====consult
 :- discontiguous(triple/3).
 :- discontiguous(link/5).
@@ -7026,7 +7026,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "ingredients", Value).
 =====result
@@ -7034,7 +7034,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "type"), property(C, "name"), property(C, "local"), property_setter(C, "name", _), property_setter(C, "local", _), collection_adder(C, "entriess", _), collection_adder(C, "ingredientss", _), collection_adder(C, "commentss", _), collection_remover(C, "entriess", _), collection_remover(C, "ingredientss", _), collection_remover(C, "commentss", _), collection_setter(C, "entriess", _), collection_setter(C, "ingredientss", _), collection_setter(C, "commentss", _).
 =====result
@@ -7078,7 +7078,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "ingredients", Value).
 =====result
@@ -7086,7 +7086,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "type"), property(C, "name"), property(C, "local"), property_setter(C, "name", _), property_setter(C, "local", _), collection_adder(C, "entriess", _), collection_adder(C, "ingredientss", _), collection_adder(C, "commentss", _), collection_remover(C, "entriess", _), collection_remover(C, "ingredientss", _), collection_remover(C, "commentss", _), collection_setter(C, "entriess", _), collection_setter(C, "ingredientss", _), collection_setter(C, "commentss", _).
 =====result
@@ -7422,7 +7422,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "ingredients", Value).
 =====result
@@ -7430,7 +7430,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "type"), property(C, "name"), property(C, "local"), property_setter(C, "name", _), property_setter(C, "local", _), collection_adder(C, "entriess", _), collection_adder(C, "ingredientss", _), collection_adder(C, "commentss", _), collection_remover(C, "entriess", _), collection_remover(C, "ingredientss", _), collection_remover(C, "commentss", _), collection_setter(C, "entriess", _), collection_setter(C, "ingredientss", _), collection_setter(C, "commentss", _).
 =====result
@@ -7474,7 +7474,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "ingredients", Value).
 =====result
@@ -7482,7 +7482,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "className"), property(C, "generateSDNA").
 =====result
@@ -7534,7 +7534,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "ingredients", Value).
 =====result
@@ -7542,7 +7542,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "type"), property(C, "name"), property(C, "local"), property_setter(C, "name", _), property_setter(C, "local", _), collection_adder(C, "entriess", _), collection_adder(C, "ingredientss", _), collection_adder(C, "commentss", _), collection_remover(C, "entriess", _), collection_remover(C, "ingredientss", _), collection_remover(C, "commentss", _), collection_setter(C, "entriess", _), collection_setter(C, "ingredientss", _), collection_setter(C, "commentss", _).
 =====result
@@ -8812,7 +8812,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "ingredients", Value).
 =====result
@@ -8864,7 +8864,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "ingredients", Value).
 =====result
@@ -10200,7 +10200,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "ingredients", Value).
 =====result
@@ -10208,7 +10208,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "type"), property(C, "name"), property(C, "local"), property_setter(C, "name", _), property_setter(C, "local", _), collection_adder(C, "entriess", _), collection_adder(C, "ingredientss", _), collection_adder(C, "commentss", _), collection_remover(C, "entriess", _), collection_remover(C, "ingredientss", _), collection_remover(C, "commentss", _), collection_setter(C, "entriess", _), collection_setter(C, "ingredientss", _), collection_setter(C, "commentss", _).
 =====result
@@ -10252,7 +10252,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "ingredients", Value).
 =====result
@@ -10260,7 +10260,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "className"), property(C, "generateSDNA").
 =====result
@@ -10334,9 +10334,9 @@ subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20reco
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "ingredients", Value).
 =====query
@@ -10352,7 +10352,7 @@ subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20reco
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "className"), property(C, "generateSDNA").
 =====result
@@ -10408,7 +10408,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "ingredients", Value).
 =====result
@@ -10468,7 +10468,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "ingredients", Value).
 =====result
@@ -10476,7 +10476,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "type"), property(C, "name"), property(C, "local"), property_setter(C, "name", _), property_setter(C, "local", _), collection_adder(C, "entriess", _), collection_adder(C, "ingredientss", _), collection_adder(C, "commentss", _), collection_remover(C, "entriess", _), collection_remover(C, "ingredientss", _), collection_remover(C, "commentss", _), collection_setter(C, "entriess", _), collection_setter(C, "ingredientss", _), collection_setter(C, "commentss", _).
 =====result
@@ -10520,7 +10520,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "ingredients", Value).
 =====result
@@ -10572,7 +10572,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "ingredients", Value).
 =====result
@@ -10580,7 +10580,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "type"), property(C, "name"), property(C, "local"), property_setter(C, "name", _), property_setter(C, "local", _), collection_adder(C, "entriess", _), collection_adder(C, "ingredientss", _), collection_adder(C, "commentss", _), collection_remover(C, "entriess", _), collection_remover(C, "ingredientss", _), collection_remover(C, "commentss", _), collection_setter(C, "entriess", _), collection_setter(C, "ingredientss", _), collection_setter(C, "commentss", _).
 =====result
@@ -10938,7 +10938,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20collection%20test", "ingredients", Value).
 =====result
@@ -10990,7 +10990,7 @@ subject_class("Recipe", C), collection(C, Collection).
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "entries", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "ingredients", Value).
 =====result
@@ -10998,7 +10998,7 @@ false
 =====query
 subject_class("Recipe", C), collection_getter(C, "literal://string:Active%20record%20implementation%20test%20local%20link", "comments", Value).
 =====result
-[{"C":"nzkpcwbu","Value":[""]}]
+[{"C":"nzkpcwbu","Value":[]}]
 =====query
 subject_class(Class, C), property(C, "type"), property(C, "name"), property(C, "local"), property_setter(C, "name", _), property_setter(C, "local", _), collection_adder(C, "entriess", _), collection_adder(C, "ingredientss", _), collection_adder(C, "commentss", _), collection_remover(C, "entriess", _), collection_remover(C, "ingredientss", _), collection_remover(C, "commentss", _), collection_setter(C, "entriess", _), collection_setter(C, "ingredientss", _), collection_setter(C, "commentss", _).
 =====result

--- a/src/machine/lib_machine.rs
+++ b/src/machine/lib_machine.rs
@@ -630,4 +630,84 @@ mod tests {
 
         assert_eq!(output, Ok(QueryResolution::False));
     }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "it takes too long to run")]
+    #[ignore = "broken"]
+    fn mischivious_string1() {
+        let mut machine = Machine::new_lib();
+
+        let result = machine.run_query(String::from(r##"A = [ "[", "", "]" ]."##));
+
+        assert_eq!(
+            result,
+            Ok(QueryResolution::Matches(vec![QueryMatch {
+                bindings: BTreeMap::from([(
+                    String::from("A"),
+                    Value::List(vec![
+                        Value::str_literal("["),
+                        Value::str_literal(""),
+                        Value::str_literal("]")
+                    ])
+                )])
+            }]))
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "it takes too long to run")]
+    #[ignore = "broken"]
+    fn mischivious_string2() {
+        let mut machine = Machine::new_lib();
+
+        let result = machine.run_query(String::from(r##"A = [ "\",", "Test", ",\"" ]."##));
+
+        assert_eq!(
+            result,
+            Ok(QueryResolution::Matches(vec![QueryMatch {
+                bindings: BTreeMap::from([(
+                    String::from("A"),
+                    Value::List(vec![
+                        Value::str_literal("\","),
+                        Value::str_literal("Test"),
+                        Value::str_literal(",\"")
+                    ])
+                )])
+            }]))
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "it takes too long to run")]
+    #[ignore = "broken"]
+    fn mischivious_strings() {
+        let mut machine = Machine::new_lib();
+
+        let result = machine.run_query(String::from(
+            r##"A = [ '"', "'", "[","{", { "{" :  [ "]", "}", "]" ] } ]."##,
+        ));
+
+        assert_eq!(
+            result,
+            Ok(QueryResolution::Matches(vec![QueryMatch {
+                bindings: BTreeMap::from([(
+                    String::from("A"),
+                    Value::List(vec![
+                        Value::str_literal("\""),
+                        Value::str_literal("'"),
+                        Value::str_literal("["),
+                        Value::str_literal("{"),
+                        Value::Structure(
+                            atom!("{}"),
+                            vec![Value::List(vec![
+                                Value::str_literal("]"),
+                                Value::str_literal("}"),
+                                Value::str_literal("]"),
+                            ])]
+                        )
+                    ])
+                )])
+            }]))
+        );
+    }
 }

--- a/src/machine/lib_machine.rs
+++ b/src/machine/lib_machine.rs
@@ -633,7 +633,6 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore = "it takes too long to run")]
-    #[ignore = "broken"]
     fn mischivious_string1() {
         let mut machine = Machine::new_lib();
 
@@ -646,7 +645,7 @@ mod tests {
                     String::from("A"),
                     Value::List(vec![
                         Value::str_literal("["),
-                        Value::str_literal(""),
+                        Value::List(vec![]), // the empty string is also the empty list?
                         Value::str_literal("]")
                     ])
                 )])
@@ -656,11 +655,10 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore = "it takes too long to run")]
-    #[ignore = "broken"]
     fn mischivious_string2() {
         let mut machine = Machine::new_lib();
 
-        let result = machine.run_query(String::from(r##"A = [ "\",", "Test", ",\"" ]."##));
+        let result = machine.run_query(String::from(r#"A = [ "\",", "Test", ",\"" ]."#));
 
         assert_eq!(
             result,
@@ -668,9 +666,9 @@ mod tests {
                 bindings: BTreeMap::from([(
                     String::from("A"),
                     Value::List(vec![
-                        Value::str_literal("\","),
+                        Value::str_literal(r#"","#),
                         Value::str_literal("Test"),
-                        Value::str_literal(",\"")
+                        Value::str_literal(r#",""#)
                     ])
                 )])
             }]))
@@ -679,12 +677,11 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore = "it takes too long to run")]
-    #[ignore = "broken"]
     fn mischivious_strings() {
         let mut machine = Machine::new_lib();
 
         let result = machine.run_query(String::from(
-            r##"A = [ '"', "'", "[","{", { "{" :  [ "]", "}", "]" ] } ]."##,
+            r#"A = [ '"', "'", "[","{", { "{" :  [ "]", "}", "]" ] } ]."#,
         ));
 
         assert_eq!(
@@ -693,8 +690,8 @@ mod tests {
                 bindings: BTreeMap::from([(
                     String::from("A"),
                     Value::List(vec![
-                        Value::str_literal("\""),
-                        Value::str_literal("'"),
+                        Value::str_literal(r#"""#),
+                        Value::str_literal(r"'"),
                         Value::str_literal("["),
                         Value::str_literal("{"),
                         Value::Structure(

--- a/src/machine/lib_machine.rs
+++ b/src/machine/lib_machine.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::str::FromStr as _;
 
 use crate::atom_table;
 use crate::heap_print::{HCPrinter, HCValueOutputter, PrinterOutputter};
@@ -202,7 +201,7 @@ impl Machine {
                 if var_key.to_string() != output {
                     bindings.insert(
                         var_key.to_string(),
-                        Value::from_str(&output).expect("Couldn't convert Houtput to Value"),
+                        output.parse().expect("Couldn't convert Houtput to Value"),
                     );
                 }
             }

--- a/src/machine/lib_machine.rs
+++ b/src/machine/lib_machine.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::str::FromStr as _;
 
 use crate::atom_table;
 use crate::heap_print::{HCPrinter, HCValueOutputter, PrinterOutputter};
@@ -201,7 +202,7 @@ impl Machine {
                 if var_key.to_string() != output {
                     bindings.insert(
                         var_key.to_string(),
-                        Value::try_from(output).expect("Couldn't convert Houtput to Value"),
+                        Value::from_str(&output).expect("Couldn't convert Houtput to Value"),
                     );
                 }
             }
@@ -258,10 +259,10 @@ mod tests {
             output,
             Ok(QueryResolution::Matches(vec![
                 QueryMatch::from(btreemap! {
-                    "P" => Value::from("p1"),
+                    "P" => Value::str_literal("p1"),
                 }),
                 QueryMatch::from(btreemap! {
-                    "P" => Value::from("p2"),
+                    "P" => Value::str_literal("p2"),
                 }),
             ]))
         );
@@ -315,8 +316,8 @@ mod tests {
             result,
             Ok(QueryResolution::Matches(vec![QueryMatch::from(
                 btreemap! {
-                    "C" => Value::from("c"),
-                    "Actions" => Value::from("[{action: \"addLink\", source: \"this\", predicate: \"todo://state\", target: \"todo://ready\"}]"),
+                    "C" => Value::str_literal("c"),
+                    "Actions" => Value::str_literal("[{action: \"addLink\", source: \"this\", predicate: \"todo://state\", target: \"todo://ready\"}]"),
                 }
             ),]))
         );
@@ -328,8 +329,8 @@ mod tests {
             result,
             Ok(QueryResolution::Matches(vec![QueryMatch::from(
                 btreemap! {
-                    "C" => Value::from("xyz"),
-                    "Actions" => Value::from("[{action: \"addLink\", source: \"this\", predicate: \"recipe://title\", target: \"literal://string:Meta%20Muffins\"}]"),
+                    "C" => Value::str_literal("xyz"),
+                    "Actions" => Value::str_literal("[{action: \"addLink\", source: \"this\", predicate: \"recipe://title\", target: \"literal://string:Meta%20Muffins\"}]"),
                 }
             ),]))
         );
@@ -339,10 +340,10 @@ mod tests {
             result,
             Ok(QueryResolution::Matches(vec![
                 QueryMatch::from(btreemap! {
-                    "Class" => Value::from("Todo")
+                    "Class" => Value::str_literal("Todo")
                 }),
                 QueryMatch::from(btreemap! {
-                    "Class" => Value::from("Recipe")
+                    "Class" => Value::str_literal("Recipe")
                 }),
             ]))
         );
@@ -414,10 +415,10 @@ mod tests {
             output,
             Ok(QueryResolution::Matches(vec![
                 QueryMatch::from(btreemap! {
-                    "P" => Value::from("p1"),
+                    "P" => Value::str_literal("p1"),
                 }),
                 QueryMatch::from(btreemap! {
-                    "P" => Value::from("p2"),
+                    "P" => Value::str_literal("p2"),
                 }),
             ]))
         );
@@ -519,8 +520,8 @@ mod tests {
                 btreemap! {
                     "Result" => Value::List(
                         Vec::from([
-                            Value::List([Value::from("p1"), Value::from("b")].into()),
-                            Value::List([Value::from("p2"), Value::from("b")].into()),
+                            Value::List([Value::str_literal("p1"), Value::str_literal("b")].into()),
+                            Value::List([Value::str_literal("p2"), Value::str_literal("b")].into()),
                         ])
                     ),
                 }

--- a/src/machine/parsed_results.rs
+++ b/src/machine/parsed_results.rs
@@ -103,23 +103,30 @@ fn write_prolog_match_as_json<W: std::fmt::Write>(
     writer.write_char('}')
 }
 
+fn write_prolog_query_resolution_as_json<W: std::fmt::Write>(
+    resolution: &QueryResolution,
+    f: &mut W,
+) -> Result<(), std::fmt::Error> {
+    match resolution {
+        QueryResolution::True => f.write_str("true"),
+        QueryResolution::False => f.write_str("false"),
+        QueryResolution::Matches(matches) => {
+            f.write_char('[')?;
+            if let Some((first, rest)) = matches.split_first() {
+                write_prolog_match_as_json(f, first)?;
+                for other in rest {
+                    f.write_char(',')?;
+                    write_prolog_match_as_json(f, other)?;
+                }
+            }
+            f.write_char(']')
+        }
+    }
+}
+
 impl Display for QueryResolution {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            QueryResolution::True => f.write_str("true"),
-            QueryResolution::False => f.write_str("false"),
-            QueryResolution::Matches(matches) => {
-                f.write_char('[')?;
-                if let Some((first, rest)) = matches.split_first() {
-                    write_prolog_match_as_json(f, first)?;
-                    for other in rest {
-                        f.write_char(',')?;
-                        write_prolog_match_as_json(f, other)?;
-                    }
-                }
-                f.write_char(']')
-            }
-        }
+        write_prolog_query_resolution_as_json(self, f)
     }
 }
 

--- a/src/machine/parsed_results.rs
+++ b/src/machine/parsed_results.rs
@@ -206,7 +206,7 @@ fn split_response_string(input: &str) -> Vec<String> {
     let mut start = 0;
     let mut result = Vec::new();
 
-    for (i, c) in input.chars().enumerate() {
+    for (i, c) in input.char_indices() {
         match c {
             '[' => level_bracket += 1,
             ']' => level_bracket -= 1,
@@ -220,7 +220,7 @@ fn split_response_string(input: &str) -> Vec<String> {
                 && !in_single_quotes =>
             {
                 result.push(input[start..i].trim().to_string());
-                start = i + 1;
+                start = i + ','.len_utf8();
             }
             _ => {}
         }
@@ -289,13 +289,13 @@ fn split_nested_list(input: &str) -> Vec<String> {
     let mut start = 0;
     let mut result = Vec::new();
 
-    for (i, c) in input.chars().enumerate() {
+    for (i, c) in input.char_indices() {
         match c {
             '[' => level += 1,
             ']' => level -= 1,
             ',' if level == 0 => {
-                result.push(input[start..i].trim().to_string());
-                start = i + 1;
+                result.push(input[start..i].trim());
+                start = i + ','.len_utf8();
             }
             _ => {}
         }

--- a/src/machine/parsed_results.rs
+++ b/src/machine/parsed_results.rs
@@ -278,7 +278,7 @@ impl TryFrom<String> for QueryResolutionLine {
                     .iter()
                     .map(|(key, value)| -> Result<(String, Value), ()> {
                         let key = key.to_string();
-                        Ok((key,value.parse()?))
+                        Ok((key, value.parse()?))
                     })
                     .filter_map(Result::ok)
                     .collect::<BTreeMap<_, _>>(),
@@ -373,4 +373,3 @@ impl FromStr for Value {
         }
     }
 }
-

--- a/src/machine/parsed_results.rs
+++ b/src/machine/parsed_results.rs
@@ -278,7 +278,7 @@ impl TryFrom<String> for QueryResolutionLine {
                     .iter()
                     .map(|(key, value)| -> Result<(String, Value), ()> {
                         let key = key.to_string();
-                        Ok((key, Value::from_str(value)?))
+                        Ok((key,value.parse()?))
                     })
                     .filter_map(Result::ok)
                     .collect::<BTreeMap<_, _>>(),
@@ -349,7 +349,7 @@ impl FromStr for Value {
             for value in iter {
                 let items: Vec<_> = value.split(':').collect();
                 if let [_key, value] = items.as_slice() {
-                    values.push(Value::from_str(value)?);
+                    values.push(value.parse()?);
                 }
             }
 
@@ -361,7 +361,7 @@ impl FromStr for Value {
             for value in iter {
                 let items: Vec<_> = value.split(':').collect();
                 if let [_key, value] = items.as_slice() {
-                    values.push(Value::from_str(value)?);
+                    values.push(value.parse()?);
                 }
             }
 

--- a/tests/proptest-regressions/proptests.txt
+++ b/tests/proptest-regressions/proptests.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 776c0a9a265b5c528867150fa9a6069b45e52f7cb8f2d490f748ea2b49c68f3b # shrinks to query_result = Matches([QueryMatch { bindings: {"A": Structure(Atom { index: 6864 }, [])} }])
+cc 763dda9ce302dc4cc20ad2cafc4af80275d7af890519073e09a1697fa2f9a9be # shrinks to query_result = Matches([QueryMatch { bindings: {"_": Var, "_0": Var} }])

--- a/tests/scryer/main.rs
+++ b/tests/scryer/main.rs
@@ -2,6 +2,8 @@ mod helper;
 mod issues;
 mod src_tests;
 
+// a proptest dep doesn't compile on wasm
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 mod proptests;
 
 /// To add new cli test copy an existing .toml file in `tests/scryer/cli/issues/` or `tests/scryer/cli/issues/src_tests/`,

--- a/tests/scryer/main.rs
+++ b/tests/scryer/main.rs
@@ -2,6 +2,8 @@ mod helper;
 mod issues;
 mod src_tests;
 
+mod proptests;
+
 /// To add new cli test copy an existing .toml file in `tests/scryer/cli/issues/` or `tests/scryer/cli/issues/src_tests/`,
 /// adjust as necessary the `-f` and `--no-add-history` args should be kept but additional args may be added.
 /// For input on stdin add a .stdin file with the same filename.

--- a/tests/scryer/proptests.rs
+++ b/tests/scryer/proptests.rs
@@ -50,8 +50,16 @@ fn generate_value() -> impl Strategy<Value = Value> {
 #[test]
 fn result_is_valid_json() {
     let table = AtomTable::new();
-
     proptest! {
+        (if cfg!(miri) {
+            ProptestConfig {
+                failure_persistence: None,
+                cases: 5,
+                ..ProptestConfig::default()
+            }
+        } else {
+            ProptestConfig::default()
+        }),
         |(query_result in generate_query_resolution())|{
             let json_str = format!("{query_result}");
             if let Err(err) = serde_json::Value::from_str(&json_str) {

--- a/tests/scryer/proptests.rs
+++ b/tests/scryer/proptests.rs
@@ -1,0 +1,65 @@
+use std::{num::NonZeroI128, str::FromStr};
+
+use dashu::Rational;
+use prop::test_runner::Reason;
+use proptest::prelude::*;
+
+use scryer_prolog::{
+    atom_table::{Atom, AtomTable},
+    machine::parsed_results::{QueryMatch, QueryResolution, Value},
+};
+
+fn generate_query_resolution() -> impl Strategy<Value = QueryResolution> {
+    prop_oneof![
+        Just(QueryResolution::False),
+        Just(QueryResolution::True),
+        prop::collection::vec(generate_query_match(), 1..5).prop_map(QueryResolution::Matches)
+    ]
+}
+
+fn atom() -> impl Strategy<Value = Atom> {
+    any::<String>().prop_map(|atom| AtomTable::build_with(&AtomTable::new(), &atom))
+}
+
+fn generate_query_match() -> impl Strategy<Value = QueryMatch> {
+    prop::collection::btree_map(any::<String>(), generate_value(), 1..5)
+        .prop_map(|map| QueryMatch { bindings: map })
+}
+
+fn generate_value() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        Just(Value::Var),
+        any::<u128>().prop_map(|v| Value::Integer(v.into())),
+        any::<(i128, NonZeroI128)>().prop_map(|(n, d)| Value::Rational(
+            Rational::from_parts_signed(n.into(), i128::from(d).into())
+        )),
+        any::<f64>().prop_map(|f| Value::Float(ordered_float::OrderedFloat(f))),
+        atom().prop_map(Value::Atom),
+        any::<String>().prop_map(Value::String),
+    ];
+
+    leaf.prop_recursive(8, 32, 10, |inner| {
+        prop_oneof![
+            (atom(), prop::collection::vec(inner.clone(), 0..10))
+                .prop_map(|(atom, values)| Value::Structure(atom, values)),
+            prop::collection::vec(inner.clone(), 0..10).prop_map(Value::List)
+        ]
+    })
+}
+
+#[test]
+fn result_is_valid_json() {
+    let table = AtomTable::new();
+
+    proptest! {
+        |(query_result in generate_query_resolution())|{
+            let json_str = format!("{query_result}");
+            if let Err(err) = serde_json::Value::from_str(&json_str) {
+                println!("{json_str:?}");
+                return Err(TestCaseError::Fail(Reason::from(format!("{err}"))))
+            }
+        }
+    };
+
+    drop(table);
+}


### PR DESCRIPTION
- replace some `{starts,ends}_with` followed by manual string indexing with `strip_{prefix,suffix}`
  - mostly behind new helper `strip_delimiters{,_str}`
- don't assume chars are one utf-8 byte each
- don't turn `&str` into String unnecessarily
- replace some `splitn(2,..)` check that result is two long with `split_once`
- replace some `v.split(..).next().unwrap()` with `v.split_once(..).map_or(v, |(v,_)| v)`
- replace length check followed by manual indexing with pattern matching
- replace `impl From<&str>` and `impl TryFrom<String>` for `Value` with `Value::str_literal` and `impl FromStr`
  - having both `TryFrom<String>` and `TryFrom<&str>` (implied by `From<&str>`) with different behavior is confusing 
  - using a `String` rather than `&str` for parsing values required an extra allocations 