### PR TITLE
More explicit warning for lambda not shadowing.

### DIFF
--- a/src/lib/lambda.pl
+++ b/src/lib/lambda.pl
@@ -67,7 +67,8 @@ Free contains variables that are valid outside the scope of the lambda
 expression. They are thus free variables within.
 
 All other variables of Goal are considered local variables. They must
-not appear outside the lambda expression. This restriction is
+not appear outside the lambda expression, as lambda does not introduce 
+a new scope or shadow existing bindings. This restriction is
 currently not checked. Violations may lead to unexpected bindings.
 
 In the following example the parentheses around X>3 are necessary.


### PR DESCRIPTION
Is there cause for adding this text to the lambda documentation? 

From the current text, I was prepared for unchecked accidental capture outside the intended scope when a binder from the lambda was referred to outside the lambda's body.

Even after reading, I still _hadn't_ (and perhaps I should have!) expected bound occurrences inside the body and bound occurrences outside the body to unify. 

```
:- use_module(library(lambda)).
:- use_module(library(clpz)).

gt(F, [N]) :- call(F, N).

def1(X,Z) :- gt(\Y^(3 #> #(Y)), X), Z = Y.
def2(Y) :- gt(\Y^(3 #> #(Y)), Y).
```

```
$ scryer-prolog -f
?- [temp].
   true.
?- def1(A,B). %% surprising but explainable
   A = [_A], clpz:(_A in inf..2).
?- def2(A). %% hadn't expected.
   error(type_error(integer,[_84]),must_be/2).
?-
```



