### PR TITLE
Add flake.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 src/static_atoms.rs
 target/
-
+.direnv/
 
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1723541349,
+        "narHash": "sha256-LrmeqqHdPgAJsVKIJja8jGgRG/CA2y6SGT2TjX5Do68=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4877ea239f4d02410c3516101faf35a81af0c30e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1723515680,
+        "narHash": "sha256-nHdKymsHCVIh0Wdm4MvSgxcTTg34FJIYHRQkQYaSuvk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "4ee3d9e9569f70d7bb40f28804d6fe950c81eab3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "A modern Prolog implementation written mostly in Rust";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, flake-utils, rust-overlay, ... }:
+    let 
+      meta = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
+      inherit (meta) name version;
+      overlays = [ 
+        (import rust-overlay)
+        (self: super: {
+          rustToolchainDev = super.rust-bin.stable.latest.default.override {
+            extensions = [ "rust-src" "rust-analyzer" ];
+          };
+          rustToolchainNightly = super.rust-bin.selectLatestNightlyWith (toolchain:
+            toolchain.default.override {
+              extensions = [ "rust-src" "rust-analyzer" "miri" ];
+            }
+          );
+        })
+      ];
+    in flake-utils.lib.eachDefaultSystem(system:
+      let 
+        pkgs = import nixpkgs { inherit system overlays; };
+        nativeBuildInputs = with pkgs; [ pkg-config ];
+        buildInputs = with pkgs; [ openssl ];
+      in
+      {
+        devShells = {
+          default = pkgs.mkShell {
+            nativeBuildInputs = nativeBuildInputs;
+            buildInputs = buildInputs ++ (with pkgs; [
+              rustToolchainDev
+            ]);
+          };
+          # For use with Miri and stuff like it
+          nightly = pkgs.mkShell {
+            nativeBuildInputs = nativeBuildInputs;
+            buildInputs = buildInputs ++ (with pkgs; [
+              rustToolchainNightly
+            ]);
+          };
+        };
+
+        packages = rec {
+          default = scryer-prolog;
+          scryer-prolog = pkgs.rustPlatform.buildRustPackage {
+            pname = name;
+            inherit version;
+            src = ./.;
+            nativeBuildInputs = nativeBuildInputs;
+            buildInputs = buildInputs;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+            release = true;
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
This should make the lives of people using Nix/NixOS (like me) much easier. This will also enable anyone with the nix package manager to run (or even install) the latest git version directly from Github like this:

```
$ nix run github:mthom/scryer-prolog
```

Which I think is a nice accessibility option for more users to test the latest master. Maybe we should put this in the README? 

Included are 2 devshells, one with an stable toolchain and one with nightly (with Miri included). A `.envrc` is also provided to automatically load the stable devshell environment with [direnv](https://direnv.net/) when entering the directory.

There is also support for nix in MacOS, and I think I would need to change this a bit to make it work there, but I don't have a Mac to test it. We also _could_ go full unga bunga and have a fully reproducible CI based entirely on top of Nix, but I don't think that is really necessary and I really just want to not have to think about dependencies in my NixOS system. This PR changes absolutely nothing for developers or users that don't use the nix package manager.