### PR TITLE
Line numbers start at 1

### DIFF
--- a/src/loader.pl
+++ b/src/loader.pl
@@ -210,7 +210,8 @@ load_loop(Stream, Evacuable) :-
        '$conclude_load'(Evacuable)
     ;  var(Term) ->
        instantiation_error(load/1)
-    ;  warn_about_singletons(Singletons, LinesRead),
+    ;  LineNum is LinesRead + 1,
+       warn_about_singletons(Singletons, LineNum),
        compile_term(Term, Evacuable),
        load_loop(Stream, Evacuable)
     ).

--- a/tests/scryer/cli/src_tests/directive_errors.md
+++ b/tests/scryer/cli/src_tests/directive_errors.md
@@ -42,14 +42,14 @@ $ scryer-prolog -f --no-add-history tests-pl/invalid_decl7.pl -g halt
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl8.pl -g halt
-% Warning: singleton variables Var at line 0 of invalid_decl8.pl
+% Warning: singleton variables Var at line 1 of invalid_decl8.pl
    error(domain_error(operator_specifier,todo_insert_invalid_term_here),load/1).
 
 ```
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl9.pl -g halt
-% Warning: singleton variables Var at line 0 of invalid_decl9.pl
+% Warning: singleton variables Var at line 1 of invalid_decl9.pl
    error(type_error(integer,todo_insert_invalid_term_here),load/1).
 
 ```
@@ -63,7 +63,7 @@ FIXME I belive the following test should result in a `error(instantiation_error,
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl11.pl -g halt
-% Warning: singleton variables Var at line 0 of invalid_decl11.pl
+% Warning: singleton variables Var at line 1 of invalid_decl11.pl
    error(type_error(list,todo_insert_invalid_term_here),load/1).
 
 ```
@@ -101,7 +101,7 @@ $ scryer-prolog -f --no-add-history tests-pl/invalid_decl16.pl -g halt
 
 ```trycmd
 $ scryer-prolog -f --no-add-history tests-pl/invalid_decl_issue2467.pl -g halt
-% Warning: singleton variables D at line 0 of invalid_decl_issue2467.pl
+% Warning: singleton variables D at line 1 of invalid_decl_issue2467.pl
    error(instantiation_error,load/1).
 
 ```

--- a/tests/scryer/main.rs
+++ b/tests/scryer/main.rs
@@ -22,7 +22,6 @@ fn cli_tests() {
     trycmd::TestCases::new()
         .default_bin_name("scryer-prolog")
         .case("tests/scryer/cli/issues/*.toml")
-        .skip("tests/scryer/cli/issues/singleton_warning.toml") // wrong line number
         .case("tests/scryer/cli/src_tests/*.toml")
         .case("tests/scryer/cli/src_tests/*.md");
 }


### PR DESCRIPTION
A quick (partial) fix the the singleton warning line number. See what you think!

Bumps the line number for the singleton warning. When the singleton occurs on the same line at the term starts, the line number is correct (e.g.line 1 instead of 0):

    foo(X).

However it stills mis-reports this line number as 1 instead of 5:

    foo(1) :-
        true,
        true,
        true,
        Y.

See issue #1356.