### PR TITLE
Pretty (and colorful!) errors and warnings

### DIFF
--- a/tests/scryer/cli/src_tests/directive_errors.md
+++ b/tests/scryer/cli/src_tests/directive_errors.md
@@ -1,56 +1,92 @@
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl1.pl -g halt
-   error(domain_error(operator_specifier,moin),load/1).
+   % Error: domain_error/2
+   % | expected domain: operator_specifier
+   % | culprit: moin
+   % | source: load/1
+   throw(error(domain_error(operator_specifier,moin),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl2.pl -g halt
-   error(domain_error(operator_priority,4000),load/1).
+   % Error: domain_error/2
+   % | expected domain: operator_priority
+   % | culprit: 4000
+   % | source: load/1
+   throw(error(domain_error(operator_priority,4000),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl3.pl -g halt
-   error(type_error(list,todo_insert_invalid_term_here),load/1).
+   % Error: type_error/2
+   % | expected type: list
+   % | culprit: todo_insert_invalid_term_here
+   % | source: load/1
+   throw(error(type_error(list,todo_insert_invalid_term_here),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl4.pl -g halt
-   error(domain_error(directive,op/4),load/1).
+   % Error: domain_error/2
+   % | expected domain: directive
+   % | culprit: op/4
+   % | source: load/1
+   throw(error(domain_error(directive,op/4),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl5.pl -g halt
-   error(domain_error(directive,(;)/2),load/1).
+   % Error: domain_error/2
+   % | expected domain: directive
+   % | culprit: (;)/2
+   % | source: load/1
+   throw(error(domain_error(directive,(;)/2),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl6.pl -g halt
-   error(domain_error(directive,todo_insert_invalid_term_here),load/1).
+   % Error: domain_error/2
+   % | expected domain: directive
+   % | culprit: todo_insert_invalid_term_here
+   % | source: load/1
+   throw(error(domain_error(directive,todo_insert_invalid_term_here),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl7.pl -g halt
-   error(domain_error(operator_specifier,todo_insert_invalid_term_here),load/1).
+   % Error: domain_error/2
+   % | expected domain: operator_specifier
+   % | culprit: todo_insert_invalid_term_here
+   % | source: load/1
+   throw(error(domain_error(operator_specifier,todo_insert_invalid_term_here),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl8.pl -g halt
-% Warning: singleton variables Var at line 0 of invalid_decl8.pl
-   error(domain_error(operator_specifier,todo_insert_invalid_term_here),load/1).
+   % Warning: singleton variables Var at line 0 of invalid_decl8.pl
+   % Error: domain_error/2
+   % | expected domain: operator_specifier
+   % | culprit: todo_insert_invalid_term_here
+   % | source: load/1
+   throw(error(domain_error(operator_specifier,todo_insert_invalid_term_here),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl9.pl -g halt
-% Warning: singleton variables Var at line 0 of invalid_decl9.pl
-   error(type_error(integer,todo_insert_invalid_term_here),load/1).
+   % Warning: singleton variables Var at line 0 of invalid_decl9.pl
+   % Error: type_error/2
+   % | expected type: integer
+   % | culprit: todo_insert_invalid_term_here
+   % | source: load/1
+   throw(error(type_error(integer,todo_insert_invalid_term_here),load/1)).
 
 ```
 
@@ -63,45 +99,76 @@ FIXME I belive the following test should result in a `error(instantiation_error,
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl11.pl -g halt
-% Warning: singleton variables Var at line 0 of invalid_decl11.pl
-   error(type_error(list,todo_insert_invalid_term_here),load/1).
+   % Warning: singleton variables Var at line 0 of invalid_decl11.pl
+   % Error: type_error/2
+   % | expected type: list
+   % | culprit: todo_insert_invalid_term_here
+   % | source: load/1
+   throw(error(type_error(list,todo_insert_invalid_term_here),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl12.pl -g halt
-   error(permission_error(create,operator,{}),load/1).
+   % Error: permission_error/3
+   % | operation: create
+   % | permission type: operator
+   % | culprit: {}
+   % | source: load/1
+   throw(error(permission_error(create,operator,{}),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl13.pl -g halt
-   error(permission_error(create,operator,{}),load/1).
+   % Error: permission_error/3
+   % | operation: create
+   % | permission type: operator
+   % | culprit: {}
+   % | source: load/1
+   throw(error(permission_error(create,operator,{}),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl14.pl -g halt
-   error(permission_error(create,operator,'|'),load/1).
+   % Error: permission_error/3
+   % | operation: create
+   % | permission type: operator
+   % | culprit: '|'
+   % | source: load/1
+   throw(error(permission_error(create,operator,'|'),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl15.pl -g halt
-   error(permission_error(create,operator,'|'),load/1).
+   % Error: permission_error/3
+   % | operation: create
+   % | permission type: operator
+   % | culprit: '|'
+   % | source: load/1
+   throw(error(permission_error(create,operator,'|'),load/1)).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl16.pl -g halt
-   error(permission_error(modify,operator,','),load/1).
+   % Error: permission_error/3
+   % | operation: modify
+   % | permission type: operator
+   % | culprit: ','
+   % | source: load/1
+   throw(error(permission_error(modify,operator,','),load/1)).
 
 ```
 
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl_issue2467.pl -g halt
-% Warning: singleton variables D at line 0 of invalid_decl_issue2467.pl
-   error(instantiation_error,load/1).
+   % Warning: singleton variables D at line 0 of invalid_decl_issue2467.pl
+   % Error: instantiation_error/0
+   % | source: load/1
+   throw(error(instantiation_error,load/1)).
 
 ```

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -8,7 +8,7 @@ use serial_test::serial;
 fn call_0() {
     load_module_test(
         "tests-pl/issue831-call0.pl",
-        "   error(existence_error(procedure,call/0),call/0).\n",
+        "   % Error: existence_error/2\n   % | object type: procedure\n   % | culprit: call/0\n   % | source: call/0\n   throw(error(existence_error(procedure,call/0),call/0)).\n",
     );
 }
 

--- a/tests/scryer/src_tests.rs
+++ b/tests/scryer/src_tests.rs
@@ -35,7 +35,7 @@ fn hello_world() {
 fn syntax_error() {
     load_module_test(
         "tests-pl/syntax_error.pl",
-        "   error(syntax_error(incomplete_reduction),read_term/3:6).\n",
+        "   % Error: syntax_error/1\n   % | error: incomplete_reduction\n   % | source: read_term/3\n   % | line: 6\n   % Note: This usually happens because of an trailing or missing comma\n   %       or other operators. Also, Scryer Prolog currently doesn't\n   %       give precise syntax error locations, so look in the clause\n   %       immediately before the line indicated in the error.\n   %       Related issue: <https://github.com/mthom/scryer-prolog/issues/302>\n   throw(error(syntax_error(incomplete_reduction),read_term/3:6)).\n",
     );
 }
 


### PR DESCRIPTION
This PR adds support for pretty printing user friendly errors in comments. Additionally, errors and warnings (except the ones that are implemented in Rust) can now be colored if `user:colored_terminal` is true (suggestions for a better name or way to do that are welcome), which is activated by default if stdout is a terminal (in contrast to a pipe or file). My terminal check uses `library(ffi)` to call `isatty` from `lib.so.6`. I think it works on any UNIX[^1], but I can only be sure that it works on Linux. You can enable it anyway by just asserting `user:colored_terminal` if the detection doesn't work for you, and disabling it by retracting. The colors and layout of the errors can probably be bikeshed a lot (open for suggestions, I tried to copy Rust a bit), but as this is for _users_ and not machines I think we can have this remain unstable and change at any time without much consequence.

I implemented special handling for all the ISO errors, and for `'$interrupt_thrown'/0` (Ctrl-C). Even with almost no useful information in errors I think this already surpasses a lot of other Prolog systems in _UX_ (like SWI and it's big wall of capslock red). I also left an example diagnostic for `syntax_error(incomplete_reduction)` (which in my experience is the most annoying and confusing error for beginners) as a sneak-peek to what we could have in the future: Elm-like errors that are really user friendly. Rust has that and it's really nice. With good enough diagnostics one could even learn a lot of the language just by trying stuff out and following the suggestions. I think Prolog is uniquely equipped to do error analysis for diagnostics, so the ceiling here is pretty high.

![image](https://github.com/user-attachments/assets/017626ad-67e5-4c99-a5a1-67acea7c5e95)

And now that we have user friendly errors, the machine friendly version could be as ugly as we like. In particular, I have changed error leaf answers to `throw(error(_,_))` for consistency, because I really don't know why to have this as a special case if not for readability which is now unnecessary. In the future, this can mean that we can have some very crazy stuff in the implementation defined field of `error/2`, which will be very useful for users and machines alike.

My implementation of this is kinda hacky, because I can't use libraries like `library(dcgs)` in `loader.pl` (which is where this is currently defined). Error printing may happen this early, so I don't know exactly how to avoid this, but it would be good to maybe rethink the bootstrap process a bit so we can get a bit higher level with this. 

[^1]: It's a `unistd.h` function so no Windows support there, and I know checking if stdout is a terminal is _much harder_ on Windows. We may want to implement a portable `'$isatty'(+Stream)` predicate based on [`is_terminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html#tymethod.is_terminal) later.