### PR TITLE
Warnings collection.

### DIFF
--- a/src/lib/warnings.pl
+++ b/src/lib/warnings.pl
@@ -1,0 +1,37 @@
+:- module(warnings, []).
+
+:- use_module(library(lists)).
+:- use_module(library(format)).
+
+%% warnings:output(+OutputStream).
+%
+% If defined – use `OutputStream` (eg. user_output) instead of standard error
+% for message output.
+%
+:- dynamic(output_stream/1).
+
+output(OutputStream) :- output_stream(OutputStream), !.
+output(user_error).
+
+builtin((_;_)).
+builtin((_,_)).
+builtin((_->_)).
+
+% Warn about builtin predicates re-definition. It can happen by mistake for
+% example:
+%     x :- a. b, c.
+%
+user:term_expansion(G, _) :-
+    nonvar(G),
+    builtin(G),
+    functor(G, O, 2),
+    warn("(~q) attempts to re-define ~w", [G, O/2]).
+
+warn(Format, Vars) :-
+    output(S),
+    prolog_load_context(file, F),
+    prolog_load_context(term_position, position_and_lines_read(_,L)),
+    append(["% Warning: ", Format, " at line ~d of ~a~n"], FullFormat),
+    append(Vars, [L,F], AllVars),
+    format(S, FullFormat, AllVars),
+    false.


### PR DESCRIPTION
After recent discussion #2599, I've decided to start collecting useful warnings that can be applied during compilation. If you have good ideas for warnings, please post them here.

Relevant issues: #2600 #2601.

If you want to test, just import `warnings` module:

```prolog
:- use_module(library(warnings)).
```

And that's all.