### PR TITLE
Revert "FIXED: CLP(B): Delay BDD restriction until after the instantiation"

### DIFF
--- a/src/lib/clpb.pl
+++ b/src/lib/clpb.pl
@@ -3,7 +3,7 @@
     Author:        Markus Triska
     E-mail:        triska@metalevel.at
     WWW:           https://www.metalevel.at
-    Copyright (C): 2019-2023 Markus Triska
+    Copyright (C): 2019-2025 Markus Triska
 
     Permission is hereby granted, free of charge, to any person
     obtaining a copy of this software and associated documentation
@@ -1150,8 +1150,9 @@ verify_attributes(Var, Other, Gs) :-
             (   integer(Other) ->
                 (   between(0, 1, Other) ->
                     root_get_formula_bdd(Root, Sat, BDD0),
+                    bdd_restriction(BDD0, I, Other, BDD),
                     root_put_formula_bdd(Root, Sat, BDD),
-                    Gs = [bdd_restriction(BDD0,I,Other,BDD),satisfiable_bdd(BDD)]
+                    Gs = [satisfiable_bdd(BDD)]
                 ;   no_truth_value(Other)
                 )
             ;   atom(Other) ->


### PR DESCRIPTION
This reverts commit e185b626bdf1a99ab8188ae39875f645c0de90f0.

This change is now no longer needed, and the underlying issue is apparently somewhere else entirely. See the description at&nbsp;https://github.com/mthom/scryer-prolog/issues/2732

Current master behaves differently from Scryer as it was at 099d9aaca6509496ccb28c522659b990f42037f0 (i.e., preceding the commit that is now being reverted), even on the same file.

For an example, see: https://github.com/triska/scryer-prolog/commit/dd41176b97d8369c3bb7de1c9932a9c3d10a0466

Scryer now works as expected, and compatibly with SICStus. We still need to find out what fixed the root cause of this issue.