### PR TITLE
Value heap walk in lib_machine

### DIFF
--- a/benches/setup.rs
+++ b/benches/setup.rs
@@ -13,21 +13,21 @@ pub fn prolog_benches() -> BTreeMap<&'static str, PrologBenchmark> {
             "benches/edges.pl", // name of the prolog module file to load. use the same file in multiple benchmarks
             "independent_set_count(ky, Count).", // query to benchmark in the context of the loaded module. consider making the query adjustable to tune the run time to ~0.1s
             Strategy::Reuse,
-            btreemap! { "Count" => Value::try_from("2869176".to_string()).unwrap() },
+            btreemap! { "Count" => Value::Integer(2869176.into()) },
         ),
         (
             "numlist",
             "benches/numlist.pl",
             "run_numlist(1000000, Head).",
             Strategy::Reuse,
-            btreemap! { "Head" => Value::try_from("1".to_string()).unwrap()},
+            btreemap! { "Head" => Value::Integer(1.into())},
         ),
         (
             "csv_codename",
             "benches/csv.pl",
             "get_codename(\"0020\",Name).",
             Strategy::Reuse,
-            btreemap! { "Name" => Value::try_from("SPACE".to_string()).unwrap()},
+            btreemap! { "Name" => Value::String("SPACE".into())},
         ),
     ]
     .map(|b| {

--- a/src/machine/parsed_results.rs
+++ b/src/machine/parsed_results.rs
@@ -302,7 +302,12 @@ impl Value {
                     */
 
                     if arity == 0 {
-                        term_stack.push(Value::Atom(name.as_str().to_string()));
+                        let atom_name = name.as_str().to_string();
+                        if atom_name == "[]" {
+                            term_stack.push(Value::List(vec![]));
+                        } else {
+                            term_stack.push(Value::Atom(atom_name));
+                        }
                     } else {
                         let subterms = term_stack
                             .drain(term_stack.len() - arity ..)

--- a/src/machine/parsed_results.rs
+++ b/src/machine/parsed_results.rs
@@ -194,6 +194,20 @@ impl Value {
                     let head = term_stack.pop().unwrap();
 
                     let list = match tail {
+                        Value::Atom(atom) if atom == "[]" => match head {
+                            Value::Atom(ref a) if a.chars().collect::<Vec<_>>().len() == 1 => {
+                                // Handle lists of char as strings
+                                Value::String(a.to_string())
+                            }
+                            _ => Value::List(vec![head]),
+                        },
+                        Value::List(elems) if elems.is_empty() => match head {
+                            Value::Atom(ref a) if a.chars().collect::<Vec<_>>().len() == 1 => {
+                                // Handle lists of char as strings
+                                Value::String(a.to_string())
+                            },
+                            _ => Value::List(vec![head]),
+                        },
                         Value::List(mut elems) => {
                             elems.insert(0, head);
                             Value::List(elems)
@@ -212,13 +226,6 @@ impl Value {
                                 elems.insert(0, head);
                                 Value::List(elems)
                             }
-                        },
-                        Value::Atom(atom) if atom == "[]" =>  match head {
-                            Value::Atom(ref a) if a.chars().collect::<Vec<_>>().len() == 1 => {
-                                // Handle lists of char as strings
-                                Value::String(a.to_string())
-                            }
-                            _ => Value::List(vec![head]),
                         },
                         _ => Value::Structure(".".into(), vec![head, tail]),
                     };


### PR DESCRIPTION
This improves the parsing of terms in `lib_machine`. The current interface can't differentiate strings, variables and atoms, just crashes on composite terms, and is very brittle as it's implemented as parsing a string (that isn't even in canonical form, so operators). With this PR it now does a direct heap walk to parse the term. Here's an test demonstrating what it can represent:

```rust
let mut machine = Machine::new_lib();

let query = "X = a(\"asdf\", [42, 3.14, asdf, a, [a,b|_], Z]).".into();

let result = machine.run_query(query);

let expected = Value::Structure(
    // Composite term
    "a".into(),
    vec![
        Value::String("asdf".into()), // String
        Value::List(vec![
            Value::Integer(42.into()),  // Fixnum
            Value::Float(3.14.into()),  // Float
            Value::Atom("asdf".into()), // Atom
            Value::Atom("a".into()),    // Char
            Value::Structure(
                // Partial string
                ".".into(),
                vec![
                    Value::Atom("a".into()),
                    Value::Structure(
                        ".".into(),
                        vec![
                            Value::Atom("b".into()),
                            Value::Var("_A".into()), // Anonymous variable
                        ],
                    ),
                ],
            ),
            Value::Var("Z".into()), // Named variable
        ]),
    ],
);

assert_eq!(
    result,
    Ok(QueryResolution::Matches(vec![QueryMatch::from(
        btreemap! {
            "X" => expected,
        }
    )]))
);
```

There is also support for rational numbers and arbitrary precision integers. The only thing I didn't do yet is the handling of `PStrLoc` (which I'm not sure is relevant at this stage).

I `#[ignore]`d the "integration tests" (why are they in an unit test???) of `lib_machine` because they assume the old interface where everything is a string and integers are floats. Also, they depend on the current JSON encoding which I'm also planning to improve soon to something like described in https://github.com/mthom/scryer-prolog/pull/2465#issuecomment-2276526193. After that I will then migrate the integration tests to the new format and re-enable them.

Notice that unlike #2472, _**this is a breaking change**_ (that's why the integration tests needed to be disabled), but I think a very sensible one (not being able to handle composite[^1] terms is a bit unforgivable). Changing the JSON encoding will also be a breaking change, and if we decide to really take this opportunity to break things I think we could improve the interface _a lot_.

[^1]: I just realized I used "composite terms" everywhere but I was trying to say "compound terms". I'm not even sure if there's a meaningful difference, but if there is, I meant "compound terms". I'm not changing all that now.