### PR TITLE
Fix load_context_module triggering unreachable!()

### DIFF
--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -4812,11 +4812,11 @@ impl Machine {
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }
                     &Instruction::CallLoadContextModule => {
-                        self.load_context_module(self.machine_st.registers[1]);
+                        self.load_context_module(self.deref_register(1));
                         step_or_fail!(self, self.machine_st.p += 1);
                     }
                     &Instruction::ExecuteLoadContextModule => {
-                        self.load_context_module(self.machine_st.registers[1]);
+                        self.load_context_module(self.deref_register(1));
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }
                     &Instruction::CallLoadContextStream => {

--- a/tests-pl/load-context-unreachable.pl
+++ b/tests-pl/load-context-unreachable.pl
@@ -1,0 +1,1 @@
+:- initialization((M = user, loader:load_context(M))).

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -25,3 +25,11 @@ fn issue2588_load_html() {
 fn call_qualification() {
     load_module_test("tests-pl/issue2361-call-qualified.pl", "");
 }
+
+// PR #2756: ensures that calling load_context with a bound variable doesn't trigger unreachable!()
+#[serial]
+#[test]
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+fn load_context_unreachable() {
+    load_module_test("tests-pl/load-context-unreachable.pl", "");
+}


### PR DESCRIPTION
Loading a file with the following triggers a panic, caused by `Machine::load_context_module` calling `Machine::unify_atom` with un-derefed `Var`s:

```prolog
:- initialization((M = user, loader:load_context(M))).
```

This changes the code in `dispatch.rs` to first dereference the register before calling `load_context_module`.