### PR TITLE
Fix looping memory allocation

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -371,7 +371,8 @@ impl<P, T: ArenaAllocated<Payload = P>> AllocateInArena<T> for P {
     }
 }
 
-/* apparently this overlaps the planket impl above somehow
+/* this isn't allowed due to https://github.com/rust-lang/rust/issues/20400 I think,
+   though P == ManuallyDrop<P> might also be a problem event though that shouldn't be possible
 impl<P, T: ArenaAllocated<Payload = ManuallyDrop<P>>> AllocateInArena<T> for P {
     fn arena_allocate(self, arena: &mut Arena) -> TypedArenaPtr<T> {
         T::alloc(arena, ManuallyDrop::new(self))

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -174,7 +174,9 @@ impl Stack {
             let ptr = self.buf.alloc(frame_size);
 
             if ptr.is_null() {
-                self.buf.grow();
+                if !self.buf.grow() {
+                    panic!("growing the stack failed")
+                }
             } else {
                 return ptr;
             }

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -41,22 +41,32 @@ impl<T: RawBlockTraits> RawBlock<T> {
 
     unsafe fn init_at_size(&mut self, cap: usize) {
         let layout = alloc::Layout::from_size_align_unchecked(cap, T::align());
-
-        self.base = alloc::alloc(layout) as *const _;
+        let new_base = alloc::alloc(layout).cast_const();
+        if new_base.is_null() {
+            panic!("failed to allocate for init_at_size");
+        }
+        self.base = new_base;
         self.top = self.base.add(cap);
-        *self.ptr.get_mut() = self.base as *mut _;
+        *self.ptr.get_mut() = self.base.cast_mut();
     }
 
-    pub unsafe fn grow(&mut self) {
+    pub unsafe fn grow(&mut self) -> bool {
         if self.base.is_null() {
             self.init_at_size(T::init_size());
+            true
         } else {
             let size = self.size();
             let layout = alloc::Layout::from_size_align_unchecked(size, T::align());
 
-            self.base = alloc::realloc(self.base as *mut _, layout, size * 2) as *const _;
-            self.top = (self.base as usize + size * 2) as *const _;
-            *self.ptr.get_mut() = (self.base as usize + size) as *mut _;
+            let new_base = alloc::realloc(self.base.cast_mut(), layout, size * 2).cast_const();
+            if new_base.is_null() {
+                false
+            } else {
+                self.base = new_base;
+                self.top = (self.base as usize + size * 2) as *const _;
+                *self.ptr.get_mut() = (self.base as usize + size) as *mut _;
+                true
+            }
         }
     }
 

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -43,7 +43,10 @@ impl<T: RawBlockTraits> RawBlock<T> {
         let layout = alloc::Layout::from_size_align_unchecked(cap, T::align());
         let new_base = alloc::alloc(layout).cast_const();
         if new_base.is_null() {
-            panic!("failed to allocate for init_at_size");
+            panic!(
+                "failed to allocate in init_at_size for {}",
+                std::any::type_name::<Self>()
+            );
         }
         self.base = new_base;
         self.top = self.base.add(cap);


### PR DESCRIPTION
Running the command from #2449 
<details><summary>Details</summary>
<p>
made more readable for use as a script file rather than a CLI one-liner

```bash
 L=10000

 while : ; do 
    echo $L
    sh -c "ulimit -v $L;~/home/git/scryer-prolog/target/release/scryer-prolog -f -g halt"
    L=`expr $L + 10000`
done
```

</p>
</details> 

now result in 

<details><summary>Details</summary>
<p>

```bash
$ >bash ./test.sh 
10000
/home/bennet/git/scryer-prolog/target/release/scryer-prolog: error while loading shared libraries: libssl.so.3: failed to map segment from shared object
20000
thread 'main' panicked at /home/bennet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ctrlc-3.4.4/src/lib.rs:150:10:
failed to spawn thread: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
30000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
40000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
50000
memory allocation of 524288 bytes failed
Aborted
60000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
70000
80000
90000
100000
110000
120000
130000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
140000
150000
160000
memory allocation of 524288 bytes failed
Aborted
170000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::atom_table::AtomTable>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
memory allocation of 41 bytes failed
Fatal glibc error: failed to register TLS destructor: out of memory
Aborted
180000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
190000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
200000
210000
220000
230000
memory allocation of 524288 bytes failed
Aborted
240000
memory allocation of 524288 bytes failed
Aborted
250000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
260000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
270000
280000
290000
300000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
310000
memory allocation of 524288 bytes failed
Aborted
320000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
330000
340000
350000
360000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
370000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
380000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
390000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
400000
410000
420000
430000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
440000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
450000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
460000
memory allocation of 69632 bytes failed
Aborted
470000
480000
490000
500000
memory allocation of 524288 bytes failed
Aborted
510000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
520000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
530000
540000
550000
560000
570000
memory allocation of 524288 bytes failed
Aborted
580000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
590000
memory allocation of 69632 bytes failed
Aborted
600000
610000
620000
630000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
640000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
650000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
660000
670000
680000
690000
700000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
710000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
720000
memory allocation of 101888 bytes failed
Aborted
730000
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
780000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
790000
800000
810000
820000
830000
memory allocation of 524288 bytes failed
Aborted
840000
memory allocation of 524288 bytes failed
Aborted
850000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
860000
870000
880000
890000
900000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
910000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
920000
930000
940000
950000
960000
970000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
980000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
990000
1000000
1010000
1020000
1030000
1040000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
1050000
memory allocation of 131072 bytes failed
Aborted
1060000
1070000
1080000
1090000
1100000
1110000
thread 'main' panicked at src/raw_block.rs:46:13:
failed to allocate in init_at_size for scryer_prolog::raw_block::RawBlock<scryer_prolog::machine::stack::Stack>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
1120000
1130000
1140000
1150000
1160000
1170000
1180000
memory allocation of 1630208 bytes failed
Aborted
1190000
1200000
1210000
1220000
1230000
1240000
1250000
1260000
1270000
1280000
1290000
1300000
1310000
1320000
1330000
1340000
1350000
1360000
1370000
1380000
1390000
1400000
1410000
1420000
1430000
1440000
1450000
1460000
1470000
1480000
1490000
1500000
1510000
1520000
1530000
1540000
1550000
1560000
1570000
1580000
1590000
1600000
1610000
1620000
1630000
1640000
1650000
1660000
1670000
1680000
^C   error('$interrupt_thrown',repl/0).
```

</p>
</details> 