### PR TITLE
toplevel.pl: fix arity mismatch in read_input/2

### DIFF
--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -357,17 +357,17 @@ read_input(LeafAnswer, Stop) :-
           nl,
           write('   '),
           write_leaf_answer(LeafAnswer, [depth(deep)]),
-          read_input(LeafAnswer)
+          read_input(LeafAnswer, Stop)
        ;  C = p ->
           nl,
           write('   '),
           write_leaf_answer(LeafAnswer, [depth(shallow)]),
-          read_input(LeafAnswer)
+          read_input(LeafAnswer, Stop)
        ;  member(C, [';', ' ', n]) ->
           nl, write(';  ')
        ;  C = h ->
           help_message,
-          read_input(LeafAnswer)
+          read_input(LeafAnswer, Stop)
        ;  C = a ->
           bb_put('$report_all', true),
           nl, write(';  ')
@@ -376,7 +376,7 @@ read_input(LeafAnswer, Stop) :-
           More is 5 - Count mod 5,
           bb_put('$report_n_more', More),
           nl, write(';  ')
-       ;  read_input(LeafAnswer)
+       ;  read_input(LeafAnswer, Stop)
        )
     ).
 

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -352,32 +352,33 @@ read_input(LeafAnswer, Stop) :-
     (  member(C, ['\n', .]) ->
        nl, write(';  ... .'), nl,
        Stop = stop
-    ;  (  C = w ->
-          nl,
-          write('   '),
-          write_leaf_answer(LeafAnswer, [depth(deep)]),
-          read_input(LeafAnswer, Stop)
-       ;  C = p ->
-          nl,
-          write('   '),
-          write_leaf_answer(LeafAnswer, [depth(shallow)]),
-          read_input(LeafAnswer, Stop)
-       ;  member(C, [';', ' ', n]) ->
-          Stop = continue,
-          nl, write(';  ')
-       ;  C = h ->
-          help_message,
-          read_input(LeafAnswer, Stop)
-       ;  C = a ->
-          bb_put('$report_all', true),
-          nl, write(';  ')
-       ;  C = f ->
-          bb_get('$answer_count', Count),
-          More is 5 - Count mod 5,
-          bb_put('$report_n_more', More),
-          nl, write(';  ')
-       ;  read_input(LeafAnswer, Stop)
-       )
+    ;  C = w ->
+       nl,
+       write('   '),
+       write_leaf_answer(LeafAnswer, [depth(deep)]),
+       read_input(LeafAnswer, Stop)
+    ;  C = p ->
+       nl,
+       write('   '),
+       write_leaf_answer(LeafAnswer, [depth(shallow)]),
+       read_input(LeafAnswer, Stop)
+    ;  member(C, [';', ' ', n]) ->
+       nl, write(';  '),
+       Stop = continue
+    ;  C = h ->
+       help_message,
+       read_input(LeafAnswer, Stop)
+    ;  C = a ->
+       bb_put('$report_all', true),
+       nl, write(';  '),
+       Stop = continue
+    ;  C = f ->
+       bb_get('$answer_count', Count),
+       More is 5 - Count mod 5,
+       bb_put('$report_n_more', More),
+       nl, write(';  '),
+       Stop = continue
+    ;  read_input(LeafAnswer, Stop)
     ).
 
 needs_bracketing(Value, Op) :-

--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -352,8 +352,7 @@ read_input(LeafAnswer, Stop) :-
     (  member(C, ['\n', .]) ->
        nl, write(';  ... .'), nl,
        Stop = stop
-    ;  Stop = continue,
-       (  C = w ->
+    ;  (  C = w ->
           nl,
           write('   '),
           write_leaf_answer(LeafAnswer, [depth(deep)]),
@@ -364,6 +363,7 @@ read_input(LeafAnswer, Stop) :-
           write_leaf_answer(LeafAnswer, [depth(shallow)]),
           read_input(LeafAnswer, Stop)
        ;  member(C, [';', ' ', n]) ->
+          Stop = continue,
           nl, write(';  ')
        ;  C = h ->
           help_message,


### PR DESCRIPTION
I ran into the same problem today and I figured I'd take a stab at it. Unfortunately, I'm not certain it is the right approach, but it no longer errors like it did before.

Fixes #2650.