### PR TITLE
Relax version constraint on reqwest dependency 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities"]
 build = "build/main.rs"
 rust-version = "1.77"
 
-[lib]s
+[lib]
 crate-type = ["cdylib", "rlib"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,8 @@ ctrlc = { version = "3.4.4", optional = true }
 hostname = { version = "0.4.0", optional = true }
 libffi = { version = "3.2.0", optional = true }
 native-tls = { version = "0.2.12", optional = true }
+// allow dependent crates to pick the patch version that works with other
+// dependencies, while also updating to latest when possible
 reqwest = { version = "0.11.*", optional = true }
 rustyline = { version = "14.0.0", optional = true }
 tokio = { version = "1.39.2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,8 @@ ctrlc = { version = "3.4.4", optional = true }
 hostname = { version = "0.4.0", optional = true }
 libffi = { version = "3.2.0", optional = true }
 native-tls = { version = "0.2.12", optional = true }
-// allow dependent crates to pick the patch version that works with other
-// dependencies, while also updating to latest when possible
+# allow dependent crates to pick the patch version that works with other
+# dependencies, while also updating to latest when possible
 reqwest = { version = "0.11.*", optional = true }
 rustyline = { version = "14.0.0", optional = true }
 tokio = { version = "1.39.2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,9 @@ libffi = { version = "3.2.0", optional = true }
 native-tls = { version = "0.2.12", optional = true }
 # allow dependent crates to pick the patch version that works with other
 # dependencies, while also updating to latest when possible
-reqwest = { version = "0.11.*", optional = true }
+# the version requirement of reqwest is kept low for compatibility with old deno versions 
+# that pin request to 0.11.20
+reqwest = { version = "0.11.0", optional = true }
 rustyline = { version = "14.0.0", optional = true }
 tokio = { version = "1.39.2", features = ["full"] }
 warp = { version = "0.3.7", features = ["tls"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,6 @@ ctrlc = { version = "3.4.4", optional = true }
 hostname = { version = "0.4.0", optional = true }
 libffi = { version = "3.2.0", optional = true }
 native-tls = { version = "0.2.12", optional = true }
-# allow dependent crates to pick the patch version that works with other
-# dependencies, while also updating to latest when possible
 # the version requirement of reqwest is kept low for compatibility with old deno versions 
 # that pin request to 0.11.20
 reqwest = { version = "0.11.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities"]
 build = "build/main.rs"
 rust-version = "1.77"
 
-[lib]
+[lib]s
 crate-type = ["cdylib", "rlib"]
 
 [features]
@@ -87,7 +87,7 @@ ctrlc = { version = "3.4.4", optional = true }
 hostname = { version = "0.4.0", optional = true }
 libffi = { version = "3.2.0", optional = true }
 native-tls = { version = "0.2.12", optional = true }
-reqwest = { version = "0.11.27", optional = true }
+reqwest = { version = "0.11.*", optional = true }
 rustyline = { version = "14.0.0", optional = true }
 tokio = { version = "1.39.2", features = ["full"] }
 warp = { version = "0.3.7", features = ["tls"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ hostname = { version = "0.4.0", optional = true }
 libffi = { version = "3.2.0", optional = true }
 native-tls = { version = "0.2.12", optional = true }
 # the version requirement of reqwest is kept low for compatibility with old deno versions 
-# that pin request to 0.11.20
+# that pin reqwest to 0.11.20
 reqwest = { version = "0.11.0", optional = true }
 rustyline = { version = "14.0.0", optional = true }
 tokio = { version = "1.39.2", features = ["full"] }


### PR DESCRIPTION
`0.11.*` instead of `0.11.27`.

Cargo will pick the latest patch that's possible with `*`, but also not fail if another dependency in the build ensemble has reqwest pinned to something below patch 27.

This enables us to include scryer alongside an older Deno version that we're currently forced to stick with.