### PR TITLE
Add test module to reproduce hanging call to http_open

### DIFF
--- a/tests-pl/issue-http_open-hanging.pl
+++ b/tests-pl/issue-http_open-hanging.pl
@@ -1,0 +1,21 @@
+:- module(http_open_hanging, [submit_request/0]).
+
+:- use_module(library(charsio)).
+:- use_module(library(http/http_open)).
+
+send_request :-
+    Options = [
+        method('get'),
+        status_code(StatusCode),
+        request_headers([]),
+        headers(_)
+    ],
+    http_open("http://scryer.pl", _Stream, Options),
+    write_term('received response with status code'(StatusCode), []), nl.
+
+main :-
+    send_request,
+    send_request,
+    send_request.
+
+:- initialization(main).

--- a/tests/scryer/helper.rs
+++ b/tests/scryer/helper.rs
@@ -1,3 +1,5 @@
+use scryer_prolog::MachineBuilder;
+
 pub(crate) trait Expectable {
     #[track_caller]
     fn assert_eq(self, other: &[u8]);
@@ -30,4 +32,17 @@ pub(crate) fn load_module_test<T: Expectable>(file: &str, expected: T) {
 
     let mut wam = MachineBuilder::default().build();
     expected.assert_eq(wam.test_load_file(file).as_slice());
+}
+
+pub(crate) fn load_module_test_with_tokio_runtime<T: Expectable>(file: &str, expected: T) {
+    #[cfg(not(target_arch = "wasm32"))]
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async move {
+        let mut wam = MachineBuilder::default().build();
+        expected.assert_eq(wam.test_load_file(file).as_slice())
+    });
 }

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -1,4 +1,4 @@
-use crate::helper::load_module_test;
+use crate::helper::{load_module_test, load_module_test_with_tokio_runtime};
 use serial_test::serial;
 
 // issue #831
@@ -42,4 +42,11 @@ fn load_context_unreachable() {
 #[cfg_attr(miri, ignore = "it takes too long to run")]
 fn issue2725_dcg_without_module() {
     load_module_test("tests-pl/issue2725.pl", "");
+}
+
+#[test]
+#[cfg(feature = "http")]
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+fn http_open_hanging() {
+    load_module_test_with_tokio_runtime("tests-pl/issue-http_open-hanging.pl", "received response with status code(200)\nreceived response with status code(200)\nreceived response with status code(200)");
 }


### PR DESCRIPTION
```
cargo test \
--no-run --package scryer-prolog \
--test scryer issues::http_open_hanging \
--profile test
```