### PR TITLE
Fix rnd_i clipping floats that don't fit in Fixnum

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -374,7 +374,10 @@ pub(crate) fn rnd_i(n: &'_ Number, arena: &mut Arena) -> Number {
             if I64_MIN_TO_F <= f && f <= I64_MAX_TO_F {
                 fixnum!(Number, f.into_inner() as i64, arena)
             } else {
-                Number::Integer(arena_alloc!(Integer::from(f.0 as i64), arena))
+                Number::Integer(arena_alloc!(
+                    Integer::try_from(f.0).expect("Floats may not be infinite"),
+                    arena
+                ))
             }
         }
         Number::Rational(ref r) => {


### PR DESCRIPTION
This fixes #2772.

The current implementation of `rnd_i` incorrectly casts `f` (an `f64`) into an `i64`, before casting it into an `Integer`.

This PR changes its implementation to use `Integer::try_from(f)` instead. `Number::Float` is expected to be finite (as far as I can tell), so the error case doesn't need to be gracefully handled.