### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 # See https://github.com/LukeMathWalker/cargo-chef
-ARG RUST_VERSION=1-buster
-FROM rust:${RUST_VERSION} as planner
+ARG DEBIAN_RELEASE=bookworm
+ARG RUST_VERSION=1-${DEBIAN_RELEASE}
+FROM rust:${RUST_VERSION} AS planner
 WORKDIR /scryer-prolog
 RUN cargo install cargo-chef 
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM rust:${RUST_VERSION} as cacher
+FROM rust:${RUST_VERSION} AS cacher
 WORKDIR /scryer-prolog
 RUN cargo install cargo-chef
 COPY --from=planner /scryer-prolog/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
-FROM rust:${RUST_VERSION} as builder
+FROM rust:${RUST_VERSION} AS builder
 WORKDIR /scryer-prolog
 COPY . .
 # Copy over the cached dependencies
@@ -20,9 +21,11 @@ COPY --from=cacher /scryer-prolog/target target
 COPY --from=cacher $CARGO_HOME $CARGO_HOME
 RUN cargo build --release --bin scryer-prolog
 
-# Newer versions of Debian (i.e. bookworm) contain libssl3 instead of libssl1.1 
-# which we depend on.
-FROM debian:bullseye-slim
+FROM debian:${DEBIAN_RELEASE}-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssl \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /scryer-prolog/target/release/scryer-prolog /usr/local/bin
 ENV RUST_BACKTRACE=1
 # Sanity check the binary: if it can't be executed (e.g. if there are missing libraries) 


### PR DESCRIPTION
Partially resolves #2646 

Dockerfile now uses consistent Debian versions across the builder and the executable images, hopefully preventing libssl issues like the one in #2013.

We can now use Debian Bookworm as the base as opposed to Debian Bullseye. Bullseye [reached end-of-life on  2024-08-14](https://www.debian.org/releases/).

Doesn't resolve the ask to keep previous versions up to date as well, but I don't think the project has the capacity to support a complex process like that right now...