### PR TITLE
Fix not compiling without hostname feature

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -1772,7 +1772,7 @@ impl Machine {
         self.machine_st.fail = true;
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "hostname"))]
     #[inline(always)]
     pub(crate) fn current_hostname(&mut self) {
         if let Ok(host) = hostname::get() {
@@ -1789,7 +1789,7 @@ impl Machine {
         self.machine_st.fail = true;
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(target_arch = "wasm32", not(feature = "hostname")))]
     pub(crate) fn current_hostname(&mut self) {
         unimplemented!()
     }


### PR DESCRIPTION
On current `master`, if we compile without the `hostname` feature there is a compiler error (unless the target is Wasm). This fixes it. In particular, this allows compiling Scryer Prolog with `--no-default-features`.