### PR TITLE
Document non counted backtracking

### DIFF
--- a/src/lib/iso_ext.pl
+++ b/src/lib/iso_ext.pl
@@ -223,6 +223,7 @@ run_cleaners_without_handling(Cp) :-
 %% call_with_inference_limit(Goal, Limit, Result).
 %
 % Similar to `call(Goal)` but it limits the number of inferences for each solution of Goal.
+% Calls to it may be nested, but only the last limit will be in power.
 call_with_inference_limit(G, L, R) :-
     (  integer(L) ->
        (  L < 0 ->

--- a/src/lib/ops_and_meta_predicates.pl
+++ b/src/lib/ops_and_meta_predicates.pl
@@ -5,9 +5,13 @@
 
 :- op(1199, fx, meta_predicate).
 
-/* this is an implementation specific declarative operator used to implement call_with_inference_limit/3
-   and setup_call_cleanup/3. switches to the default trust_me and retry_me_else. Indexing choice
-   instructions are unchanged. */
+% Declarative operator used to implement `call_with_inference_limit/3` and
+% `setup_call_cleanup/3`. Compiler switches to the default trust_me, retry_me_else
+% and some other instructions for all predicates the marked with it. Indexing
+% choice instructions are unchanged.
+%
+% Default instructins are not subject to inference counting, so their execution
+% will not be considered if they happen to be called by `call_with_inference_limit/3`.
 :- op(700, fx, non_counted_backtracking).
 
 % arithmetic operators.

--- a/src/lib/ops_and_meta_predicates.pl
+++ b/src/lib/ops_and_meta_predicates.pl
@@ -5,13 +5,16 @@
 
 :- op(1199, fx, meta_predicate).
 
-% Declarative operator used to implement `call_with_inference_limit/3` and
-% `setup_call_cleanup/3`. Compiler switches to the default trust_me, retry_me_else
-% and some other instructions for all predicates the marked with it. Indexing
-% choice instructions are unchanged.
+% Implementation specific declarative operator used to implement
+% call_with_inference_limit/3 and setup_call_cleanup/3. Compiler switches
+% to the default trust_me, retry_me_else and some other instructions for all
+% predicates that are marked with it. Indexing choice instructions are unchanged.
 %
-% Default instructins are not subject to inference counting, so their execution
-% will not be considered if they happen to be called by `call_with_inference_limit/3`.
+% Implementation details:
+% Default instructions are not subject to inference counting, so their
+% execution will not be considered if they happen to be called by
+% call_with_inference_limit/3.
+%
 :- op(700, fx, non_counted_backtracking).
 
 % arithmetic operators.


### PR DESCRIPTION
While reading loader.pl module it was not obvious to me at all what exactly does `non_counted_backtracking` to the predicates and should I use it for new predicates in that module or not. After reading sources I came up with new documentation. Basically there is a single counter which is incremented on every instruction that is an "inference", but for "default" instructions (instructions that start with `default_` prefix) that counter isn't incremented and isn't checked. When counter reaches a limit (defined for example when you use `call_with_inference_limit/3`) it forces unconditional exit and stops evaluating rest of instructions (I hope I got that part right).

**UPDT:**
There is only a single inference counter and a single variable that holds a max inference limit, that's why when you use nested calls to `call_with_inference_limit/3` old limit value is overwritten. I don't know exactly how it behaves on backtracking though.