### PR TITLE
Prevent http_open/3 from hanging

### DIFF
--- a/tests-pl/issue-http_open-hanging.pl
+++ b/tests-pl/issue-http_open-hanging.pl
@@ -1,0 +1,23 @@
+:- module(http_open_hanging, [submit_request/0]).
+
+:- use_module(library(charsio)).
+:- use_module(library(http/http_open)).
+
+send_request :-
+    Options = [
+        method('get'),
+        status_code(StatusCode),
+        request_headers([]),
+        headers(_)
+    ],
+    http_open("https://scryer.pl", _Stream, Options),
+    write_term('received response with status code':StatusCode, []), nl.
+
+main :-
+    send_request,
+    send_request,
+    send_request,
+    send_request,
+    send_request.
+
+:- initialization(main).

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -1,4 +1,6 @@
 use crate::helper::load_module_test;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::helper::load_module_test_with_tokio_runtime;
 use serial_test::serial;
 
 // issue #831
@@ -42,4 +44,15 @@ fn load_context_unreachable() {
 #[cfg_attr(miri, ignore = "it takes too long to run")]
 fn issue2725_dcg_without_module() {
     load_module_test("tests-pl/issue2725.pl", "");
+}
+
+#[test]
+#[cfg(feature = "http")]
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+fn http_open_hanging() {
+    load_module_test_with_tokio_runtime(
+        "tests-pl/issue-http_open-hanging.pl",
+            "received response with status code:200\nreceived response with status code:200\nreceived response with status code:200\nreceived response with status code:200\nreceived response with status code:200\n"
+    );
 }


### PR DESCRIPTION
Hello 👋🏼,

Replacing `futures::executor::block_on` with `tokio::block_in_place` may help in closing https://github.com/mthom/scryer-prolog/issues/2834:


CI workflows appears to be ok in this [fork](https://github.com/thierrymarianne/contrib-scryer-prolog/actions/runs/13529411529/job/37807772388).

Please, let me know how a better fix could be applied 
(for the time being or in the long run).