### PR TITLE
README: link to latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ strings.
 Precompiled binaries for several platforms are available for download
 at:
 
-**https://github.com/mthom/scryer-prolog/releases/tag/v0.9.3**
+**https://github.com/mthom/scryer-prolog/releases/latest**
 
 ### Native Compilation
 


### PR DESCRIPTION
This will automatically redirect to the release marked "latest" in GitHub. So the link won't become stale and doesn't need updating.