### PR TITLE
fix segfault by dropping loader state payload after resetting machine

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -305,8 +305,10 @@ impl<T: ?Sized + ArenaAllocated> TypedArenaPtr<T> {
 
 impl<P, T: ?Sized + ArenaAllocated<Payload = ManuallyDrop<P>>> TypedArenaPtr<T> {
     pub fn drop_payload(&mut self) {
-        self.set_tag(ArenaHeaderTag::Dropped);
-        unsafe { ManuallyDrop::drop(&mut *self.as_ptr()) }
+        if self.get_tag() != ArenaHeaderTag::Dropped {
+            self.set_tag(ArenaHeaderTag::Dropped);
+            unsafe { ManuallyDrop::drop(&mut *self.as_ptr()) }
+        }
     }
 }
 

--- a/src/machine/loader.rs
+++ b/src/machine/loader.rs
@@ -323,8 +323,8 @@ impl<'a> LoadState<'a> for LiveLoadAndMachineState<'a> {
     #[inline(always)]
     fn reset_machine(loader: &mut Loader<'a, Self>) {
         if loader.payload.load_state.get_tag() != ArenaHeaderTag::Dropped {
-            loader.payload.load_state.drop_payload();
             loader.reset_machine();
+            loader.payload.load_state.drop_payload();
         }
     }
 


### PR DESCRIPTION
- under some circumstances the payload is accessed durring reset which would cause a segfault if we drop the payload too early