### PR TITLE
Be conservative with visibility

### DIFF
--- a/benches/run_iai.rs
+++ b/benches/run_iai.rs
@@ -5,7 +5,7 @@ mod setup;
 mod iai {
     use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 
-    use scryer_prolog::machine::parsed_results::QueryResolution;
+    use scryer_prolog::QueryResolution;
 
     use super::setup;
 

--- a/benches/setup.rs
+++ b/benches/setup.rs
@@ -1,10 +1,7 @@
 use std::{collections::BTreeMap, fs, path::Path};
 
 use maplit::btreemap;
-use scryer_prolog::machine::{
-    parsed_results::{QueryResolution, Value},
-    Machine,
-};
+use scryer_prolog::{Machine, QueryResolution, Value};
 
 pub fn prolog_benches() -> BTreeMap<&'static str, PrologBenchmark> {
     [
@@ -88,7 +85,7 @@ mod test {
     #[test]
     fn validate_benchmarks() {
         use super::prolog_benches;
-        use scryer_prolog::machine::parsed_results::{QueryMatch, QueryResolution};
+        use scryer_prolog::{QueryMatch, QueryResolution};
         use std::{fmt::Write, fs};
 
         struct BenchResult {

--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -3281,14 +3281,14 @@ pub fn generate_instructions_rs() -> TokenStream {
             }
         }
 
-        #[macro_export]
         macro_rules! _instr {
             #(
                 #instr_macro_arms
             );*
         }
 
-        pub use _instr as instr; // https://github.com/rust-lang/rust/pull/52234#issuecomment-976702997
+        // https://github.com/rust-lang/rust/pull/52234#issuecomment-976702997
+        pub(crate) use _instr as instr;
     }
 }
 

--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -137,7 +137,7 @@ enum InlinedClauseType {
 #[allow(dead_code)]
 #[derive(ToDeriveInput, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumProperty, EnumString))]
-enum REPLCodePtr {
+enum ReplCodePtr {
     #[strum_discriminants(strum(props(Arity = "4", Name = "$add_discontiguous_predicate")))]
     AddDiscontiguousPredicate,
     #[strum_discriminants(strum(props(Arity = "4", Name = "$add_dynamic_predicate")))]
@@ -534,7 +534,7 @@ enum SystemClauseType {
     #[strum_discriminants(strum(props(Arity = "2", Name = "$shell")))]
     Shell,
     #[strum_discriminants(strum(props(Arity = "1", Name = "$pid")))]
-    PID,
+    Pid,
     #[strum_discriminants(strum(props(Arity = "4", Name = "$chars_base64")))]
     CharsBase64,
     #[strum_discriminants(strum(props(Arity = "1", Name = "$devour_whitespace")))]
@@ -608,7 +608,7 @@ enum SystemClauseType {
     InferenceLimitExceeded,
     #[strum_discriminants(strum(props(Arity = "1", Name = "$argv")))]
     Argv,
-    REPL(REPLCodePtr),
+    Repl(ReplCodePtr),
 }
 
 #[allow(dead_code)]
@@ -811,7 +811,7 @@ fn derive_input(ty: &Type) -> Option<DeriveInput> {
     let system_clause_type: Type = parse_quote! { SystemClauseType };
     let compare_term_type: Type = parse_quote! { CompareTerm };
     let compare_number_type: Type = parse_quote! { CompareNumber };
-    let repl_code_ptr_type: Type = parse_quote! { REPLCodePtr };
+    let repl_code_ptr_type: Type = parse_quote! { ReplCodePtr };
 
     if ty == &clause_type {
         Some(ClauseType::to_derive_input())
@@ -826,7 +826,7 @@ fn derive_input(ty: &Type) -> Option<DeriveInput> {
     } else if ty == &compare_term_type {
         Some(CompareTerm::to_derive_input())
     } else if ty == &repl_code_ptr_type {
-        Some(REPLCodePtr::to_derive_input())
+        Some(ReplCodePtr::to_derive_input())
     } else {
         None
     }
@@ -983,6 +983,7 @@ fn generate_instruction_preface() -> TokenStream {
         }
 
         /// `IndexingInstruction` cf. page 110 of wambook.
+        #[allow(clippy::enum_variant_names)]
         #[derive(Clone, Debug)]
         pub enum IndexingInstruction {
             // The first index is the optimal argument being indexed.
@@ -1867,7 +1868,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::CallSetEnv |
                     &Instruction::CallUnsetEnv |
                     &Instruction::CallShell |
-                    &Instruction::CallPID |
+                    &Instruction::CallPid |
                     &Instruction::CallCharsBase64 |
                     &Instruction::CallDevourWhitespace |
                     &Instruction::CallIsSTOEnabled |
@@ -2104,7 +2105,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::ExecuteSetEnv |
                     &Instruction::ExecuteUnsetEnv |
                     &Instruction::ExecuteShell |
-                    &Instruction::ExecutePID |
+                    &Instruction::ExecutePid |
                     &Instruction::ExecuteCharsBase64 |
                     &Instruction::ExecuteDevourWhitespace |
                     &Instruction::ExecuteIsSTOEnabled |
@@ -2357,7 +2358,7 @@ pub fn generate_instructions_rs() -> TokenStream {
     let builtin_type_variants = attributeless_enum::<BuiltInClauseType>();
     let inlined_type_variants = attributeless_enum::<InlinedClauseType>();
     let system_clause_type_variants = attributeless_enum::<SystemClauseType>();
-    let repl_code_ptr_variants = attributeless_enum::<REPLCodePtr>();
+    let repl_code_ptr_variants = attributeless_enum::<ReplCodePtr>();
     let compare_number_variants = attributeless_enum::<CompareNumber>();
     let compare_term_variants = attributeless_enum::<CompareTerm>();
 
@@ -2708,14 +2709,14 @@ pub fn generate_instructions_rs() -> TokenStream {
 
         clause_type_from_name_and_arity_arms.push(if !variant_fields.is_empty() {
             quote! {
-                (atom!(#name), #arity) => ClauseType::System(SystemClauseType::REPL(
-                    REPLCodePtr::#ident(#(#variant_fields),*)
+                (atom!(#name), #arity) => ClauseType::System(SystemClauseType::Repl(
+                    ReplCodePtr::#ident(#(#variant_fields),*)
                 ))
             }
         } else {
             quote! {
-                (atom!(#name), #arity) => ClauseType::System(SystemClauseType::REPL(
-                    REPLCodePtr::#ident
+                (atom!(#name), #arity) => ClauseType::System(SystemClauseType::Repl(
+                    ReplCodePtr::#ident
                 ))
             }
         });
@@ -2723,13 +2724,13 @@ pub fn generate_instructions_rs() -> TokenStream {
         clause_type_name_arms.push(if !variant_fields.is_empty() {
             quote! {
                 ClauseType::System(
-                    SystemClauseType::REPL(REPLCodePtr::#ident(..))
+                    SystemClauseType::Repl(ReplCodePtr::#ident(..))
                 ) => atom!(#name)
             }
         } else {
             quote! {
                 ClauseType::System(
-                    SystemClauseType::REPL(REPLCodePtr::#ident)
+                    SystemClauseType::Repl(ReplCodePtr::#ident)
                 ) => atom!(#name)
             }
         });
@@ -2743,14 +2744,14 @@ pub fn generate_instructions_rs() -> TokenStream {
 
         clause_type_to_instr_arms.push(if !variant_fields.is_empty() {
             quote! {
-                ClauseType::System(SystemClauseType::REPL(
-                    REPLCodePtr::#ident(#(#placeholder_ids),*)
+                ClauseType::System(SystemClauseType::Repl(
+                    ReplCodePtr::#ident(#(#placeholder_ids),*)
                 )) => Instruction::#instr_ident(#(*#placeholder_ids),*)
             }
         } else {
             quote! {
-                ClauseType::System(SystemClauseType::REPL(
-                    REPLCodePtr::#ident
+                ClauseType::System(SystemClauseType::Repl(
+                    ReplCodePtr::#ident
                 )) => Instruction::#instr_ident
             }
         });
@@ -3109,6 +3110,7 @@ pub fn generate_instructions_rs() -> TokenStream {
     quote! {
         #preface_tokens
 
+        #[allow(clippy::enum_variant_names)]
         #[derive(Clone, Debug)]
         pub enum CompareTerm {
             #(
@@ -3116,6 +3118,7 @@ pub fn generate_instructions_rs() -> TokenStream {
             )*
         }
 
+        #[allow(clippy::enum_variant_names)]
         #[derive(Clone, Copy, Debug)]
         pub enum CompareNumber {
             #(
@@ -3161,7 +3164,7 @@ pub fn generate_instructions_rs() -> TokenStream {
         }
 
         #[derive(Clone, Debug)]
-        pub enum REPLCodePtr {
+        pub enum ReplCodePtr {
             #(
                 #repl_code_ptr_variants,
             )*
@@ -3228,7 +3231,7 @@ pub fn generate_instructions_rs() -> TokenStream {
                 }
             }
 
-            pub fn to_default(self) -> Instruction {
+            pub fn into_default(self) -> Instruction {
                 match self {
                     #(
                         #to_default_arms,
@@ -3237,7 +3240,7 @@ pub fn generate_instructions_rs() -> TokenStream {
                 }
             }
 
-            pub fn to_execute(self) -> Instruction {
+            pub fn into_execute(self) -> Instruction {
                 match self {
                     #(
                         #to_execute_arms,
@@ -3418,8 +3421,8 @@ impl InstructionData {
             );
 
             (name, arity, CountableInference::NotCounted)
-        } else if id == "REPLCodePtr" {
-            let (name, arity) = add_discriminant_data::<REPLCodePtrDiscriminants>(
+        } else if id == "ReplCodePtr" {
+            let (name, arity) = add_discriminant_data::<ReplCodePtrDiscriminants>(
                 &variant,
                 prefix,
                 &mut self.repl_code_ptr_variants,

--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -3252,6 +3252,7 @@ pub fn generate_instructions_rs() -> TokenStream {
                 )
             }
 
+            #[allow(dead_code)]
             pub fn is_ctrl_instr(&self) -> bool {
                 matches!(self,
                     Instruction::Allocate(_) |
@@ -3262,6 +3263,7 @@ pub fn generate_instructions_rs() -> TokenStream {
                 )
             }
 
+            #[allow(dead_code)]
             pub fn is_query_instr(&self) -> bool {
                 matches!(self,
                     &Instruction::GetVariable(..) |

--- a/build/static_string_indexing.rs
+++ b/build/static_string_indexing.rs
@@ -156,8 +156,6 @@ pub fn index_static_strings(instruction_rs_path: &std::path::Path) -> TokenStrea
     let static_strs: &Vec<_> = &visitor.static_strs.into_iter().collect();
 
     quote! {
-        use phf;
-
         static STRINGS: [&str; #static_strs_len] = [
             #(
                 #static_strs,

--- a/build/static_string_indexing.rs
+++ b/build/static_string_indexing.rs
@@ -164,7 +164,6 @@ pub fn index_static_strings(instruction_rs_path: &std::path::Path) -> TokenStrea
             )*
         ];
 
-        #[macro_export]
         macro_rules! atom {
             #((#static_strs) => { Atom { index: #indices_iter } };)*
         }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -29,7 +29,6 @@ use std::ptr::addr_of_mut;
 use std::ptr::NonNull;
 use std::sync::RwLock;
 
-#[macro_export]
 macro_rules! arena_alloc {
     ($e:expr, $arena:expr) => {{
         let result = $e;
@@ -37,7 +36,6 @@ macro_rules! arena_alloc {
     }};
 }
 
-#[macro_export]
 macro_rules! float_alloc {
     ($e:expr, $arena:expr) => {{
         let result = $e;

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -894,6 +894,8 @@ const_assert!(mem::size_of::<OrderedFloat<f64>>() == 8);
 mod tests {
     use std::ops::Deref;
 
+    use crate::arena::*;
+    use crate::atom_table::*;
     use crate::machine::mock_wam::*;
     use crate::machine::partial_string::*;
 

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -124,7 +124,6 @@ impl Hash for Atom {
     }
 }
 
-#[macro_export]
 macro_rules! is_char {
     ($s:expr) => {
         !$s.is_empty() && $s.chars().nth(1).is_none()

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -124,12 +124,6 @@ impl Hash for Atom {
     }
 }
 
-macro_rules! is_char {
-    ($s:expr) => {
-        !$s.is_empty() && $s.chars().nth(1).is_none()
-    };
-}
-
 pub enum AtomString<'a> {
     Static(&'a str),
     Dynamic(AtomTableRef<str>),

--- a/src/bin/scryer-prolog.rs
+++ b/src/bin/scryer-prolog.rs
@@ -1,27 +1,3 @@
 fn main() -> std::process::ExitCode {
-    use scryer_prolog::atom_table::Atom;
-    use scryer_prolog::*;
-
-    #[cfg(feature = "repl")]
-    ctrlc::set_handler(move || {
-        scryer_prolog::machine::INTERRUPT.store(true, std::sync::atomic::Ordering::Relaxed);
-    })
-    .unwrap();
-
-    #[cfg(target_arch = "wasm32")]
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-
-    #[cfg(not(target_arch = "wasm32"))]
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-
-    runtime.block_on(async move {
-        let mut wam = machine::Machine::new(Default::default());
-        wam.run_module_predicate(atom!("$toplevel"), (atom!("$repl"), 0))
-    })
+    scryer_prolog::run_binary()
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -8,11 +8,9 @@ use crate::instructions::*;
 use crate::iterators::*;
 use crate::parser::ast::*;
 use crate::targets::*;
-use crate::temp_v;
 use crate::types::*;
 use crate::variable_records::*;
 
-use crate::instr;
 use crate::machine::disjuncts::*;
 use crate::machine::machine_errors::*;
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -557,14 +557,14 @@ impl<'b> CodeGenerator<'b> {
         match call_policy {
             CallPolicy::Default => {
                 if self.marker.in_tail_position {
-                    code.push_back(call_instr.to_execute().to_default());
+                    code.push_back(call_instr.into_execute().into_default());
                 } else {
-                    code.push_back(call_instr.to_default())
+                    code.push_back(call_instr.into_default())
                 }
             }
             CallPolicy::Counted => {
                 if self.marker.in_tail_position {
-                    code.push_back(call_instr.to_execute());
+                    code.push_back(call_instr.into_execute());
                 } else {
                     code.push_back(call_instr)
                 }

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -159,17 +159,6 @@ impl ChunkedTermVec {
             .push_back(ChunkedTerms::Branch(Vec::with_capacity(capacity)));
     }
 
-    pub fn push_branch_arm(&mut self, branch: VecDeque<ChunkedTerms>) {
-        match self.chunk_vec.back_mut().unwrap() {
-            ChunkedTerms::Branch(branches) => {
-                branches.push(branch);
-            }
-            ChunkedTerms::Chunk(_) => {
-                self.chunk_vec.push_back(ChunkedTerms::Branch(vec![branch]));
-            }
-        }
-    }
-
     #[inline]
     pub fn add_chunk(&mut self) {
         self.chunk_vec

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -327,8 +327,6 @@ pub trait HCValueOutputter {
     fn new() -> Self;
     fn push_char(&mut self, c: char);
     fn append(&mut self, s: &str);
-    fn begin_new_var(&mut self);
-    fn insert(&mut self, index: usize, c: char);
     fn result(self) -> Self::Output;
     fn ends_with(&self, s: &str) -> bool;
     fn len(&self) -> usize;
@@ -360,16 +358,6 @@ impl HCValueOutputter for PrinterOutputter {
 
     fn push_char(&mut self, c: char) {
         self.contents.push(c);
-    }
-
-    fn begin_new_var(&mut self) {
-        if !self.contents.is_empty() {
-            self.contents += ", ";
-        }
-    }
-
-    fn insert(&mut self, idx: usize, c: char) {
-        self.contents.insert(idx, c);
     }
 
     fn result(self) -> Self::Output {
@@ -496,7 +484,6 @@ pub struct HCPrinter<'a, Outputter> {
     pub numbervars: bool,
     pub quoted: bool,
     pub ignore_ops: bool,
-    pub print_strings_as_strs: bool,
     pub max_depth: usize,
     pub double_quotes: bool,
 }
@@ -561,7 +548,6 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
             quoted: false,
             ignore_ops: false,
             var_names: IndexMap::new(),
-            print_strings_as_strs: false,
             max_depth: 0,
             double_quotes: false,
         }

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -4,11 +4,6 @@ use crate::parser::ast::*;
 use crate::parser::dashu::base::RemEuclid;
 use crate::parser::dashu::integer::Sign;
 use crate::parser::dashu::{ibig, Integer, Rational};
-use crate::{
-    alpha_numeric_char, capital_letter_char, cut_char, decimal_digit_char, graphic_token_char,
-    semicolon_char, sign_char, single_quote_char, small_letter_char, solo_char,
-    variable_indicator_char,
-};
 
 use crate::forms::*;
 use crate::heap_iter::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,43 +7,49 @@ extern crate static_assertions;
 extern crate maplit;
 
 #[macro_use]
-pub mod macros;
+pub(crate) mod macros;
 #[macro_use]
-pub mod atom_table;
+pub(crate) mod atom_table;
 #[macro_use]
-pub mod arena;
+pub(crate) mod arena;
 #[macro_use]
-pub mod parser;
+pub(crate) mod parser;
 mod allocator;
 mod arithmetic;
-pub mod codegen;
+pub(crate) mod codegen;
 mod debray_allocator;
 #[cfg(feature = "ffi")]
 mod ffi;
 mod forms;
 mod heap_iter;
-pub mod heap_print;
+pub(crate) mod heap_print;
 #[cfg(feature = "http")]
 mod http;
 mod indexing;
 mod variable_records;
 #[macro_use]
-pub mod instructions {
+pub(crate) mod instructions {
     include!(concat!(env!("OUT_DIR"), "/instructions.rs"));
 }
 mod iterators;
-pub mod machine;
+pub(crate) mod machine;
 mod raw_block;
-pub mod read;
+pub(crate) mod read;
 #[cfg(feature = "repl")]
 mod repl_helper;
 mod targets;
-pub mod types;
+pub(crate) mod types;
 
 use instructions::instr;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
+
+// Re-exports
+pub use machine::config::*;
+pub use machine::lib_machine::*;
+pub use machine::parsed_results::*;
+pub use machine::Machine;
 
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
@@ -55,4 +61,32 @@ pub fn eval_code(s: &str) -> String {
     let mut wam = Machine::with_test_streams();
     let bytes = wam.test_load_string(s);
     String::from_utf8_lossy(&bytes).to_string()
+}
+
+pub fn run_binary() -> std::process::ExitCode {
+    use crate::atom_table::Atom;
+    use crate::machine::{Machine, INTERRUPT};
+
+    #[cfg(feature = "repl")]
+    ctrlc::set_handler(move || {
+        INTERRUPT.store(true, std::sync::atomic::Ordering::Relaxed);
+    })
+    .unwrap();
+
+    #[cfg(target_arch = "wasm32")]
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    #[cfg(not(target_arch = "wasm32"))]
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async move {
+        let mut wam = Machine::new(Default::default());
+        wam.run_module_predicate(atom!("$toplevel"), (atom!("$repl"), 0))
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,6 @@ mod repl_helper;
 mod targets;
 pub(crate) mod types;
 
-use instructions::instr;
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 

--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -15,8 +15,6 @@ use crate::parser::ast::*;
 use crate::parser::dashu::{Integer, Rational};
 use crate::types::*;
 
-use crate::fixnum;
-
 use ordered_float::{Float, OrderedFloat};
 
 use std::cmp;
@@ -24,7 +22,6 @@ use std::convert::TryFrom;
 use std::f64;
 use std::mem;
 
-#[macro_export]
 macro_rules! try_numeric_result {
     ($e: expr, $stub_gen: expr) => {
         match $e {

--- a/src/machine/attributed_variables.rs
+++ b/src/machine/attributed_variables.rs
@@ -1,7 +1,6 @@
 use crate::heap_iter::*;
 use crate::machine::*;
 use crate::parser::ast::*;
-use crate::temp_v;
 use crate::types::*;
 
 use indexmap::IndexSet;

--- a/src/machine/compile.rs
+++ b/src/machine/compile.rs
@@ -1194,11 +1194,8 @@ fn print_overwrite_warning(
     key: PredicateKey,
     is_dynamic: bool,
 ) {
-    if let CompilationTarget::Module(module_name) = compilation_target {
-        match module_name {
-            atom!("builtins") | atom!("loader") => return,
-            _ => {}
-        }
+    if let CompilationTarget::Module(atom!("builtins") | atom!("loader")) = compilation_target {
+        return;
     }
 
     match code_ptr.tag() {

--- a/src/machine/disjuncts.rs
+++ b/src/machine/disjuncts.rs
@@ -95,11 +95,6 @@ pub struct ChunkInfo {
     vars: Vec<VarInfo>,
 }
 
-#[derive(Debug)]
-pub struct BranchArm {
-    pub arm_terms: Vec<QueryTerm>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BranchInfo {
     branch_num: BranchNumber,

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -4611,11 +4611,11 @@ impl Machine {
                         self.shell();
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }
-                    &Instruction::CallPID => {
+                    &Instruction::CallPid => {
                         self.pid();
                         step_or_fail!(self, self.machine_st.p += 1);
                     }
-                    &Instruction::ExecutePID => {
+                    &Instruction::ExecutePid => {
                         self.pid();
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -7,8 +7,6 @@ use crate::machine::machine_state::*;
 use crate::machine::*;
 use crate::types::*;
 
-use crate::try_numeric_result;
-
 use fxhash::FxBuildHasher;
 
 macro_rules! step_or_fail {

--- a/src/machine/gc.rs
+++ b/src/machine/gc.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::atom_table::*;
 use crate::machine::heap::*;
 use crate::types::*;

--- a/src/machine/loader.rs
+++ b/src/machine/loader.rs
@@ -211,7 +211,6 @@ impl PredicateQueue {
     }
 }
 
-#[macro_export]
 macro_rules! predicate_queue {
     [$($v:expr),*] => (
         PredicateQueue {

--- a/src/machine/machine_errors.rs
+++ b/src/machine/machine_errors.rs
@@ -572,15 +572,6 @@ impl MachineState {
                     stub,
                 )
             }
-            SessionError::QueryCannotBeDefinedAsFact => {
-                let error_atom = atom!("query_cannot_be_defined_as_fact");
-
-                self.permission_error(
-                    Permission::Create,
-                    atom!("static_procedure"),
-                    functor!(error_atom),
-                )
-            }
         }
     }
 
@@ -710,9 +701,7 @@ impl MachineError {
 pub enum CompilationError {
     Arithmetic(ArithmeticError),
     ParserError(ParserError),
-    CannotParseCyclicTerm,
     ExceededMaxArity,
-    ExpectedRel,
     InadmissibleFact,
     InadmissibleQueryTerm,
     InvalidDirective(DirectiveError),
@@ -722,7 +711,6 @@ pub enum CompilationError {
     InvalidRuleHead,
     InvalidUseModuleDecl,
     InvalidModuleResolution(Atom),
-    UnreadableTerm,
 }
 
 #[derive(Debug)]
@@ -765,14 +753,8 @@ impl CompilationError {
             CompilationError::Arithmetic(..) => {
                 functor!(atom!("arithmetic_error"))
             }
-            CompilationError::CannotParseCyclicTerm => {
-                functor!(atom!("cannot_parse_cyclic_term"))
-            }
             CompilationError::ExceededMaxArity => {
                 functor!(atom!("exceeded_max_arity"))
-            }
-            CompilationError::ExpectedRel => {
-                functor!(atom!("expected_relation"))
             }
             CompilationError::InadmissibleFact => {
                 // TODO: type_error(callable, _).
@@ -805,9 +787,6 @@ impl CompilationError {
             }
             CompilationError::ParserError(ref err) => {
                 functor!(err.as_atom())
-            }
-            CompilationError::UnreadableTerm => {
-                functor!(atom!("unreadable_term"))
             }
         }
     }
@@ -1063,7 +1042,6 @@ pub enum SessionError {
     NamelessEntry,
     OpIsInfixAndPostFix(Atom),
     PredicateNotMultifileOrDiscontiguous(CompilationTarget, PredicateKey),
-    QueryCannotBeDefinedAsFact,
 }
 
 impl From<std::io::Error> for SessionError {

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -256,29 +256,14 @@ impl MachineState {
         unifier.unify_internal();
     }
 
-    pub fn unify_structure(&mut self, s1: usize, value: HeapCellValue) {
-        let mut unifier = DefaultUnifier::from(self);
-        unifier.unify_structure(s1, value);
-    }
-
     pub fn unify_atom(&mut self, atom: Atom, value: HeapCellValue) {
         let mut unifier = DefaultUnifier::from(self);
         unifier.unify_atom(atom, value);
     }
 
-    pub fn unify_list(&mut self, l1: usize, value: HeapCellValue) {
-        let mut unifier = DefaultUnifier::from(self);
-        unifier.unify_list(l1, value);
-    }
-
     pub fn unify_complete_string(&mut self, atom: Atom, value: HeapCellValue) {
         let mut unifier = DefaultUnifier::from(self);
         unifier.unify_complete_string(atom, value);
-    }
-
-    pub fn unify_partial_string(&mut self, value_1: HeapCellValue, value_2: HeapCellValue) {
-        let mut unifier = DefaultUnifier::from(self);
-        unifier.unify_partial_string(value_1, value_2);
     }
 
     pub fn unify_char(&mut self, c: char, value: HeapCellValue) {

--- a/src/machine/mock_wam.rs
+++ b/src/machine/mock_wam.rs
@@ -1,9 +1,6 @@
-pub use crate::arena::*;
-pub use crate::atom_table::*;
 use crate::heap_print::*;
 pub use crate::machine::heap::*;
 pub use crate::machine::machine_state::*;
-pub use crate::machine::stack::*;
 pub use crate::machine::streams::*;
 pub use crate::machine::*;
 pub use crate::parser::ast::*;
@@ -23,9 +20,10 @@ use std::ops::{Deref, DerefMut, Index, IndexMut};
 pub struct MockWAM {
     pub machine_st: MachineState,
     pub op_dir: OpDir,
-    pub flags: MachineFlags,
+    //pub flags: MachineFlags,
 }
 
+#[allow(dead_code)]
 impl MockWAM {
     pub fn new() -> Self {
         let op_dir = default_op_dir();
@@ -33,7 +31,7 @@ impl MockWAM {
         Self {
             machine_st: MachineState::new(),
             op_dir,
-            flags: MachineFlags::default(),
+            //flags: MachineFlags::default(),
         }
     }
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -250,7 +250,7 @@ pub(crate) fn get_structure_index(value: HeapCellValue) -> Option<CodeIndex> {
 
 impl Machine {
     #[inline]
-    pub fn prelude_view_and_machine_st(&mut self) -> (MachinePreludeView, &mut MachineState) {
+    fn prelude_view_and_machine_st(&mut self) -> (MachinePreludeView, &mut MachineState) {
         (
             MachinePreludeView {
                 indices: &mut self.indices,
@@ -270,7 +270,7 @@ impl Machine {
             .unwrap()
     }
 
-    pub fn throw_session_error(&mut self, err: SessionError, key: PredicateKey) {
+    fn throw_session_error(&mut self, err: SessionError, key: PredicateKey) {
         let err = self.machine_st.session_error(err);
         let stub = functor_stub(key.0, key.1);
         let err = self.machine_st.error_form(err, stub);
@@ -278,7 +278,7 @@ impl Machine {
         self.machine_st.throw_exception(err);
     }
 
-    pub fn run_module_predicate(
+    pub(crate) fn run_module_predicate(
         &mut self,
         module_name: Atom,
         key: PredicateKey,
@@ -297,7 +297,7 @@ impl Machine {
         unreachable!();
     }
 
-    pub fn load_file(&mut self, path: &str, stream: Stream) {
+    fn load_file(&mut self, path: &str, stream: Stream) {
         self.machine_st.registers[1] = stream_as_cell!(stream);
         self.machine_st.registers[2] =
             atom_as_cell!(AtomTable::build_with(&self.machine_st.atom_tbl, path));
@@ -357,11 +357,11 @@ impl Machine {
         }
     }
 
-    pub fn set_user_input(&mut self, input: String) {
+    fn set_user_input(&mut self, input: String) {
         self.user_input = Stream::from_owned_string(input, &mut self.machine_st.arena);
     }
 
-    pub fn get_user_output(&self) -> String {
+    fn get_user_output(&self) -> String {
         let output_bytes: Vec<_> = self.user_output.bytes().map(|b| b.unwrap()).collect();
         String::from_utf8(output_bytes).unwrap()
     }

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -271,14 +271,6 @@ impl Machine {
             .unwrap()
     }
 
-    fn throw_session_error(&mut self, err: SessionError, key: PredicateKey) {
-        let err = self.machine_st.session_error(err);
-        let stub = functor_stub(key.0, key.1);
-        let err = self.machine_st.error_form(err, stub);
-
-        self.machine_st.throw_exception(err);
-    }
-
     pub(crate) fn run_module_predicate(
         &mut self,
         module_name: Atom,
@@ -356,15 +348,6 @@ impl Machine {
                 self.machine_st.attr_var_init.verify_attrs_loc = code_index.local().unwrap();
             }
         }
-    }
-
-    fn set_user_input(&mut self, input: String) {
-        self.user_input = Stream::from_owned_string(input, &mut self.machine_st.arena);
-    }
-
-    fn get_user_output(&self) -> String {
-        let output_bytes: Vec<_> = self.user_output.bytes().map(|b| b.unwrap()).collect();
-        String::from_utf8(output_bytes).unwrap()
     }
 
     pub(crate) fn configure_modules(&mut self) {

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -1,4 +1,5 @@
 pub mod args;
+#[macro_use]
 pub mod arithmetic_ops;
 pub mod attributed_variables;
 pub mod code_walker;

--- a/src/machine/parsed_results.rs
+++ b/src/machine/parsed_results.rs
@@ -24,7 +24,7 @@ pub enum QueryResolution {
     Matches(Vec<QueryMatch>),
 }
 
-pub fn write_prolog_value_as_json<W: Write>(
+fn write_prolog_value_as_json<W: Write>(
     writer: &mut W,
     value: &Value,
 ) -> Result<(), std::fmt::Error> {

--- a/src/machine/partial_string.rs
+++ b/src/machine/partial_string.rs
@@ -213,8 +213,7 @@ impl<'a> HeapPStrIter<'a> {
         self.brent_st.hare = orig_hare;
     }
 
-    #[allow(clippy::inherent_to_string)]
-    pub fn to_string(&mut self) -> String {
+    pub fn to_string_mut(&mut self) -> String {
         let mut buf = String::with_capacity(32);
 
         for iteratee in self.by_ref() {

--- a/src/machine/partial_string.rs
+++ b/src/machine/partial_string.rs
@@ -104,11 +104,6 @@ impl<'a> HeapPStrIter<'a> {
     }
 
     #[inline(always)]
-    pub fn num_steps(&self) -> usize {
-        self.brent_st.num_steps()
-    }
-
-    #[inline(always)]
     pub fn chars(mut self) -> PStrCharsIter<'a> {
         let item = self.next();
         PStrCharsIter { iter: self, item }

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -529,11 +529,6 @@ impl From<TypedArenaPtr<ReadlineStream>> for Stream {
 
 impl Stream {
     #[inline]
-    pub fn from_readline_stream(stream: ReadlineStream, arena: &mut Arena) -> Stream {
-        Stream::Readline(arena_alloc!(StreamLayout::new(stream), arena))
-    }
-
-    #[inline]
     pub fn from_owned_string(string: String, arena: &mut Arena) -> Stream {
         Stream::Byte(arena_alloc!(
             StreamLayout::new(CharReader::new(ByteStream(Cursor::new(

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -1040,7 +1040,7 @@ impl MachineState {
                 self.heap.push(value);
 
                 let mut iter = HeapPStrIter::new(&self.heap, h);
-                let string = iter.to_string();
+                let string = iter.to_string_mut();
                 let at_terminator = iter.at_string_terminator();
 
                 self.heap.pop();

--- a/src/machine/term_stream.rs
+++ b/src/machine/term_stream.rs
@@ -7,8 +7,6 @@ use crate::parser::ast::*;
 use crate::parser::parser::*;
 use crate::read::devour_whitespace;
 
-use crate::predicate_queue;
-
 use fxhash::FxBuildHasher;
 use indexmap::IndexSet;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -144,7 +144,6 @@ macro_rules! stack_loc_as_cell {
     };
 }
 
-#[macro_export]
 macro_rules! heap_loc_as_cell {
     ($h:expr) => {
         HeapCellValue::build_with(HeapCellValueTag::Var, $h as u64)

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -26,6 +26,7 @@ pub type Specifier = u32;
 
 pub const MAX_ARITY: usize = 1023;
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum OpDeclSpec {
     XFX = 0x0001,
@@ -660,7 +661,7 @@ impl fmt::Display for Literal {
 }
 
 impl Literal {
-    pub fn to_atom(&self, atom_tbl: &Arc<AtomTable>) -> Option<Atom> {
+    pub fn as_atom(&self, atom_tbl: &Arc<AtomTable>) -> Option<Atom> {
         match self {
             Literal::Atom(atom) => Some(atom.defrock_brackets(atom_tbl)),
             _ => None,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -185,12 +185,6 @@ macro_rules! is_prefix {
     };
 }
 
-macro_rules! is_postfix {
-    ($x:expr) => {
-        $x as u32 & ($crate::parser::ast::XF as u32 | $crate::parser::ast::YF as u32) != 0
-    };
-}
-
 macro_rules! is_infix {
     ($x:expr) => {
         ($x as u32
@@ -312,12 +306,6 @@ macro_rules! temp_v {
     };
 }
 
-macro_rules! perm_v {
-    ($x:expr) => {
-        $crate::parser::ast::RegType::Perm($x)
-    };
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum GenContext {
     Head,
@@ -407,10 +395,6 @@ impl DoubleQuotes {
         matches!(self, DoubleQuotes::Chars)
     }
 
-    pub fn is_atom(self) -> bool {
-        matches!(self, DoubleQuotes::Atom)
-    }
-
     pub fn is_codes(self) -> bool {
         matches!(self, DoubleQuotes::Codes)
     }
@@ -422,20 +406,6 @@ pub enum Unknown {
     Error,
     Fail,
     Warn,
-}
-
-impl Unknown {
-    pub fn is_error(self) -> bool {
-        matches!(self, Unknown::Error)
-    }
-
-    pub fn is_fail(self) -> bool {
-        matches!(self, Unknown::Fail)
-    }
-
-    pub fn is_warn(self) -> bool {
-        matches!(self, Unknown::Warn)
-    }
 }
 
 pub fn default_op_dir() -> OpDir {
@@ -455,6 +425,7 @@ pub enum ArithmeticError {
     UninstantiatedVar,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum ParserError {
     BackQuotedString(usize, usize),
@@ -783,14 +754,6 @@ impl From<&str> for Var {
 }
 
 impl Var {
-    #[inline(always)]
-    pub fn as_str(&self) -> Option<&str> {
-        match self {
-            Var::Named(value) => Some(value),
-            _ => None,
-        }
-    }
-
     #[allow(clippy::inherent_to_string)]
     #[inline(always)]
     pub fn to_string(&self) -> String {
@@ -815,26 +778,10 @@ pub enum Term {
 }
 
 impl Term {
-    pub fn into_literal(self) -> Option<Literal> {
-        match self {
-            Term::Literal(_, c) => Some(c),
-            _ => None,
-        }
-    }
-
     pub fn first_arg(&self) -> Option<&Term> {
         match self {
             Term::Clause(_, _, ref terms) => terms.first(),
             _ => None,
-        }
-    }
-
-    pub fn set_name(&mut self, new_name: Atom) {
-        match self {
-            Term::Literal(_, Literal::Atom(ref mut atom)) | Term::Clause(_, ref mut atom, ..) => {
-                *atom = new_name;
-            }
-            _ => {}
         }
     }
 
@@ -853,15 +800,6 @@ impl Term {
             _ => 0,
         }
     }
-}
-
-#[inline]
-pub fn source_arity(terms: &[Term]) -> usize {
-    if let Some(Term::Literal(_, Literal::CodeIndex(_))) = terms.last() {
-        return terms.len() - 1;
-    }
-
-    terms.len()
 }
 
 pub(crate) fn unfold_by_str_once(term: &mut Term, s: Atom) -> Option<(Term, Term)> {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -139,7 +139,6 @@ pub const BTERM: u32 = 0x11000;
 
 pub const NEGATIVE_SIGN: u32 = 0x0200;
 
-#[macro_export]
 macro_rules! fixnum {
     ($wrapper:tt, $n:expr, $arena:expr) => {
         Fixnum::build_with_checked($n)
@@ -180,21 +179,18 @@ macro_rules! is_negate {
     };
 }
 
-#[macro_export]
 macro_rules! is_prefix {
     ($x:expr) => {
         $x as u32 & ($crate::parser::ast::FX as u32 | $crate::parser::ast::FY as u32) != 0
     };
 }
 
-#[macro_export]
 macro_rules! is_postfix {
     ($x:expr) => {
         $x as u32 & ($crate::parser::ast::XF as u32 | $crate::parser::ast::YF as u32) != 0
     };
 }
 
-#[macro_export]
 macro_rules! is_infix {
     ($x:expr) => {
         ($x as u32
@@ -205,48 +201,41 @@ macro_rules! is_infix {
     };
 }
 
-#[macro_export]
 macro_rules! is_xfx {
     ($x:expr) => {
         ($x as u32 & $crate::parser::ast::XFX as u32) != 0
     };
 }
 
-#[macro_export]
 macro_rules! is_xfy {
     ($x:expr) => {
         ($x as u32 & $crate::parser::ast::XFY as u32) != 0
     };
 }
 
-#[macro_export]
 macro_rules! is_yfx {
     ($x:expr) => {
         ($x as u32 & $crate::parser::ast::YFX as u32) != 0
     };
 }
-#[macro_export]
 macro_rules! is_yf {
     ($x:expr) => {
         ($x as u32 & $crate::parser::ast::YF as u32) != 0
     };
 }
 
-#[macro_export]
 macro_rules! is_xf {
     ($x:expr) => {
         ($x as u32 & $crate::parser::ast::XF as u32) != 0
     };
 }
 
-#[macro_export]
 macro_rules! is_fx {
     ($x:expr) => {
         ($x as u32 & $crate::parser::ast::FX as u32) != 0
     };
 }
 
-#[macro_export]
 macro_rules! is_fy {
     ($x:expr) => {
         ($x as u32 & $crate::parser::ast::FY as u32) != 0
@@ -317,14 +306,12 @@ impl Default for VarReg {
     }
 }
 
-#[macro_export]
 macro_rules! temp_v {
     ($x:expr) => {
         $crate::parser::ast::RegType::Temp($x)
     };
 }
 
-#[macro_export]
 macro_rules! perm_v {
     ($x:expr) => {
         $crate::parser::ast::RegType::Perm($x)

--- a/src/parser/char_reader.rs
+++ b/src/parser/char_reader.rs
@@ -53,11 +53,6 @@ impl<R> CharReader<R> {
     }
 
     #[inline]
-    pub fn inner(&self) -> &R {
-        &self.inner
-    }
-
-    #[inline]
     pub fn inner_mut(&mut self) -> &mut R {
         &mut self.inner
     }
@@ -98,10 +93,6 @@ impl<R> CharReader<R> {
 
     pub fn buffer(&self) -> &[u8] {
         &self.buf[self.pos..]
-    }
-
-    pub fn into_inner(self) -> R {
-        self.inner
     }
 
     pub fn reset_buffer(&mut self) {

--- a/src/parser/macros.rs
+++ b/src/parser/macros.rs
@@ -1,237 +1,204 @@
-#[macro_export]
 macro_rules! char_class {
     ($c: expr, [$head:expr]) => ($c == $head);
-    ($c: expr, [$head:expr $(, $cs:expr)+]) => ($c == $head || $crate::char_class!($c, [$($cs),*]));
+    ($c: expr, [$head:expr $(, $cs:expr)+]) => ($c == $head || char_class!($c, [$($cs),*]));
 }
 
-#[macro_export]
 macro_rules! alpha_char {
     ($c: expr) => {
         (!$c.is_numeric()
             && !$c.is_whitespace()
             && !$c.is_control()
-            && !$crate::graphic_token_char!($c)
-            && !$crate::layout_char!($c)
-            && !$crate::meta_char!($c)
-            && !$crate::solo_char!($c))
+            && !graphic_token_char!($c)
+            && !layout_char!($c)
+            && !meta_char!($c)
+            && !solo_char!($c))
             || $c == '_'
     };
 }
 
-#[macro_export]
 macro_rules! alpha_numeric_char {
     ($c: expr) => {
-        $crate::alpha_char!($c) || $c.is_numeric()
+        alpha_char!($c) || $c.is_numeric()
     };
 }
 
-#[macro_export]
 macro_rules! backslash_char {
     ($c: expr) => {
         $c == '\\'
     };
 }
 
-#[macro_export]
 macro_rules! back_quote_char {
     ($c: expr) => {
         $c == '`'
     };
 }
 
-#[macro_export]
 macro_rules! octet_char {
     ($c: expr) => {
         ('\u{0000}'..='\u{00FF}').contains(&$c)
     };
 }
 
-#[macro_export]
 macro_rules! capital_letter_char {
     ($c: expr) => {
         $c.is_uppercase()
     };
 }
 
-#[macro_export]
 macro_rules! comment_1_char {
     ($c: expr) => {
         $c == '/'
     };
 }
 
-#[macro_export]
 macro_rules! comment_2_char {
     ($c: expr) => {
         $c == '*'
     };
 }
 
-#[macro_export]
 macro_rules! cut_char {
     ($c: expr) => {
         $c == '!'
     };
 }
 
-#[macro_export]
 macro_rules! decimal_digit_char {
     ($c: expr) => {
         $c.is_ascii_digit()
     };
 }
 
-#[macro_export]
 macro_rules! decimal_point_char {
     ($c: expr) => {
         $c == '.'
     };
 }
 
-#[macro_export]
 macro_rules! double_quote_char {
     ($c: expr) => {
         $c == '"'
     };
 }
 
-#[macro_export]
 macro_rules! end_line_comment_char {
     ($c: expr) => {
         $c == '%'
     };
 }
 
-#[macro_export]
 macro_rules! exponent_char {
     ($c: expr) => {
         $c == 'e' || $c == 'E'
     };
 }
 
-#[macro_export]
 macro_rules! graphic_char {
-    ($c: expr) => ($crate::char_class!($c, ['#', '$', '&', '*', '+', '-', '.', '/', ':',
+    ($c: expr) => (char_class!($c, ['#', '$', '&', '*', '+', '-', '.', '/', ':',
                                             '<', '=', '>', '?', '@', '^', '~']))
 }
 
-#[macro_export]
 macro_rules! graphic_token_char {
     ($c: expr) => {
-        $crate::graphic_char!($c) || $crate::backslash_char!($c)
+        graphic_char!($c) || backslash_char!($c)
     };
 }
 
-#[macro_export]
 macro_rules! hexadecimal_digit_char {
     ($c: expr) => {
         $c.is_ascii_digit() || ('A'..='F').contains(&$c) || ('a'..='f').contains(&$c)
     };
 }
 
-#[macro_export]
 macro_rules! layout_char {
     ($c: expr) => {
-        $crate::char_class!($c, [' ', '\r', '\n', '\t', '\u{0B}', '\u{0C}'])
+        char_class!($c, [' ', '\r', '\n', '\t', '\u{0B}', '\u{0C}'])
     };
 }
 
-#[macro_export]
 macro_rules! meta_char {
     ($c: expr) => {
-        $crate::char_class!($c, ['\\', '\'', '"', '`'])
+        char_class!($c, ['\\', '\'', '"', '`'])
     };
 }
 
-#[macro_export]
 macro_rules! new_line_char {
     ($c: expr) => {
         $c == '\n'
     };
 }
 
-#[macro_export]
 macro_rules! octal_digit_char {
     ($c: expr) => {
         ('0'..='7').contains(&$c)
     };
 }
 
-#[macro_export]
 macro_rules! binary_digit_char {
     ($c: expr) => {
         $c == '0' || $c == '1'
     };
 }
 
-#[macro_export]
 macro_rules! prolog_char {
     ($c: expr) => {
-        $crate::graphic_char!($c)
-            || $crate::alpha_numeric_char!($c)
-            || $crate::solo_char!($c)
-            || $crate::layout_char!($c)
-            || $crate::meta_char!($c)
+        graphic_char!($c)
+            || alpha_numeric_char!($c)
+            || solo_char!($c)
+            || layout_char!($c)
+            || meta_char!($c)
     };
 }
 
-#[macro_export]
 macro_rules! semicolon_char {
     ($c: expr) => {
         $c == ';'
     };
 }
 
-#[macro_export]
 macro_rules! sign_char {
     ($c: expr) => {
         $c == '-' || $c == '+'
     };
 }
 
-#[macro_export]
 macro_rules! single_quote_char {
     ($c: expr) => {
         $c == '\''
     };
 }
 
-#[macro_export]
 macro_rules! small_letter_char {
     ($c: expr) => {
         $c.is_alphabetic() && !$c.is_uppercase()
     };
 }
 
-#[macro_export]
 macro_rules! solo_char {
     ($c: expr) => {
-        $crate::char_class!($c, ['!', '(', ')', ',', ';', '[', ']', '{', '}', '|', '%'])
+        char_class!($c, ['!', '(', ')', ',', ';', '[', ']', '{', '}', '|', '%'])
     };
 }
 
-#[macro_export]
 macro_rules! space_char {
     ($c: expr) => {
         $c == ' '
     };
 }
 
-#[macro_export]
 macro_rules! symbolic_control_char {
     ($c: expr) => {
-        $crate::char_class!($c, ['a', 'b', 'f', 'n', 'r', 't', 'v', '0'])
+        char_class!($c, ['a', 'b', 'f', 'n', 'r', 't', 'v', '0'])
     };
 }
 
-#[macro_export]
 macro_rules! symbolic_hexadecimal_char {
     ($c: expr) => {
         $c == 'x'
     };
 }
 
-#[macro_export]
 macro_rules! variable_indicator_char {
     ($c: expr) => {
         $c == '_'

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -180,31 +180,6 @@ pub fn get_op_desc(name: Atom, op_dir: &CompositeOpDir) -> Option<CompositeOpDes
     }
 }
 
-pub fn get_clause_spec(name: Atom, arity: usize, op_dir: &CompositeOpDir) -> Option<OpDesc> {
-    match arity {
-        1 => {
-            /* This is a clause with an operator principal functor. Prefix operators
-            are supposed over post.
-             */
-            if let Some(cell) = op_dir.get(name, Fixity::Pre) {
-                return Some(cell);
-            }
-
-            if let Some(cell) = op_dir.get(name, Fixity::Post) {
-                return Some(cell);
-            }
-        }
-        2 => {
-            if let Some(cell) = op_dir.get(name, Fixity::In) {
-                return Some(cell);
-            }
-        }
-        _ => {}
-    };
-
-    None
-}
-
 fn affirm_xfx(priority: usize, d2: TokenDesc, d3: TokenDesc, d1: TokenDesc) -> bool {
     d2.priority <= priority
         && is_term!(d3.spec)
@@ -339,16 +314,6 @@ impl<'a, R: CharRead> Parser<'a, R> {
             TokenType::End => Some(atom!(".")),
             _ => None,
         }
-    }
-
-    #[inline]
-    pub fn line_num(&self) -> usize {
-        self.lexer.line_num
-    }
-
-    #[inline]
-    pub fn col_num(&self) -> usize {
-        self.lexer.col_num
     }
 
     fn get_term_name(&mut self, td: TokenDesc) -> Option<Atom> {

--- a/tests/scryer/helper.rs
+++ b/tests/scryer/helper.rs
@@ -26,7 +26,7 @@ impl Expectable for &[u8] {
 /// Tests whether the file can be successfully loaded
 /// and produces the expected output during it
 pub(crate) fn load_module_test<T: Expectable>(file: &str, expected: T) {
-    use scryer_prolog::machine::mock_wam::*;
+    use scryer_prolog::Machine;
 
     let mut wam = Machine::with_test_streams();
     expected.assert_eq(wam.test_load_file(file).as_slice());


### PR DESCRIPTION
Part of #2490. Related previous discussion #2512. This PR does the following:

- Refactors all of the code of the binary into a `run_binary()` function in the library interface, so that we don't have to make stuff like `Atom` and `atom!` public.
- Turns everything that didn't make sense to be `pub` (and wasn't used in tests or benchmarks) into `pub(crate)` (or stricter) instead. Maybe most of those could/should be even stricter, but this is out of scope because it would not be a breaking change if done after this PR.

Currently the following are public (our semver surface) and `pub use`d at the top level of the library:

- Structs
  - `Machine`
    - All fields private.
    - `new_lib`
    - `load_module_string`
    - `consult_module_string`
    - `run_query`
    - `run_query_iter`
    - `with_test_streams` (only used in integration tests)
    - `test_load_file` (only used in integration tests)
    - `test_load_string` (only used in Wasm build)
    - `get_inference_count` (only used in benchmarks)
    - `new`
  - `MachineConfig`
    - All fields public, not `#[non_exhaustive]`.
    - `in_memory`
    - `with_toplevel`
  - `QueryMatch`
    - All fields public, not `#[non_exhaustive]`.
  - `QueryState`
    - All fields private.
- Enums
  - `QueryResolution`
    - Not `#[non_exhaustive]`
  - `QueryResolutionLine`
    - Not `#[non_exhaustive]`
  - `StreamConfig`
    - Not `#[non_exhaustive]`
  - `Value`
    - Not `#[non_exhaustive]`
- Functions
  - `run_binary`
- Type Aliases
  - `QueryResult`

`cargo check` goes crazy with the amount of dead code warnings. It didn't point it before because `pub` code isn't considered in dead code analysis. Clippy goes even crazier, it seems to be linting the generated files now for some reason (which is good, but why didn't it do that before?). No errors in either though.

# Open questions

Can be addressed in another PR.

- Should we keep the `Machine` methods that are only used in tests, benchmarks and the Wasm build or should we refactor to use the rest of the interface instead so that we get a cleaner public interface?
- Should `run_binary` be behind a feature?

# Remaining work

- [x] Handle visibility for the 54 `#[macro_use]` macros. I think _all of them_ should probably be private, as they leak internal details and aren't really useful to users. ~This will be quite a chore, because Scryer Prolog seems to rely a lot on these macros being public and global.~ Was actually very easy.
- [x] Maybe deal with at least part of the dead code pointed by `cargo check` (maybe by just `#[allow(dead_code)]`ing most of it).
- [x] Maybe deal with Clippy warnings. 

# Out of scope for this PR

- Separating binary and/or lib into separate packages in a workspace.
- Naming.
- Future proofing APIs (things like keeping struct fields private and `#[non_exhaustive]`ing enums).
- Documentation.
- Freezing signatures and traits.