### PR TITLE
Callback streams for use as library

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -181,6 +181,7 @@ pub enum ArenaHeaderTag {
     ReadlineStream = 0b110000,
     StaticStringStream = 0b110100,
     ByteStream = 0b111000,
+    CallbackStream = 0b111001,
     StandardOutputStream = 0b1100,
     StandardErrorStream = 0b11000,
     NullStream = 0b111100,
@@ -840,6 +841,9 @@ unsafe fn drop_slab_in_place(value: NonNull<AllocSlab>, tag: ArenaHeaderTag) {
         }
         ArenaHeaderTag::ByteStream => {
             drop_typed_slab_in_place!(ByteStream, value);
+        }
+        ArenaHeaderTag::CallbackStream => {
+            drop_typed_slab_in_place!(CallbackStream, value);
         }
         ArenaHeaderTag::LiveLoadState | ArenaHeaderTag::InactiveLoadState => {
             drop_typed_slab_in_place!(LiveLoadState, value);

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -182,6 +182,7 @@ pub enum ArenaHeaderTag {
     StaticStringStream = 0b110100,
     ByteStream = 0b111000,
     CallbackStream = 0b111001,
+    InputChannelStream = 0b111010,
     StandardOutputStream = 0b1100,
     StandardErrorStream = 0b11000,
     NullStream = 0b111100,
@@ -844,6 +845,9 @@ unsafe fn drop_slab_in_place(value: NonNull<AllocSlab>, tag: ArenaHeaderTag) {
         }
         ArenaHeaderTag::CallbackStream => {
             drop_typed_slab_in_place!(CallbackStream, value);
+        }
+        ArenaHeaderTag::InputChannelStream => {
+            drop_typed_slab_in_place!(InputChannelStream, value);
         }
         ArenaHeaderTag::LiveLoadState | ArenaHeaderTag::InactiveLoadState => {
             drop_typed_slab_in_place!(LiveLoadState, value);

--- a/src/machine/config.rs
+++ b/src/machine/config.rs
@@ -15,7 +15,6 @@ use super::{
 #[derive(Default)]
 enum OutputStreamConfigInner {
     #[default]
-    Null,
     Memory,
     Stdout,
     Stderr,
@@ -25,7 +24,6 @@ enum OutputStreamConfigInner {
 impl std::fmt::Debug for OutputStreamConfigInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Null => write!(f, "Null"),
             Self::Memory => write!(f, "Memory"),
             Self::Stdout => write!(f, "Stdout"),
             Self::Stderr => write!(f, "Stderr"),
@@ -41,30 +39,27 @@ pub struct OutputStreamConfig {
 }
 
 impl OutputStreamConfig {
-    /// Ignores all output.
-    pub fn null() -> Self {
-        Self {
-            inner: OutputStreamConfigInner::Null,
-        }
-    }
     /// Sends output to stdout.
     pub fn stdout() -> Self {
         Self {
             inner: OutputStreamConfigInner::Stdout,
         }
     }
+
     /// Sends output to stderr.
     pub fn stderr() -> Self {
         Self {
             inner: OutputStreamConfigInner::Stderr,
         }
     }
+
     /// Keeps output in a memory buffer.
     pub fn memory() -> Self {
         Self {
             inner: OutputStreamConfigInner::Memory,
         }
     }
+
     /// Calls a callback with the output whenever the stream is written to.
     pub fn callback(callback: Callback) -> Self {
         Self {
@@ -74,7 +69,6 @@ impl OutputStreamConfig {
 
     fn into_stream(self, arena: &mut Arena) -> Stream {
         match self.inner {
-            OutputStreamConfigInner::Null => Stream::Null(StreamOptions::default()),
             OutputStreamConfigInner::Memory => Stream::from_owned_string("".to_owned(), arena),
             OutputStreamConfigInner::Stdout => Stream::stdout(arena),
             OutputStreamConfigInner::Stderr => Stream::stderr(arena),
@@ -104,12 +98,14 @@ impl InputStreamConfig {
             inner: InputStreamConfigInner::Null,
         }
     }
+
     /// Gets input from stdin.
     pub fn stdin() -> Self {
         Self {
             inner: InputStreamConfigInner::Stdin,
         }
     }
+
     /// Connects the input to the receiving end of a channel.
     pub fn channel() -> (UserInput, Self) {
         let (sender, receiver) = channel();
@@ -176,8 +172,10 @@ impl StreamConfig {
             user_input,
             StreamConfig {
                 stdin: channel_stream,
-                stdout: stdout.map_or_else(OutputStreamConfig::null, OutputStreamConfig::callback),
-                stderr: stderr.map_or_else(OutputStreamConfig::null, OutputStreamConfig::callback),
+                stdout: stdout
+                    .map_or_else(OutputStreamConfig::memory, OutputStreamConfig::callback),
+                stderr: stderr
+                    .map_or_else(OutputStreamConfig::memory, OutputStreamConfig::callback),
             },
         )
     }

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -620,7 +620,7 @@ fn callback_streams() {
 
     let (mut user_input, streams) = StreamConfig::with_callbacks(
         Some(Box::new(move |x| {
-            x.read_to_string(&mut *test_string2.borrow_mut()).unwrap();
+            x.read_to_string(&mut test_string2.borrow_mut()).unwrap();
         })),
         None,
     );

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -1,5 +1,8 @@
+use std::io::Write;
+use std::{cell::RefCell, io::Read, rc::Rc};
+
 use super::*;
-use crate::MachineBuilder;
+use crate::{MachineBuilder, StreamConfig};
 
 #[test]
 #[cfg_attr(miri, ignore = "it takes too long to run")]
@@ -607,4 +610,35 @@ fn errors_and_exceptions() {
         complete_answer,
         [Ok(LeafAnswer::Exception(Term::atom("a")))]
     );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn callback_streams() {
+    let test_string = Rc::new(RefCell::new(String::new()));
+    let test_string2 = test_string.clone();
+
+    let (mut user_input, streams) = StreamConfig::with_callbacks(
+        Some(Box::new(move |x| {
+            x.read_to_string(&mut *test_string2.borrow_mut()).unwrap();
+        })),
+        None,
+    );
+    let mut machine = MachineBuilder::default().with_streams(streams).build();
+
+    write!(&mut user_input, "a(1,2,3).").unwrap();
+
+    let complete_answer: Vec<_> = machine
+        .run_query("read(A), write('asdf'), nl, flush_output.")
+        .collect();
+
+    assert_eq!(
+        complete_answer,
+        [Ok(LeafAnswer::from_bindings([(
+            "A",
+            Term::compound("a", [Term::integer(1), Term::integer(2), Term::integer(3)])
+        ),]))]
+    );
+
+    assert_eq!(*test_string.borrow(), "asdf\n");
 }

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -2112,10 +2112,8 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn user_input_string_stream() {
-        let streams = StreamConfig {
-            stdin: InputStreamConfig::string("a(1,2,3)."),
-            ..Default::default()
-        };
+        let streams =
+            StreamConfig::default().with_user_input(InputStreamConfig::string("a(1,2,3)."));
 
         let mut machine = MachineBuilder::default().with_streams(streams).build();
 
@@ -2144,11 +2142,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn user_input_channel_stream() {
         let (mut user_input, channel_stream) = InputStreamConfig::channel();
-        let streams = StreamConfig {
-            stdin: channel_stream,
-            ..Default::default()
-        };
-
+        let streams = StreamConfig::default().with_user_input(channel_stream);
         let mut machine = MachineBuilder::default().with_streams(streams).build();
 
         let complete_answer: Vec<_> = machine
@@ -2204,15 +2198,13 @@ mod tests {
     fn user_output_callback_stream() {
         let test_string = Rc::new(RefCell::new(String::new()));
 
-        let streams = StreamConfig {
-            stdout: OutputStreamConfig::callback(Box::new({
+        let streams =
+            StreamConfig::default().with_user_output(OutputStreamConfig::callback(Box::new({
                 let test_string = test_string.clone();
                 move |x| {
                     x.read_to_string(&mut test_string.borrow_mut()).unwrap();
                 }
-            })),
-            ..Default::default()
-        };
+            })));
 
         let mut machine = MachineBuilder::default().with_streams(streams).build();
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -305,6 +305,7 @@ macro_rules! match_untyped_arena_ptr_pat {
             | ArenaHeaderTag::ReadlineStream
             | ArenaHeaderTag::StaticStringStream
             | ArenaHeaderTag::ByteStream
+            | ArenaHeaderTag::CallbackStream
             | ArenaHeaderTag::StandardOutputStream
             | ArenaHeaderTag::StandardErrorStream
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -306,6 +306,7 @@ macro_rules! match_untyped_arena_ptr_pat {
             | ArenaHeaderTag::StaticStringStream
             | ArenaHeaderTag::ByteStream
             | ArenaHeaderTag::CallbackStream
+            | ArenaHeaderTag::InputChannelStream
             | ArenaHeaderTag::StandardOutputStream
             | ArenaHeaderTag::StandardErrorStream
     };


### PR DESCRIPTION
This adds a new `StreamConfig` option that allows both to asynchronously react to the `Machine` writing to stdout or stderr, and to programatically send data to its stdin, all in-memory.

This is an incredible feature for many reasons, like being able to get stdout in parts and not just all at once, but the application I have in mind is running the same toplevel we use for CLI inside Wasm in the Scryer Playground, which will be a great improvement in usability!