### PR TITLE
Ignore `KeyEventKind::Release` events when reading a char

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -68,7 +68,7 @@ use cpu_time::ProcessTime;
 use std::time::{Duration, SystemTime};
 
 #[cfg(feature = "repl")]
-use crossterm::event::{read, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{read, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 #[cfg(feature = "repl")]
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 
@@ -111,12 +111,14 @@ pub(crate) fn get_key() -> KeyEvent {
     loop {
         let key_ = read();
         if let Ok(Event::Key(key_)) = key_ {
-            match key_.code {
-                KeyCode::Char(_) | KeyCode::Enter | KeyCode::Tab => {
-                    key = key_;
-                    break;
+            if key_.kind != KeyEventKind::Release {
+                match key_.code {
+                    KeyCode::Char(_) | KeyCode::Enter | KeyCode::Tab => {
+                        key = key_;
+                        break;
+                    }
+                    _ => (),
                 }
-                _ => (),
             }
         }
     }


### PR DESCRIPTION
Windows sends `KeyEventKind::Release` events, and Linux does not. This resulted in a release of `\n` being interpreted as a `\n` on Windows and preventing the user from getting more than one answer at the toplevel.

Closes #2672 
