### PR TITLE
Make AtomTable fully safe and prepare for garbage collection

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -74,10 +74,7 @@ impl RawBlockTraits for F64Table {
         F64_TABLE_INIT_SIZE
     }
 
-    #[inline]
-    fn align() -> usize {
-        F64_TABLE_ALIGN
-    }
+    const ALIGN: usize = F64_TABLE_ALIGN;
 }
 
 #[derive(Debug)]

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -179,10 +179,7 @@ impl RawBlockTraits for AtomTable {
         ATOM_TABLE_INIT_SIZE
     }
 
-    #[inline]
-    fn align() -> usize {
-        ATOM_TABLE_ALIGN
-    }
+    const ALIGN: usize = ATOM_TABLE_ALIGN;
 }
 
 #[bitfield]
@@ -552,7 +549,7 @@ impl AtomTable {
             }
 
             let size = mem::size_of::<AtomHeader>() + string.len();
-            let size = size.next_multiple_of(AtomTable::align());
+            let size = size.next_multiple_of(AtomTable::ALIGN);
 
             unsafe {
                 let len_ptr = loop {

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -7,18 +7,26 @@ use std::mem;
 use std::ops::{Index, IndexMut};
 use std::ptr;
 
+/// TODO: remove this in favor of [`Ord::max`] once const fns
+/// can be added in traits (https://github.com/rust-lang/rust/issues/67792)
+const fn usize_max(lhs: usize, rhs: usize) -> usize {
+    if lhs > rhs {
+        lhs
+    } else {
+        rhs
+    }
+}
+
 impl RawBlockTraits for Stack {
     #[inline]
     fn init_size() -> usize {
         10 * 1024 * 1024
     }
 
-    #[inline]
-    fn align() -> usize {
-        mem::align_of::<OrFrame>()
-            .max(mem::align_of::<AndFrame>())
-            .max(mem::align_of::<HeapCellValue>())
-    }
+    const ALIGN: usize = usize_max(
+        usize_max(mem::align_of::<OrFrame>(), mem::align_of::<AndFrame>()),
+        mem::align_of::<HeapCellValue>(),
+    );
 }
 
 #[inline(always)]

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -224,7 +224,7 @@ impl Stack {
     }
 
     pub(crate) fn top(&self) -> usize {
-        unsafe { self.buf.len() }
+        self.buf.len()
     }
 
     pub(crate) fn allocate_or_frame(&mut self, num_cells: usize) -> usize {

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -301,6 +301,25 @@ impl Stack {
         }
     }
 
+    /// Reads an [`OrFrame`] placed immediately after [`self.top()`](Self::top).
+    ///
+    /// # Safety
+    ///
+    /// The stack must contain a valid [`OrFrame`] at offset [`self.top()`](Self::top).
+    ///
+    /// No other allocations must have been done since the last call to [`truncate()`](Self::truncate).
+    #[inline(always)]
+    pub(crate) unsafe fn read_dangling_or_frame(&self) -> &OrFrame {
+        unsafe {
+            // SAFETY:
+            // - Assumed: the stack contains a valid `OrFrame` at this offset
+            // - Assumed: no other allocations have been done since the last call to `self.truncate()`
+            // - Postcondition: from `self.buf.truncate`, the pointer `ptr` is not yet invalidated.
+            let ptr = self.buf.get_unchecked(self.top());
+            &*(ptr as *const OrFrame)
+        }
+    }
+
     #[inline(always)]
     pub(crate) fn index_or_frame_mut(&mut self, b: usize) -> &mut OrFrame {
         unsafe {

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -62,6 +62,11 @@ impl Index<usize> for AndFrame {
     type Output = HeapCellValue;
 
     fn index(&self, index: usize) -> &Self::Output {
+        assert!(
+            index > 0 && index <= self.prelude.num_cells,
+            "Invalid index within AndFrame: {index} not in 1..={}",
+            self.prelude.num_cells
+        );
         let prelude_offset = prelude_size::<AndFramePrelude>();
         let index_offset = (index - 1) * mem::size_of::<HeapCellValue>();
 
@@ -76,6 +81,11 @@ impl Index<usize> for AndFrame {
 
 impl IndexMut<usize> for AndFrame {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        assert!(
+            index > 0 && index <= self.prelude.num_cells,
+            "Invalid index within AndFrame: {index} not in 1..={}",
+            self.prelude.num_cells
+        );
         let prelude_offset = prelude_size::<AndFramePrelude>();
         let index_offset = (index - 1) * mem::size_of::<HeapCellValue>();
 
@@ -95,7 +105,7 @@ impl Index<usize> for Stack {
     fn index(&self, index: usize) -> &Self::Output {
         unsafe {
             // TODO: implement some mechanism to verify soundness
-            let ptr = self.buf.get_unchecked(index);
+            let ptr = self.buf.get(index).unwrap();
             &*(ptr as *const HeapCellValue)
         }
     }
@@ -136,6 +146,11 @@ impl Index<usize> for OrFrame {
 
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
+        assert!(
+            index < self.prelude.num_cells,
+            "Invalid index within OrFrame: {index} not in 0..{}",
+            self.prelude.num_cells
+        );
         let prelude_offset = prelude_size::<OrFramePrelude>();
         let index_offset = index * mem::size_of::<HeapCellValue>();
 
@@ -151,6 +166,11 @@ impl Index<usize> for OrFrame {
 impl IndexMut<usize> for OrFrame {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        assert!(
+            index < self.prelude.num_cells,
+            "Invalid index within OrFrame: {index} not in 0..{}",
+            self.prelude.num_cells
+        );
         let prelude_offset = prelude_size::<OrFramePrelude>();
         let index_offset = index * mem::size_of::<HeapCellValue>();
 
@@ -202,6 +222,7 @@ impl Stack {
     pub(crate) fn allocate_and_frame(&mut self, num_cells: usize) -> usize {
         let frame_size = AndFrame::size_of(num_cells);
 
+        // TODO: prove safety of this block and prove that it upholds the invariants of `Stack`.
         unsafe {
             let e = self.buf.len();
             let new_ptr = self.alloc(frame_size);
@@ -230,6 +251,7 @@ impl Stack {
     pub(crate) fn allocate_or_frame(&mut self, num_cells: usize) -> usize {
         let frame_size = OrFrame::size_of(num_cells);
 
+        // TODO: prove safety of this block and prove that it upholds the invariants of `Stack`.
         unsafe {
             let b = self.buf.len();
             let new_ptr = self.alloc(frame_size);
@@ -254,7 +276,8 @@ impl Stack {
     #[inline(always)]
     pub(crate) fn index_and_frame(&self, e: usize) -> &AndFrame {
         unsafe {
-            let ptr = self.buf.get_unchecked(e);
+            let ptr = self.buf.get(e).unwrap();
+            // TODO: ensure safety of this cast
             &*(ptr as *const AndFrame)
         }
     }
@@ -263,7 +286,8 @@ impl Stack {
     pub(crate) fn index_and_frame_mut(&mut self, e: usize) -> &mut AndFrame {
         unsafe {
             // This is doing alignment wrong
-            let ptr = self.buf.get_unchecked(e);
+            let ptr = self.buf.get(e).unwrap();
+            // TODO: ensure safety of this cast
             &mut *(ptr as *mut AndFrame)
         }
     }
@@ -271,7 +295,8 @@ impl Stack {
     #[inline(always)]
     pub(crate) fn index_or_frame(&self, b: usize) -> &OrFrame {
         unsafe {
-            let ptr = self.buf.get_unchecked(b);
+            let ptr = self.buf.get(b).unwrap();
+            // TODO: ensure safety of this cast
             &*(ptr as *const OrFrame)
         }
     }
@@ -280,6 +305,7 @@ impl Stack {
     pub(crate) fn index_or_frame_mut(&mut self, b: usize) -> &mut OrFrame {
         unsafe {
             let ptr = self.buf.get_mut_unchecked(b);
+            // TODO: ensure safety of this cast
             &mut *(ptr as *mut OrFrame)
         }
     }

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -284,10 +284,18 @@ impl Stack {
         }
     }
 
+    /// Panics if `byte_offset` is not aligned to [`Stack::ALIGN`].
+    ///
+    /// Frames beyond `byte_offset` become invalidated after a call to this function.
     #[inline(always)]
-    pub(crate) fn truncate(&mut self, b: usize) {
+    pub(crate) fn truncate(&mut self, byte_offset: usize) {
         unsafe {
-            self.buf.truncate(b);
+            // TODO: implement a way to mitigate indexing to invalidated frames,
+            // and/or mark this function as unsafe.
+            //
+            // I think that one could also create a safer abstraction for the
+            // "store offset, do work, truncate to offset" kind of tasks.
+            self.buf.truncate(byte_offset);
         }
     }
 }

--- a/src/machine/stack.rs
+++ b/src/machine/stack.rs
@@ -237,7 +237,7 @@ impl Stack {
 
             for idx in 0..num_cells {
                 ptr::write(
-                    (new_ptr as usize + offset) as *mut HeapCellValue,
+                    new_ptr.add(offset).cast::<HeapCellValue>(),
                     stack_loc_as_cell!(OrFrame, b, idx),
                 );
 

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -1235,8 +1235,10 @@ impl Machine {
                                 // the last clause of the retract
                                 // helper to delay deallocation of its
                                 // environment frame.
-                                let clause_b = self.machine_st.stack.top();
-                                self.machine_st.stack.index_or_frame(clause_b).prelude.biip as usize
+                                unsafe {
+                                    // TODO: verify that the assumption above always holds
+                                    self.machine_st.stack.read_dangling_or_frame().prelude.biip as usize
+                                }
                             };
 
                             return (

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -85,12 +85,14 @@ impl<T: RawBlockTraits> RawBlock<T> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `offset < self.len()`
+    /// The caller must ensure that `offset` is within a region allocated with [`Self::alloc`].
+    ///
+    /// It must notably ensure that `offset < self.capacity()`.
     pub unsafe fn get_unchecked(&self, offset: usize) -> *const u8 {
         // SAFETY:
         // - Invariant: `self.base + self.size() == self.top` is the top bound of
         //   the allocated region.
-        // - Assumed: `offset < self.len()`
+        // - Assumed: `offset < self.capacity()`
         // Thus `self.base + offset` is within the allocated region.
         self.base.add(offset)
     }
@@ -111,10 +113,12 @@ impl<T: RawBlockTraits> RawBlock<T> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `offset < self.len()`
+    /// The caller must ensure that `offset` is within a region allocated with [`Self::alloc`].
+    ///
+    /// It must notably ensure that `offset < self.capacity()`.
     pub unsafe fn get_mut_unchecked(&mut self, offset: usize) -> *mut u8 {
         unsafe {
-            // SAFETY: Assumed: `offset < self.len()`
+            // SAFETY: Assumed.
             self.get_unchecked(offset).cast_mut()
         }
     }

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -71,9 +71,9 @@ impl<T: RawBlockTraits> RawBlock<T> {
     /// The caller is responsible for ensuring that the return value points to
     /// valid objects, and that no mutable access may happen on it.
     pub fn get(&self, offset: usize) -> Option<*const u8> {
-        if offset < self.capacity() {
+        if offset < self.len() {
             Some(unsafe {
-                // SAFETY: Asserted: `offset < self.capacity()`.
+                // SAFETY: Asserted: `offset < self.len()`.
                 self.get_unchecked(offset)
             })
         } else {
@@ -85,12 +85,12 @@ impl<T: RawBlockTraits> RawBlock<T> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `offset < self.capacity()`
+    /// The caller must ensure that `offset < self.len()`
     pub unsafe fn get_unchecked(&self, offset: usize) -> *const u8 {
         // SAFETY:
         // - Invariant: `self.base + self.size() == self.top` is the top bound of
         //   the allocated region.
-        // - Assumed: `offset < self.capacity()`
+        // - Assumed: `offset < self.len()`
         // Thus `self.base + offset` is within the allocated region.
         self.base.add(offset)
     }
@@ -111,10 +111,10 @@ impl<T: RawBlockTraits> RawBlock<T> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `offset < self.capacity()`
+    /// The caller must ensure that `offset < self.len()`
     pub unsafe fn get_mut_unchecked(&mut self, offset: usize) -> *mut u8 {
         unsafe {
-            // SAFETY: Assumed: `offset < self.capacity()`
+            // SAFETY: Assumed: `offset < self.len()`
             self.get_unchecked(offset).cast_mut()
         }
     }

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -31,6 +31,8 @@ pub struct RawBlock<T: RawBlockTraits> {
     /// # Safety
     ///
     /// `head <= self.capacity()`
+    ///
+    /// `head` must always be a multiple of [`T::ALIGN`](RawBlockTraits::ALIGN).
     head: Cell<usize>,
 
     _marker: PhantomData<T>,
@@ -229,7 +231,16 @@ impl<T: RawBlockTraits> RawBlock<T> {
     /// this function is marked as unsafe.
     ///
     /// Does not resize the allocated region of memory.
+    ///
+    /// Panics if `new_len` is not a multiple of [`T::ALIGN`](RawBlockTraits::ALIGN).
     pub unsafe fn truncate(&mut self, new_len: usize) {
+        assert_eq!(
+            new_len % T::ALIGN,
+            0,
+            "RawBlock::truncate(new_len = {new_len}) requires new_len to be aligned to {}",
+            T::ALIGN
+        );
+
         let head = self.head.get_mut();
         if new_len < *head {
             *head = new_len;

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -247,6 +247,14 @@ impl<T: RawBlockTraits> RawBlock<T> {
         }
     }
 
+    /// Allocates `size` bytes into the buffer, returning a mutable
+    /// pointer to beginning of them. If there are not enough bytes available,
+    /// returns [`ptr::null_mut()`].
+    ///
+    /// If non-null, the return value is guaranteed to point to
+    /// at least `size` bytes of unused memory.
+    ///
+    /// The return value is aligned to [`T::ALIGN`](RawBlockTraits::ALIGN).
     pub unsafe fn alloc(&self, size: usize) -> *mut u8 {
         let aligned_size = size.next_multiple_of(T::ALIGN);
 

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -123,7 +123,8 @@ impl<T: RawBlockTraits> RawBlock<T> {
     }
 
     pub unsafe fn alloc(&self, size: usize) -> *mut u8 {
-        let aligned_size = size.next_multiple_of(size);
+        let aligned_size = size.next_multiple_of(T::ALIGN);
+
         if self.free_space() >= aligned_size {
             let ptr = *self.ptr.get();
             *self.ptr.get() = ptr.add(aligned_size) as *mut _;


### PR DESCRIPTION
This is a followup to #2727 that gives `AtomTable` the ability to verify that `Atom`s are safe to dereference and the ability to shuffle their layout for garbage collection purposes, by adding another layer of indirection.

-----

Prior to this change, `Atom`s would contain the offset of their `AtomHeader` within a buffer. This lets us resize the buffer to add new atoms, but it is prone to issues caused by atoms with invalid offsets and it doesn't let us defragment the `AtomTable` once garbage collection is introduced.

```
                 |   buffer   |
                 +------------+
                 |    ...     |
Atom(0x12580) -> | AtomHeader | @12580
                 | "Hello wo" | @12588
                 | "rld!"____ | @12590
                 |    ...     |
```

-----

With this change, the `Atom`s now store an index into an array of indices, meaning that verifying the validity of an atom is as simple as checking that it is within this array:

```
            | offsets |    |   buffer   |
            +---------+    +------------+
            |   ...   |    |    ...     |
Atom(13) -> | 0x12580 | -> | AtomHeader | @12580
            |   ...   |    | "Hello wo" | @12588
            |   ...   |    | "rld!"____ | @12590
            |   ...   |    |    ...     |
```

This also lets us safely change the order of atoms within the buffer, by changing the offsets, without needing to modify the existing `Atom`s, which paves the way towards garbage collection within `AtomTable`.

One important detail with my implementation is that the `offsets` array is stored within an `Arcu`, which means that the read from the buffer in `Atom::as_ptr` now *depends on* `atom_table.inner.offsets.read()`, which is an acquire atomic operation. When a new atom is added to the table with `AtomTable::build_with`, the write to the buffer is *sequenced before* `atom_table.inner.offsets.replace(new_offsets)`: `Atom::as_ptr` is now guaranteed (by my limited experience with atomics) to observe the changes as expected.

Instances where the lack of this property cause actual issues are exceedingly rare. A thread would need to somehow have access to an atom offset created from another thread, without synchronization, and immediately try to read its data.

The `Sync`-ness of `AtomTable` is now proved, making it (hopefully) safe :)