### PR TITLE
Experiment with a macro system inspired by KL1 language.

### DIFF
--- a/src/lib/goals.pl
+++ b/src/lib/goals.pl
@@ -1,0 +1,34 @@
+:- module(goals, [
+        call_unifiers/2,
+        expand_subgoals/3
+]).
+
+:- use_module(library(lists), [maplist/3,maplist/4]).
+:- use_module(library(loader), [expand_goal/3]).
+:- use_module(library(lambda)).
+
+:- meta_predicate(call_unifiers(0, ?)).
+
+%% call_unifiers(?G_0, -Us).
+%
+% `Us` is a list of unifiers that are equivalent to calling G_0.
+call_unifiers(G_0, Us) :-
+    term_variables(G_0, GVs),
+    copy_term(G_0/GVs, H_0/HVs),
+    H_0,
+    maplist(_+\A^B^(A=B)^true, GVs, HVs, Us).
+
+
+%% expand_sub_goals(?M, ?A, -X).
+%
+% Similar to expand_goal/3, but recursively tries to expand every sub-term.
+% TODO: Try to make it more generic, don't rely on (#)/2.
+expand_subgoals(M, A, X) :-
+    nonvar(A) ->
+        (   functor(A, (#), 2) ->
+            expand_goal(A, M, X)
+        ;   A =.. [F|Args],
+            maplist(expand_subgoals(M), Args, XArgs),
+            X =.. [F|XArgs]
+        )
+    ;   A = X.

--- a/src/lib/goals.pl
+++ b/src/lib/goals.pl
@@ -22,7 +22,9 @@ call_unifiers(G_0, Us) :-
 %% expand_sub_goals(?M, ?A, -X).
 %
 % Similar to expand_goal/3, but recursively tries to expand every sub-term.
+%
 % TODO: Try to make it more generic, don't rely on (#)/2.
+% FIXME: Using expand_goal/2  may be quite unpredictable, consider using something else.
 expand_subgoals(M, A, X) :-
     nonvar(A) ->
         (   functor(A, (#), 2) ->

--- a/src/lib/macros.pl
+++ b/src/lib/macros.pl
@@ -5,8 +5,9 @@
 ]).
 
 :- use_module(library(si), [atomic_si/1]).
-:- use_module(library(lists), [maplist/3]).
 :- use_module(library(error), [instantiation_error/1]).
+:- use_module(library(loader), [prolog_load_context/2]).
+:- use_module(library(goals), [call_unifiers/2,expand_subgoals/3]).
 
 :- discontiguous(macro/3).
 :- multifile(macro/3).
@@ -18,6 +19,7 @@ user:term_expansion((M#A ==> B),  macros:macro(M, A, B)      ).
 % Capturing erroneous expansions.
 % It slows down expansion, but it will produce (more) meaningful error if some
 % user macro happens to be poorly written.
+% IMPORTANT: Must be the first macro definition seen by compiler
 M#A ==> _  :-
     (var(M); var(A)), instantiation_error(M#A).
 
@@ -38,8 +40,14 @@ quote#_   ==> _ :- !, false.
 
 % Compile time computation: Inline last argument
 inline_last#G ==> [X] :-
-    loader:load_context(M),
+    load_module_context(M),
     M:call(G, X).
+
+
+% Evaluates G and if it succeeds replaces it with solutions.
+compile#G ==> Us :-
+    load_module_context(M),
+    call_unifiers(M:G, Us).
 
 
 % Sub-goal expansion
@@ -47,18 +55,8 @@ expand#A ==> X :-
     expand_subgoals(_, A, X).
 
 
-%% expand_sub_goals(?M, ?A, -X).
-%
-% Similar to expand_goal/3, but recursively tries to expand every sub-term.
-expand_subgoals(M, A, X) :-
-    nonvar(A) ->
-        (   functor(A, (#), 2) ->
-            expand_goal(A, M, X)
-        ;   A =.. [F|Args],
-            maplist(expand_subgoals(M), Args, XArgs),
-            X =.. [F|XArgs]
-        )
-    ;   A = X.
+load_module_context(Module) :- prolog_load_context(module, Module), !.
+load_module_context(user).
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/lib/macros.pl
+++ b/src/lib/macros.pl
@@ -12,8 +12,11 @@
 :- discontiguous(macro/3).
 :- multifile(macro/3).
 
-user:term_expansion((M#A ==> B), (macros:macro(M, A, H) :- G)) :- nonvar(B), B = (H :- G).
-user:term_expansion((M#A ==> B),  macros:macro(M, A, B)      ).
+user:term_expansion((M#A ==> B), X) :-
+    nonvar(B),
+    B = (H :- G) ->
+        X = (macros:macro(M, A, H) :- G)
+    ;   X =  macros:macro(M, A, B).
 
 
 % Capturing erroneous expansions.

--- a/src/lib/macros.pl
+++ b/src/lib/macros.pl
@@ -60,5 +60,6 @@ macro_wrapper(M, A, _) :-
 
 user:goal_expansion(M#A, X) :-
     atomic_si(M),
-    when_si(nonvar(A), true),
-    macro_wrapper(M, A, X).
+    when_si(nonvar(A),
+        macro_wrapper(M, A, X)
+    ).

--- a/src/lib/macros.pl
+++ b/src/lib/macros.pl
@@ -1,16 +1,25 @@
 :- module(macros, [
-    op(199, xfx, (#)),
+    op(199, xfy, (#)),
     op(1200, xfy, (==>)),
     macro/3
 ]).
 
 :- use_module(library(si), [atomic_si/1]).
+:- use_module(library(lists), [maplist/3]).
+:- use_module(library(error), [instantiation_error/1]).
 
 :- discontiguous(macro/3).
 :- multifile(macro/3).
 
-user:term_expansion((M#A ==> H :- G), (macros:macro(M, A, H) :- G)).
-user:term_expansion((M#A ==> B     ),  macros:macro(M, A, B)      ).
+user:term_expansion((M#A ==> B), (macros:macro(M, A, H) :- G)) :- nonvar(B), B = (H :- G).
+user:term_expansion((M#A ==> B),  macros:macro(M, A, B)      ).
+
+
+% Capturing erroneous expansions.
+% It slows down expansion, but it will produce (more) meaningful error if some
+% user macro happens to be poorly written.
+M#A ==> _  :-
+    (var(M); var(A)), instantiation_error(M#A).
 
 % Basic
 M#(A,B)  ==> M#A, M#B.
@@ -20,10 +29,37 @@ M#(\+ A) ==> \+ M#A.
 M#{A}    ==> {M#A}.
 _#!      ==> !.
 
+
+% Controlling macro expansion.
+% Any unrecognized macro will be left as it were, but by using quote you can
+% be sure that no other macro definition will be invoked
+quote#_   ==> _ :- !, false.
+
+
 % Compile time computation: Inline last argument
 inline_last#G ==> [X] :-
     loader:load_context(M),
     M:call(G, X).
+
+
+% Sub-goal expansion
+expand#A ==> X :-
+    expand_subgoals(_, A, X).
+
+
+%% expand_sub_goals(?M, ?A, -X).
+%
+% Similar to expand_goal/3, but recursively tries to expand every sub-term.
+expand_subgoals(M, A, X) :-
+    nonvar(A) ->
+        (   functor(A, (#), 2) ->
+            expand_goal(A, M, X)
+        ;   A =.. [F|Args],
+            maplist(expand_subgoals(M), Args, XArgs),
+            X =.. [F|XArgs]
+        )
+    ;   A = X.
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -31,5 +67,3 @@ user:goal_expansion(M#A, X) :-
     atomic_si(M),
     nonvar(A),
     macro(M, A, X).
-
-:- use_module(library(subterm_expansion)).

--- a/src/lib/macros.pl
+++ b/src/lib/macros.pl
@@ -1,0 +1,35 @@
+:- module(macros, [
+    op(199, xfx, (#)),
+    op(1200, xfy, (==>)),
+    macro/3
+]).
+
+:- use_module(library(si), [atomic_si/1]).
+
+:- discontiguous(macro/3).
+:- multifile(macro/3).
+
+user:term_expansion((M#A ==> H :- G), (macros:macro(M, A, H) :- G)).
+user:term_expansion((M#A ==> B     ),  macros:macro(M, A, B)      ).
+
+% Basic
+M#(A,B)  ==> M#A, M#B.
+M#(A;B)  ==> M#A; M#B.
+M#(A->B) ==> M#A -> M#B.
+M#(\+ A) ==> \+ M#A.
+M#{A}    ==> {M#A}.
+_#!      ==> !.
+
+% Compile time computation: Inline last argument
+inline_last#G ==> [X] :-
+    loader:load_context(M),
+    M:call(G, X).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+user:goal_expansion(M#A, X) :-
+    atomic_si(M),
+    nonvar(A),
+    macro(M, A, X).
+
+:- use_module(library(subterm_expansion)).

--- a/src/lib/string_macros.pl
+++ b/src/lib/string_macros.pl
@@ -1,0 +1,20 @@
+:- module(string_macros, [
+    macro/3
+]).
+
+:- use_module(library(si), [list_si/1]).
+:- use_module(library(crypto), [hex_bytes/2]).
+:- use_module(library(macros)).
+
+% Base conversion
+16#H ==> [B] :- list_si(H), hex_bytes(H, B).
+
+% String enums
+tel#null ==> 16#"00".
+tel#bell ==> 16#"07".
+tel#bs   ==> 16#"08".
+tel#ht   ==> 16#"09".
+tel#lf   ==> 16#"0a".
+tel#vt   ==> 16#"0b".
+tel#ff   ==> 16#"0c".
+tel#cr   ==> 16#"0d".

--- a/src/lib/string_macros.pl
+++ b/src/lib/string_macros.pl
@@ -1,3 +1,10 @@
+/** Commonly useful string macros
+ *
+ *  TODO: Add more base conversions
+ *  TODO: Add enum for every common ASCII name
+ */
+
+
 :- module(string_macros, [
     macro/3
 ]).
@@ -6,10 +13,10 @@
 :- use_module(library(crypto), [hex_bytes/2]).
 :- use_module(library(macros)).
 
-% Base conversion
+% Base conversion on on numeric strings
 16#H ==> [B] :- list_si(H), hex_bytes(H, B).
 
-% String enums
+% Common ASCII characters
 tel#null ==> 16#"00".
 tel#bell ==> 16#"07".
 tel#bs   ==> 16#"08".

--- a/src/lib/subterm_expansion.pl
+++ b/src/lib/subterm_expansion.pl
@@ -1,0 +1,9 @@
+:- module(subterm_expansion, []).
+
+:- use_module(library(macros)).
+
+% Workaround for lacking subterm substitution
+user:goal_expansion(foo(M#A), foo(X)) :-
+    expand_goal(M#A, _, X).
+user:goal_expansion(X = (M#B), X = Y) :-
+    expand_goal(M#B, _, Y).

--- a/src/lib/subterm_expansion.pl
+++ b/src/lib/subterm_expansion.pl
@@ -1,9 +1,0 @@
-:- module(subterm_expansion, []).
-
-:- use_module(library(macros)).
-
-% Workaround for lacking subterm substitution
-user:goal_expansion(foo(M#A), foo(X)) :-
-    expand_goal(M#A, _, X).
-user:goal_expansion(X = (M#B), X = Y) :-
-    expand_goal(M#B, _, Y).

--- a/src/lib/warnings.pl
+++ b/src/lib/warnings.pl
@@ -1,0 +1,19 @@
+:- module(warnings, [
+    warn/2,
+    warn/3
+]).
+
+:- use_module(library(format)).
+:- use_module(library(pio)).
+
+warn(Format, Vars) :-
+    warn(user_error, Format, Vars).
+warn(Stream, Format, Vars) :-
+    prolog_load_context(file, File),
+    prolog_load_context(term_position, position_and_lines_read(_,Line)),
+    phrase_to_stream(
+        (
+            "% Warning: ", format_(Format,Vars), format_(" at line ~d of ~a~n",[Line,File])
+        ),
+        Stream
+    ).

--- a/src/lib/warnings.pl
+++ b/src/lib/warnings.pl
@@ -6,8 +6,17 @@
 :- use_module(library(format)).
 :- use_module(library(pio)).
 
+%% warn(+Format, ?Vars).
+%
+% Same as warn/3 using default user_error stream.
 warn(Format, Vars) :-
     warn(user_error, Format, Vars).
+
+
+%% warn(+Stream, +Format, ?Vars).
+%
+% Print a warning message to Stream. Predicate is provided for uniformity of
+% warning messages throughout the codebase.
 warn(Stream, Format, Vars) :-
     prolog_load_context(file, File),
     prolog_load_context(term_position, position_and_lines_read(_,Line)),

--- a/src/tests/macros.pl
+++ b/src/tests/macros.pl
@@ -6,8 +6,6 @@
 :- use_module(library(macros)).
 :- use_module(library(clpz)).
 
-clpz:monotonic.
-
 % Numeric enums
 fep#window                  ==> 100.
     fep#create              ==> 101.

--- a/src/tests/macros.pl
+++ b/src/tests/macros.pl
@@ -23,9 +23,10 @@ string_num.
 bignum#(A < B) ==> N :-
     string_num -> N = bignum_lt(A,B); N = (A < B).
 bignum#(A > B) ==> N :-
-    \+string_num -> N = bignum_gt(A,B); N = (A > B).
+    \+string_num -> N = (A > B); N = bignum_gt(A,B).
 
-
+% Should bad macro bodies generate exceptions? If so at which point: expansion
+% time, compile time or runtime?
 bad#macro ==> 1 :- _.
 
 % TODO: Should implementation detect discontiguous macro definitions?
@@ -80,6 +81,7 @@ example(doesnt_expand_uninstantiated_macros(X)) :-
     ).
 example(compilation([A,B,C])) :-
     compile#baz(12, A, B, C).
+% What is a prefere operator precedence? Should parenthesis be required?
 example(modules(L)) :-
     compile#(lists:length(L, 5)).
 example(clpz_operators_compatibility(X,Y)) :-
@@ -91,10 +93,20 @@ example(unknown_macros) :-
     foo#bar,
     foo#fep#window. % <- Should it expand fep#window if foo is unknown?
 example(incorrect_macros) :-
-    b(a)#x,
+    b(a)#x, % <- Is it a good idea to support any ground term as a macro name?
     b(_)#x,
     _#t,
     fep#_.
-% Future tests:
-% a(b#c)#d - Should it expand b#c?
-% a#b#c#d - In which order macros should be epxanded?
+example(tbd) :-
+    a(b#c)#d, % <- Should it expand b#c? if b/0 and a/1 are registered macros?
+    a#b#c#d. % <- In which order macros should be epxanded?
+
+% Should macros be expanded in clauses heads?
+example(macro_in_heads(16#"ABCD")).
+
+% Should it be possible to rename predicate name using macros?
+(my_macro#example(macro_names)) :-
+    write('Hello'), nl.
+
+% Should it be possible to expand whole clauses in-place?
+my_macro#(my_example(X) :- hello(X)).

--- a/src/tests/macros.pl
+++ b/src/tests/macros.pl
@@ -25,6 +25,9 @@ bignum#(A < B) ==> N :-
 bignum#(A > B) ==> N :-
     \+string_num -> N = bignum_gt(A,B); N = (A > B).
 
+
+bad#macro ==> 1 :- _.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Test functions
@@ -80,3 +83,7 @@ example(clpz_operators_compatibility(X,Y)) :-
     expand#(
         #X #= #Y * inline_last#double(4)
     ).
+example(unknown_macros) :-
+    fep#hello,
+    foo#bar,
+    foo#fep#window.

--- a/src/tests/macros.pl
+++ b/src/tests/macros.pl
@@ -4,6 +4,9 @@
 
 :- use_module(library(string_macros)).
 :- use_module(library(macros)).
+:- use_module(library(clpz)).
+
+clpz:monotonic.
 
 % Numeric enums
 fep#window                  ==> 100.
@@ -16,11 +19,11 @@ fep#window                  ==> 100.
         fep#beep            ==> 113.
 
 % Conditional compilation
-%string_num.
+string_num.
 bignum#(A < B) ==> N :-
-    catch(string_num, _, false) -> N = bignum_lt(A,B); N = (A < B).
+    string_num -> N = bignum_lt(A,B); N = (A < B).
 bignum#(A > B) ==> N :-
-    catch(string_num, _, false) -> N = bignum_gt(A,B); N = (A > B).
+    \+string_num -> N = bignum_gt(A,B); N = (A > B).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -71,3 +74,9 @@ example(doesnt_expand_uninstantiated_macros(X)) :-
     ).
 example(compilation([A,B,C])) :-
     compile#baz(12, A, B, C).
+example(modules(L)) :-
+    compile#(lists:length(L, 5)).
+example(clpz_operators_compatibility(X,Y)) :-
+    expand#(
+        #X #= #Y * inline_last#double(4)
+    ).

--- a/src/tests/macros.pl
+++ b/src/tests/macros.pl
@@ -24,7 +24,10 @@ bignum#(A > B) ==> N :-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% Test functions
 double(A, B) :- B is 2 * A.
+baz(A, B, C, D) :- B is 2 * A, C is 3 * A, D is 3 * B.
+
 
 :- dynamic(example/1).
 example(formated_string(X)) :-
@@ -66,3 +69,5 @@ example(doesnt_expand_uninstantiated_macros(X)) :-
     expand#(
         _ = fep#X
     ).
+example(compilation([A,B,C])) :-
+    compile#baz(12, A, B, C).

--- a/src/tests/macros.pl
+++ b/src/tests/macros.pl
@@ -24,9 +24,13 @@ bignum#(A > B) ==> N :-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+double(A, B) :- B is 2 * A.
+
 :- dynamic(example/1).
 example(formated_string(X)) :-
-    X = inline_last#(\L^phrase(format_("This is my term ~w", [foo(1)]), L)).
+    expand#(
+        X = inline_last#(\L^phrase(format_("This is my term ~w", [foo(1)]), L))
+    ).
 example(bignum_example(A,B,P)) :-
     bignum#(
         A < B,
@@ -36,10 +40,29 @@ example(bignum_example(A,B,P)) :-
     ),
     compute(A,B).
 example(numeric_enum_example) :-
-    foo(fep#create).
+    expand#(
+        foo(fep#window, fep#create),
+        bar([fep#getl, fep#putb|_])
+    ).
 example(ascii_examples) :-
-    foo(tel#null),
-    foo(tel#bell),
-    foo(tel#bs).
+    expand#(
+        foo(tel#null) -> foo(tel#bell); foo(tel#bs)
+    ).
 example(base_conversion) :-
-    foo(16#"ABCDEF01234560").
+    expand#(
+        foo(16#"ABCDEF01234560")
+    ).
+example(quotated_goals_are_not_expanded(A)) :-
+    quote#(bignum#(A<2)).
+example(quotation_works_in_nested_terms(A)) :-
+    expand#(
+        A = [fep#putb,_,quote#fep#putb]
+    ).
+example(expands_arithmetic_functions(A,B)) :-
+    expand#(
+        B is A + fep#beep / inline_last#double(12)
+    ).
+example(doesnt_expand_uninstantiated_macros(X)) :-
+    expand#(
+        _ = fep#X
+    ).

--- a/src/tests/macros.pl
+++ b/src/tests/macros.pl
@@ -28,6 +28,9 @@ bignum#(A > B) ==> N :-
 
 bad#macro ==> 1 :- _.
 
+% TODO: Should implementation detect discontiguous macro definitions?
+fep#too_late ==> 999.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Test functions
@@ -86,4 +89,12 @@ example(clpz_operators_compatibility(X,Y)) :-
 example(unknown_macros) :-
     fep#hello,
     foo#bar,
-    foo#fep#window.
+    foo#fep#window. % <- Should it expand fep#window if foo is unknown?
+example(incorrect_macros) :-
+    b(a)#x,
+    b(_)#x,
+    _#t,
+    fep#_.
+% Future tests:
+% a(b#c)#d - Should it expand b#c?
+% a#b#c#d - In which order macros should be epxanded?

--- a/src/tests/macros.pl
+++ b/src/tests/macros.pl
@@ -1,0 +1,45 @@
+:- use_module(library(format)).
+:- use_module(library(dcgs)).
+:- use_module(library(lambda)).
+
+:- use_module(library(string_macros)).
+:- use_module(library(macros)).
+
+% Numeric enums
+fep#window                  ==> 100.
+    fep#create              ==> 101.
+    fep#create_with_buffer  ==> 102.
+    fep#get_max_size        ==> 103.
+        fep#getl            ==> 110.
+        fep#putb            ==> 111.
+        fep#flush           ==> 112.
+        fep#beep            ==> 113.
+
+% Conditional compilation
+%string_num.
+bignum#(A < B) ==> N :-
+    catch(string_num, _, false) -> N = bignum_lt(A,B); N = (A < B).
+bignum#(A > B) ==> N :-
+    catch(string_num, _, false) -> N = bignum_gt(A,B); N = (A > B).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+:- dynamic(example/1).
+example(formated_string(X)) :-
+    X = inline_last#(\L^phrase(format_("This is my term ~w", [foo(1)]), L)).
+example(bignum_example(A,B,P)) :-
+    bignum#(
+        A < B,
+        !,
+        A > 0;
+        B + 1 < P
+    ),
+    compute(A,B).
+example(numeric_enum_example) :-
+    foo(fep#create).
+example(ascii_examples) :-
+    foo(tel#null),
+    foo(tel#bell),
+    foo(tel#bs).
+example(base_conversion) :-
+    foo(16#"ABCDEF01234560").

--- a/tests/scryer/cli/src_tests/macros_tests.stderr
+++ b/tests/scryer/cli/src_tests/macros_tests.stderr
@@ -1,3 +1,4 @@
-% Warning: Unknown macro fep # hello at line 91 of macros.pl
-% Warning: Unknown macro foo # bar at line 91 of macros.pl
-% Warning: Unknown macro foo # fep#window at line 91 of macros.pl
+% Warning: Unknown macro fep # hello at line 93 of macros.pl
+% Warning: Unknown macro foo # bar at line 93 of macros.pl
+% Warning: Unknown macro foo # fep#window at line 93 of macros.pl
+% Warning: Unknown macro a # b#c#d at line 101 of macros.pl

--- a/tests/scryer/cli/src_tests/macros_tests.stderr
+++ b/tests/scryer/cli/src_tests/macros_tests.stderr
@@ -1,0 +1,3 @@
+% Warning: Unknown macro fep # hello at line 89 of macros.pl
+% Warning: Unknown macro foo # bar at line 89 of macros.pl
+% Warning: Unknown macro foo # fep#window at line 89 of macros.pl

--- a/tests/scryer/cli/src_tests/macros_tests.stderr
+++ b/tests/scryer/cli/src_tests/macros_tests.stderr
@@ -1,4 +1,4 @@
-% Warning: Unknown macro fep # hello at line 93 of macros.pl
-% Warning: Unknown macro foo # bar at line 93 of macros.pl
-% Warning: Unknown macro foo # fep#window at line 93 of macros.pl
-% Warning: Unknown macro a # b#c#d at line 101 of macros.pl
+% Warning: Unknown macro fep # hello at line 91 of macros.pl
+% Warning: Unknown macro foo # bar at line 91 of macros.pl
+% Warning: Unknown macro foo # fep#window at line 91 of macros.pl
+% Warning: Unknown macro a # b#c#d at line 99 of macros.pl

--- a/tests/scryer/cli/src_tests/macros_tests.stderr
+++ b/tests/scryer/cli/src_tests/macros_tests.stderr
@@ -1,3 +1,3 @@
-% Warning: Unknown macro fep # hello at line 89 of macros.pl
-% Warning: Unknown macro foo # bar at line 89 of macros.pl
-% Warning: Unknown macro foo # fep#window at line 89 of macros.pl
+% Warning: Unknown macro fep # hello at line 91 of macros.pl
+% Warning: Unknown macro foo # bar at line 91 of macros.pl
+% Warning: Unknown macro foo # fep#window at line 91 of macros.pl

--- a/tests/scryer/cli/src_tests/macros_tests.stdout
+++ b/tests/scryer/cli/src_tests/macros_tests.stdout
@@ -1,3 +1,7 @@
+   error(instantiation_error,when_si/2).
+   error(existence_error(macro/3,goal_expansion/2),[culprit-fep#hello]).
+   error(existence_error(macro/3,goal_expansion/2),[culprit-foo#bar]).
+   error(existence_error(macro/3,goal_expansion/2),[culprit-foo#fep#window]).
 example(formated_string(A)) :-
    A="This is my term foo(1)".
 example(bignum_example(A,B,C)) :-
@@ -47,3 +51,7 @@ example(clpz_operators_compatibility(A,B)) :-
       )
    ;  clpz:clpz_equal(#A,#B*8)
    ).
+example(unknown_macros) :-
+   fep#hello,
+   foo#bar,
+   foo#fep#window.

--- a/tests/scryer/cli/src_tests/macros_tests.stdout
+++ b/tests/scryer/cli/src_tests/macros_tests.stdout
@@ -1,10 +1,10 @@
 example(formated_string(A)) :-
    A="This is my term foo(1)".
 example(bignum_example(A,B,C)) :-
-   (  A<B,
+   (  bignum_lt(A,B),
       !,
       A>0
-   ;  B+1<C
+   ;  bignum_lt(B+1,C)
    ),
    compute(A,B).
 example(numeric_enum_example) :-
@@ -29,3 +29,21 @@ example(compilation([A,B,C])) :-
    A=24,
    B=36,
    C=72.
+example(modules(A)) :-
+   A=[B,C,D,E,F].
+example(clpz_operators_compatibility(A,B)) :-
+   (  integer(A) ->
+      (  integer(B) ->
+         A=:=B*8
+      ;  C is A,
+         clpz:clpz_equal(C,#B*8)
+      )
+   ;  integer(B) ->
+      (  true,
+         var(A) ->
+         A is B*8
+      ;  D is B*8,
+         clpz:clpz_equal(#A,D)
+      )
+   ;  clpz:clpz_equal(#A,#B*8)
+   ).

--- a/tests/scryer/cli/src_tests/macros_tests.stdout
+++ b/tests/scryer/cli/src_tests/macros_tests.stdout
@@ -1,0 +1,17 @@
+example(formated_string(A)) :-
+   A="This is my term foo(1)".
+example(bignum_example(A,B,C)) :-
+   (  A<B,
+      !,
+      A>0
+   ;  B+1<C
+   ),
+   compute(A,B).
+example(numeric_enum_example) :-
+   foo(101).
+example(ascii_examples) :-
+   foo([0]),
+   foo([7]),
+   foo([8]).
+example(base_conversion) :-
+   foo([171,205,239,1,35,69,96]).

--- a/tests/scryer/cli/src_tests/macros_tests.stdout
+++ b/tests/scryer/cli/src_tests/macros_tests.stdout
@@ -4,12 +4,13 @@
    error(existence_error(macro/3,goal_expansion/2),[culprit-foo#fep#window]).
    error(instantiation_error,functor/3).
    error(instantiation_error,when_si/2).
+   error(existence_error(macro/3,goal_expansion/2),[culprit-a#b#c#d]).
 example(formated_string(A)) :-
    A="This is my term foo(1)".
 example(bignum_example(A,B,C)) :-
    (  bignum_lt(A,B),
       !,
-      A>0
+      bignum_gt(A,0)
    ;  bignum_lt(B+1,C)
    ),
    compute(A,B).
@@ -62,3 +63,7 @@ example(incorrect_macros) :-
    b(A)#x,
    B#t,
    fep#C.
+example(tbd) :-
+   a(b#c)#d,
+   a#b#c#d.
+example(macro_in_heads(16#"ABCD")).

--- a/tests/scryer/cli/src_tests/macros_tests.stdout
+++ b/tests/scryer/cli/src_tests/macros_tests.stdout
@@ -2,6 +2,8 @@
    error(existence_error(macro/3,goal_expansion/2),[culprit-fep#hello]).
    error(existence_error(macro/3,goal_expansion/2),[culprit-foo#bar]).
    error(existence_error(macro/3,goal_expansion/2),[culprit-foo#fep#window]).
+   error(instantiation_error,functor/3).
+   error(instantiation_error,when_si/2).
 example(formated_string(A)) :-
    A="This is my term foo(1)".
 example(bignum_example(A,B,C)) :-
@@ -55,3 +57,8 @@ example(unknown_macros) :-
    fep#hello,
    foo#bar,
    foo#fep#window.
+example(incorrect_macros) :-
+   b(a)#x,
+   b(A)#x,
+   B#t,
+   fep#C.

--- a/tests/scryer/cli/src_tests/macros_tests.stdout
+++ b/tests/scryer/cli/src_tests/macros_tests.stdout
@@ -8,10 +8,20 @@ example(bignum_example(A,B,C)) :-
    ),
    compute(A,B).
 example(numeric_enum_example) :-
-   foo(101).
+   foo(100,101),
+   bar([110,111|A]).
 example(ascii_examples) :-
-   foo([0]),
-   foo([7]),
-   foo([8]).
+   (  foo([0]) ->
+      foo([7])
+   ;  foo([8])
+   ).
 example(base_conversion) :-
    foo([171,205,239,1,35,69,96]).
+example(quotated_goals_are_not_expanded(A)) :-
+   quote#bignum#(A<2).
+example(quotation_works_in_nested_terms(A)) :-
+   A=[111,B,quote#fep#putb].
+example(expands_arithmetic_functions(A,B)) :-
+   B is A+113/24.
+example(doesnt_expand_uninstantiated_macros(A)) :-
+   B=fep#A.

--- a/tests/scryer/cli/src_tests/macros_tests.stdout
+++ b/tests/scryer/cli/src_tests/macros_tests.stdout
@@ -25,3 +25,7 @@ example(expands_arithmetic_functions(A,B)) :-
    B is A+113/24.
 example(doesnt_expand_uninstantiated_macros(A)) :-
    B=fep#A.
+example(compilation([A,B,C])) :-
+   A=24,
+   B=36,
+   C=72.

--- a/tests/scryer/cli/src_tests/macros_tests.toml
+++ b/tests/scryer/cli/src_tests/macros_tests.toml
@@ -1,0 +1,6 @@
+args = [
+    "-f",
+    "--no-add-history",
+    "-g", "listing(example/1),halt",
+    "src/tests/macros.pl"
+]


### PR DESCRIPTION
Some time ago I've [stumbled](https://github.com/mthom/scryer-prolog/discussions/2604#discussioncomment-11033258) on some interesting historical code, and couldn't help myself but implement it for Scryer.

I still don't know how useful it might be, I barely see any really useful use-case, but at least it gives a sense of locality for goal expansion. By locality I mean that only explicitly marked terms are expanded.

More information about macro system in the comments in macros.pl. The easiest way to understand how it works it to check unit tests and compare them to `macros_tests.stdout`.

What do you think does it make sense?