### PR TITLE
Support hermetic build environment

### DIFF
--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -1,4 +1,4 @@
-:- module('$toplevel', []).
+:- module('$toplevel', [repl/0]).
 
 :- use_module(library(charsio)).
 :- use_module(library(error)).


### PR DESCRIPTION
In order to support hermetic build tools like bazel, I had to resolve the lib path when compiling the libraries.rs instead of baking the absolute path from the build/main.rs file. Bazel will create a temporary sandbox to compile and execute the build script and a different sandbox to compile the resulting code.

Bonus (should be a separate PR):

The function `Machine::run_module_predicate` is now private to the crate so we can't do the following anymore:

1. Create a custom Machine
2. Load additional modules
3. Run the repl on the pre-configured machine.

So by exporting the repl atom, we can replace this code in 0.9.4

```
let mut wam = Machine::new(MachineConfig::default());

wam.load_module_string("customlib", include_str!("customlib.pl").to_string());
wam.run_module_predicate(atom!("$toplevel"), (atom!("repl"), 0))
```

with

```
let mut wam = Machine::new(MachineConfig::default());

wam.load_module_string("customlib", include_str!("customlib.pl").to_string());
wam.run_query("use_module(library('$toplevel')), repl.".to_string())?;
```