### PR TITLE
Adjust format_//2 name in documentation comment

### DIFF
--- a/src/lib/format.pl
+++ b/src/lib/format.pl
@@ -28,7 +28,7 @@
 :- use_module(library(between)).
 :- use_module(library(pio)).
 
-%% format_(+FormatString, +Arguments)//
+%% format_/(+FormatString, +Arguments)
 %
 % Usage:
 %


### PR DESCRIPTION
I think this makes the name in the docstring consistent w/the way other predicates' names show up.