### PR TITLE
Convert library(error) docs to Doclog format

### DIFF
--- a/src/lib/error.pl
+++ b/src/lib/error.pl
@@ -14,31 +14,29 @@
 :- meta_predicate check_(1, ?, ?).
 
 
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   must_be(Type, Term)
-
-   This predicate is intended for type-checks of built-in predicates.
-
-   It asserts that Term is:
-
-       1) instantiated *and*
-       2) instantiated to an instance of the given Type.
-
-   It corresponds to usage mode +Term.
-
-   Currently, the following types are supported:
-
-       - atom
-       - boolean
-       - character
-       - chars
-       - in_character
-       - integer
-       - list
-       - octet_character
-       - octet_chars
-       - term
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+%% must_be(Type, Term)
+%
+% This predicate is intended for type-checks of built-in predicates.
+%
+% It asserts that Term is:
+%
+%     1) instantiated *and*
+%     2) instantiated to an instance of the given Type.
+%
+% It corresponds to usage mode +Term.
+%
+% Currently, the following types are supported:
+%
+%     - atom
+%     - boolean
+%     - character
+%     - chars
+%     - in_character
+%     - integer
+%     - list
+%     - octet_character
+%     - octet_chars
+%     - term
 
 must_be(Type, Term) :-
         must_be_(type, Type),
@@ -142,19 +140,16 @@ type(boolean).
 type(term).
 type(not_less_than_zero).
 
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   can_be(Type, Term)
-
-   This predicate is intended for type-checks of built-in predicates.
-
-   It asserts that there is a substitution which, if applied to Term,
-   makes it an instance of Type.
-
-   It corresponds to usage mode ?Term.
-
-   It supports the same types as must_be/2.
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-
+%% can_be(Type, Term)
+%
+% This predicate is intended for type-checks of built-in predicates.
+%
+% It asserts that there is a substitution which, if applied to Term,
+% makes it an instance of Type.
+%
+% It corresponds to usage mode ?Term.
+%
+% It supports the same types as must_be/2.
 
 can_be(Type, Term) :-
         must_be(type, Type),


### PR DESCRIPTION
This just converts the documentation that was already there to Doclog format so that it will appear [here](https://www.scryer.pl/error).

`library(queues)` and `library(tls)` also have docs already that aren't in the Doclog format, and I was going to convert them all in a single PR, but at least for `library(queue)` I realized that it wasn't going to be as simple as `library(error)` because of the predicate signatures that I don't really understand.