### PR TITLE
Handle module scoping in library(lambda)

### DIFF
--- a/src/lib/lambda.pl
+++ b/src/lib/lambda.pl
@@ -219,14 +219,22 @@ Further discussions
 % likely the result of an insufficient number of arguments.
 
 no_hat_call(MGoal_0) :-
-   strip_module(MGoal_0, _, Goal_0),
-   (  nonvar(Goal_0),
-      Goal_0 = (_^_)
+   strip_module(MGoal_0, _, GoalNaked_0),
+   % Strip just the automatically added lambda module prefix if needed
+   (    MGoal_0 = lambda:Goal_0 ->
+        true
+   ;    Goal_0 = MGoal_0
+   ),
+   (  nonvar(GoalNaked_0),
+      GoalNaked_0 = (_^_)
    -> throw(
 			error(
-				existence_error(lambda_parameter,MGoal_0),
+				existence_error(lambda_parameter,Goal_0),
 				_))
-	;	call(MGoal_0)
+	; % This calls the lambda at user scope, it can be overriden by 
+      % giving an explicit scope in Goal_0, because user:another_module:Goal
+      % is executed at another_module scope.
+      call(user:Goal_0)
    ).
 
 % I would like to replace this by:

--- a/tests/scryer/cli/issues/lambda_modules.in/a.pl
+++ b/tests/scryer/cli/issues/lambda_modules.in/a.pl
@@ -1,0 +1,7 @@
+:- use_module(library(lambda)).
+
+:- use_module(b).
+
+p.
+
+make_goal_a(\p).

--- a/tests/scryer/cli/issues/lambda_modules.in/b.pl
+++ b/tests/scryer/cli/issues/lambda_modules.in/b.pl
@@ -1,0 +1,18 @@
+:- module(b, [
+    make_goal_b_raw/1,
+    make_goal_b_scoped/1,
+    make_goal_b_scoped_alt/1
+]).
+
+:- use_module(library(lambda)).
+
+% Private to module b
+q.
+
+make_goal_b_raw(\q).
+
+% Giving the call to private q/0 an explicit module
+make_goal_b_scoped(\(b:q)).
+
+% Giving the entire labda a scope
+make_goal_b_scoped_alt(b:(\q)).

--- a/tests/scryer/cli/issues/lambda_modules.stdin
+++ b/tests/scryer/cli/issues/lambda_modules.stdin
@@ -1,0 +1,6 @@
+use_module(a).
+make_goal_a(G), call(G).
+make_goal_b_raw(G), call(G).
+make_goal_b_raw(G), call(b:G).
+make_goal_b_scoped(G), call(G).
+make_goal_b_scoped_alt(G), call(G).

--- a/tests/scryer/cli/issues/lambda_modules.stdout
+++ b/tests/scryer/cli/issues/lambda_modules.stdout
@@ -1,0 +1,6 @@
+   true.
+   G = /p.
+   error(existence_error(procedure,q/0),q/0).
+   G = /q.
+   G = / (b:q).
+   G = b: /q.

--- a/tests/scryer/cli/issues/lambda_modules.toml
+++ b/tests/scryer/cli/issues/lambda_modules.toml
@@ -1,0 +1,2 @@
+# issue 2255
+args = ["-f", "--no-add-history"]


### PR DESCRIPTION
Closes #2255.

This makes `library(lambda)` not terrible to use when having to deal with multiple module scopes. Example of functionality:

```prolog
%% Contents of a.pl
:- use_module(library(lambda)).

:- use_module(b).

p.

make_goal_a(\p).
```
```prolog
%% Contents of b.pl
:- module(b, [
    make_goal_b_raw/1,
    make_goal_b_scoped/1,
    make_goal_b_scoped_alt/1
]).

:- use_module(library(lambda)).

% Private to module b
q.

make_goal_b_raw(\q).

% Giving the call to private q/0 an explicit scope
make_goal_b_scoped(\(b:q)).

% Giving the entire lambda a scope
make_goal_b_scoped_alt(b:(\q)).
```
```prolog
% All of the following error in current master!
?- use_module(a).
   true.
?- make_goal_a(G), call(G).
   G = \p.
?- make_goal_b_raw(G), call(G).
   error(existence_error(procedure,q/0),q/0).
?- make_goal_b_raw(G), call(b:G).
   G = \q.
?- make_goal_b_scoped(G), call(G).
   G = \ (b:q).
?- make_goal_b_scoped_alt(G), call(G).
   G = b: \q.
```

EDIT: This does not fix whatever the hell is happening in https://github.com/mthom/scryer-prolog/issues/2255#issuecomment-2336518018, but just sidesteps it. That is probably related to module scope explicitation in goal expansion or something like that.