### PR TITLE
fix: compile under Nix flake on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,10 @@
       let 
         pkgs = import nixpkgs { inherit system overlays; };
         nativeBuildInputs = with pkgs; [ pkg-config ];
-        buildInputs = with pkgs; [ openssl ];
+        buildInputs = with pkgs; [ openssl ] ++
+                                 lib.optionals pkgs.stdenv.isDarwin [
+                                   pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+                                 ];
       in
       {
         devShells = {


### PR DESCRIPTION
Hello! I was delighted to see my development environment automatically set itself up due to the work done in https://github.com/mthom/scryer-prolog/pull/2482, and then slightly less delighted when I saw a failure to compile due to the `SystemConfiguration` framework not being provided as Rust expects on macOS.

Following the suggestion at https://discourse.nixos.org/t/ld-framework-not-found-system/15096/7, I added this framework to `buildInputs` when evaluating the flake for macOS, and now Scryer happily compiles with a single `cargo build --release`.