### PR TITLE
Upgrade docs to DocLog 2.0. Includes a test learning page

### DIFF
--- a/doclog.config.pl
+++ b/doclog.config.pl
@@ -1,0 +1,11 @@
+project_name("Scryer Prolog").
+readme_file("INDEX.dj").
+source_lib_folder("src/lib").
+websource("https://github.com/mthom/scryer-prolog/tree/master/src/lib").
+omit(["ops_and_meta_predicates.pl", "tabling"]).
+learn_pages_source_folder("learn").
+learn_pages_categories(["First steps"]).
+learn_pages([
+		   page("Test page", "First steps", "test-page.dj")
+]).
+copy_file("logo/scryer.png", "scryer.png").

--- a/learn/test-page.dj
+++ b/learn/test-page.dj
@@ -1,0 +1,3 @@
+# Test page
+
+This is a page about Scryer Prolog


### PR DESCRIPTION
I'm modifying DocLog to better support arbitrary content pages (I called them "learning pages"). Some changes will be required, the most important one is that the configuration file should live now in this repo. I also included a sample Test Page as a template for new pages.