### PR TITLE
Fine-grained multifile interfaces proposal

### DIFF
--- a/src/lib/interfaces.pl
+++ b/src/lib/interfaces.pl
@@ -1,0 +1,29 @@
+:- module(interfaces, []).
+:- use_module(library(format)).
+:- use_module(library(pio)).
+
+warn(Format, Vars) :-
+    warn(user_error, Format, Vars).
+warn(Stream, Format, Vars) :-
+    prolog_load_context(file, File),
+    prolog_load_context(term_position, position_and_lines_read(_,Line)),
+    phrase_to_stream(
+        (
+            "% Warning: ", format_(Format,Vars), format_(" at line ~d of ~a~n",[Line,File])
+        ),
+        Stream
+    ).
+
+
+user:term_expansion((H :- 0), interface(H)) :-
+    predicate_property(H, multifile).
+
+user:term_expansion((M:H :- B), _) :-
+    nonvar(B),
+    B \= 0,
+    \+ M:interface(H),
+    functor(H, F, A),
+    functor(J, F, A),
+    findall(J, M:interface(J), [Jh|Js]),
+    warn("Head ~q doesn\'t unify with any of ~q", [H, [Jh|Js]]),
+    false.

--- a/src/tests/interface/a.pl
+++ b/src/tests/interface/a.pl
@@ -1,0 +1,9 @@
+:- module(a, [
+    hello/2
+]).
+
+:- use_module(library(interfaces)).
+
+:- multifile(hello/2).
+
+hello(a, _) :- 0.

--- a/src/tests/interface/test.pl
+++ b/src/tests/interface/test.pl
@@ -1,0 +1,9 @@
+:- use_module(a).
+
+:- multifile(a:hello/2).
+
+a:hello(a, X) :- X = 1.
+a:hello(a, X) :- X = 2.
+a:hello(b, X) :- X = 3.
+a:hello(a, X) :- X = 4.
+a:hella(a, X) :- X = 4.

--- a/tests/scryer/cli/src_tests/interface_tests.stderr
+++ b/tests/scryer/cli/src_tests/interface_tests.stderr
@@ -1,0 +1,1 @@
+% Warning: Head hello(b,A) doesn't unify with any of [hello(a,B)] at line 7 of test.pl

--- a/tests/scryer/cli/src_tests/interface_tests.toml
+++ b/tests/scryer/cli/src_tests/interface_tests.toml
@@ -1,0 +1,6 @@
+args = [
+    "-f",
+    "--no-add-history",
+    "-g", "halt",
+    "src/tests/interface/test.pl"
+]


### PR DESCRIPTION
Recently I was thinking what if I have a module that defines a multifile predicate, but I want some level of control on how it can be extended. For example I may want to allow heads of new definitions only when they are unifiable with my template.

Let's say I have the following predicate in my module:
```prolog
:- module(greeting, [hello/2]).
:- multifile(hello/2).
hello(admin, "Hello admin").
```
I want others to import my module and being ably to add their own `hello/2`, but with additional constraint: I want to restrict them to greet only `user` and not admin or anything else. So the following (new) clause should be allowed `greeting:hello(user, "Hi")`, but `greeting:hello(root, "Hi")` – shouldn't.

In my proposal you need to define an "interface":
```prolog
hello(user, _) :- 0.
```

Which will be replaced during term expansion with a special predicate that will validate other clauses.

I'm open for comments and opinions.