### PR TITLE
prevent accidental amalgamation of graphic token chars in output

### DIFF
--- a/src/lib/format.pl
+++ b/src/lib/format.pl
@@ -593,7 +593,15 @@ portray_clause_(Term) -->
 
 literal(Lit, VNs) -->
         { write_term_to_chars(Lit, [quoted(true),variable_names(VNs),double_quotes(true)], Ls) },
-        seq(Ls).
+        (   { nonvar(Lit),
+              functor(Lit, F, A),
+              current_op(Pri, _, F),
+              (   A =:= 0
+              ;   Pri >= 1000
+              ) } ->
+            "(", seq(Ls), ")"
+        ;   seq(Ls)
+        ).
 
 literal_(Lit, VNs) -->
         { phrase(literal(Lit, VNs), Ls) },

--- a/src/lib/format.pl
+++ b/src/lib/format.pl
@@ -595,6 +595,14 @@ literal(Lit, VNs) -->
         { write_term_to_chars(Lit, [quoted(true),variable_names(VNs),double_quotes(true)], Ls) },
         seq(Ls).
 
+literal_(Lit, VNs) -->
+        { phrase(literal(Lit, VNs), Ls) },
+        seq(Ls),
+        (   { phrase((...,[Last]), Ls), char_type(Last, graphic_token) } ->
+            " "
+        ;   ""
+        ).
+
 portray_(Var, VNs) --> { var(Var) }, !, literal(Var, VNs).
 portray_((Head :- Body), VNs) --> !,
         literal(Head, VNs), " :-\n",
@@ -602,7 +610,7 @@ portray_((Head :- Body), VNs) --> !,
 portray_((Head --> Body), VNs) --> !,
         literal(Head, VNs), " -->\n",
         body_(Body, 0, 3, VNs).
-portray_(Any, VNs) --> literal(Any, VNs).
+portray_(Any, VNs) --> literal_(Any, VNs).
 
 
 body_(Var, C, I, VNs) --> { var(Var) }, !,
@@ -627,7 +635,7 @@ body_((A;B), C, I, VNs) --> !,
         body_(A, C1, C1, VNs), "\n",
         else_branch(B, I, VNs).
 body_(Goal, C, I, VNs) -->
-        indent_to(C, I), literal(Goal, VNs).
+        indent_to(C, I), literal_(Goal, VNs).
 
 
 % True iff Body has the shape ( If -> Then ; Else ).


### PR DESCRIPTION
This addresses #2713. Many thanks to @notoria for reporting this excellent case!

Example:

    ?- portray_clause(A = @).
    A= @ .
       true.

At other positions the now inserted space is unnecessary, as in:

    ?- portray_clause((head:- @,b)).
    head :-
       @ ,
       b.
       true.

The toplevel has a similar issue:

    ?- C = # ; false.
       C = # |<-- cursor is here; redundant space after #

There may be a way to solve this issue for all cases like this.