### PR TITLE
Documentation for read/2

### DIFF
--- a/src/lib/builtins.pl
+++ b/src/lib/builtins.pl
@@ -768,8 +768,7 @@ read(Term) :-
 
 %% read(+Stream, -Term).
 %
-% Read Term from the stream Stream with default options. **NOTE** This is not a general predicate
-% to read input from a file or the user. Use other predicates like `phrase_from_file/2` for that.
+% Same as read_term/3 with all default options.
 read(Stream, Term) :-
     read_term(Stream, Term, []).
 

--- a/src/lib/builtins.pl
+++ b/src/lib/builtins.pl
@@ -766,6 +766,10 @@ read(Term) :-
     read_term(Stream, Term, []).
     % read(Stream, Term).
 
+%% read(+Stream, -Term).
+%
+% Read Term from the stream Stream with default options. **NOTE** This is not a general predicate
+% to read input from a file or the user. Use other predicates like `phrase_from_file/2` for that.
 read(Stream, Term) :-
     read_term(Stream, Term, []).
 


### PR DESCRIPTION
Mirrored the wording in the docstrings for `read/1` and `read_term/3`.