### PR TITLE
Toplevel reimplementation with leaf answer callbacks

### DIFF
--- a/src/loader.pl
+++ b/src/loader.pl
@@ -19,10 +19,9 @@ write_error(Error) :-
     % '$fetch_global_var' is the core system call of bb_get/2, but
     % bb_get may not exist when write_error is first called, so fall
     % back on '$fetch_global_var'.
-    (  '$fetch_global_var'('$first_answer', false) ->
+    (  '$fetch_global_var'('$answer_count', C), C =\= 0 ->
        true
-    ;  write('   ') % if '$first_answer' isn't defined yet or true,
-                    % print indentation.
+    ;  write('   ') % if still in the first answer print indentation.
     ),
     (  current_prolog_flag(double_quotes, chars) ->
        DQ = true

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -170,14 +170,14 @@ repl :-
 %% Enable op declarations with lists of operands, i.e.,
 %% :- op(900, fy, [$,@]).
 
-user:term_expansion((:- op(Pred, Spec, Ops)), OpResults) :-
+user:term_expansion((:- op(Pri, Spec, Ops)), OpResults) :-
     ground(Ops),
     Ops = [Op | OtherOps],
-    expand_op_list([Op | OtherOps], Pred, Spec, OpResults).
+    expand_op_list([Op | OtherOps], Pri, Spec, OpResults).
 
 expand_op_list([], _, _, []).
-expand_op_list([Op | OtherOps], Pred, Spec, [(:- op(Pred, Spec, Op)) | OtherResults]) :-
-    expand_op_list(OtherOps, Pred, Spec, OtherResults).
+expand_op_list([Op | OtherOps], Pri, Spec, [(:- op(Pri, Spec, Op)) | OtherResults]) :-
+    expand_op_list(OtherOps, Pri, Spec, OtherResults).
 
 
 read_and_match :-

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -170,8 +170,8 @@ repl :-
 %% Enable op declarations with lists of operands, i.e.,
 %% :- op(900, fy, [$,@]).
 
-user:term_expansion((:- op(Pred, Spec, Ops)), OpResults) :- 
-    ground(Ops), 
+user:term_expansion((:- op(Pred, Spec, Ops)), OpResults) :-
+    ground(Ops),
     Ops = [Op | OtherOps],
     expand_op_list([Op | OtherOps], Pred, Spec, OpResults).
 
@@ -223,7 +223,7 @@ run_query(QueryChars, Callback_3, Options) :-
 % - `final(exception(Exception))`, where `Exception` is the exception thrown
 % - `final(true)`
 % - `final(leaf_answer(Bindings, ResidualGoals, VarNames))`, where:
-%   
+%
 %   - `Bindings` is a list of terms of the form `Var=Term`, where `Var` is a
 %     variable.
 %   - `ResidualGoals` is a list of the residual goals from the query.


### PR DESCRIPTION
I went and reimplemented a good part of the toplevel on top of a predicate I called `run_query_goal/4`. It passes all the current tests, and works the same as the old implementation in my manual testing. The idea is to eventually make this same predicate drive the library interface (when I figure out how to call arbitrary Prolog from the Rust side[^1]), other (pseudo) toplevels, and maybe even some other kinds of things, it's very general. It takes 4 arguments: the query term, a list of variable names (in the form given by the `variable_names(-VarNames)` option of [`read_term/3`](https://www.scryer.pl/builtins.html#read_term/3)), a callback goal expecting 3 arguments and a list of options. This predicate then runs the query and calls the callback with the leaf answer and additional information, and the callback then signals if the query should continue or stop. The possibilities for the first argument (the leaf answer) are:

- `final(false)`
- `final(exception(Exception))`
- `final(true)`
- `final(leaf_answer(Bindings, ResidualGoals, VarNames))`
- `pending(true)`
- `pending(leaf_answer(Bindings, ResidualGoals, VarNames))`

A principal functor of `final/1` means that this is the last leaf answer in the complete answer, and a principal functor of `pending/1` means that there are more leaf answers. Implementing this made me realize that this pending/final "attribute" of leaf answers is actually very important (it's not quite an iterator, in the Rust sense) and gives me ideas of how to improve the library interface further[^2]. The second argument to the callback is a list with additional information that we can use to implement extensions to this in the future (like reporting inference counts). The third argument needs to be instantiated by the callback to either `continue` or `stop` to signal if the query should stop.

Notice that this can fully represent residual goals (!), with projections (!!) and also reifies exceptions (!!!). The only improvement on this I can think of is to map the query variable names onto the exception like in the `leaf_answer/3` case, but it seems that variables lose their identity when going through a throw-catch, so I don't know if that is even possible.

I want to further break the toplevel into configurable/reusable pieces in the future, because that will allow a lot of really cool stuff, especially in the [Scryer Playground](https://play.scryer.pl/)!

Ok, now I gotta sleep, I've been coding this non-stop for 14 hours straight.

[^1]: I have some ideas! If it works we could move even more of the engine into Prolog very easily.
[^2]: It also was the first time I've felt a use for a soft cut, which was interesting to stumble on, ~and the first time I've actually used `subsumes_term/2`, very nice~ (this was actually not a place where `subsumes_term/2` helped much).