### PR TITLE
Ensure max_assoc/3 is shown as documented

### DIFF
--- a/src/lib/assoc.pl
+++ b/src/lib/assoc.pl
@@ -299,7 +299,7 @@ map_assoc_(t(Key,Val,B,L0,R0), Pred, t(Key,Ans,B,L1,R1)) :-
     map_assoc_(R0, Pred, R1).
 
 
-%%  max_assoc(+Assoc, -Key, -Value) is semidet.
+%% max_assoc(+Assoc, -Key, -Value) is semidet.
 %
 % True if Key-Value is in Assoc and Key is the largest key.
 


### PR DESCRIPTION
It seems DocLog can't handle a double space in the `%%` line of documentation. You can see in https://scryer.pl/assoc that `max_assoc` appears twice. First time documented and second time undocumented:
![image](https://github.com/user-attachments/assets/f7eea5cb-2714-42fe-9af8-f4813f1c6801)
![image](https://github.com/user-attachments/assets/7f7a8b6f-d3d9-42e9-8c28-14d6917c832e)
