### PR TITLE
Fix parsing of \x0\ in partial strings

### DIFF
--- a/src/functor_macro.rs
+++ b/src/functor_macro.rs
@@ -485,7 +485,7 @@ mod tests {
         let mut functor_writer = Heap::functor_writer(functor);
         functor_writer(&mut heap).unwrap();
 
-        assert_eq!(heap.cell_len(), 8);
+        assert_eq!(heap.cell_len(), 10);
 
         assert_eq!(heap[0], atom_as_cell!(atom!("second"), 1));
         assert_eq!(heap[1], pstr_loc_as_cell!(heap_index!(2)));
@@ -493,12 +493,14 @@ mod tests {
             heap.slice_to_str(heap_index!(2), "a stuttered".len()),
             "a stuttered"
         );
-        assert_eq!(heap[4], pstr_loc_as_cell!(heap_index!(5)));
+        assert_eq!(heap[4], list_loc_as_cell!(5));
+        assert_eq!(heap[5], char_as_cell!('\u{0}'));
+        assert_eq!(heap[6], pstr_loc_as_cell!(heap_index!(7)));
         assert_eq!(
-            heap.slice_to_str(heap_index!(5), " string".len()),
+            heap.slice_to_str(heap_index!(7), " string".len()),
             " string"
         );
-        assert_eq!(heap[7], empty_list_as_cell!());
+        assert_eq!(heap[9], empty_list_as_cell!());
     }
 
     #[test]


### PR DESCRIPTION
This solves a very old issue that was for years misattributed to the implementation of compact partial strings. It was in fact just a parsing problem, which means that no matter how good the implementation of partial strings was, this would still be a problem.

This closes #1969 and #2810. I think it also closes #2757 if I understood what it means correctly and maybe even #2554 (at least the internal representation part, the printing is still a bit lacking).

```prolog
?- use_module(library(lists)), length("\x0\\x0\", N). % issue 1969 
   N = 2.
?- A = "hello \x00\world". % issue 2810
   A = "hello \x0\world".
?- A = "\x0\a". % issue 2757
   A = "\x0\a".
?- write("1\x0\2"), nl. % issue 2554
[1,,2] % Doesn't actually print \x0\, but at least there's clearly 3 elements.
   true.
?- writeq("1\x0\2"), nl. % issue 2554 alt
['1','\x0\','2'] % With quoting we can see that the \x0\ is actually there.
   true.
```

The diff is surprisingly small compared to how tricky this was to get right. The rest of the codebase has very specific undocumented requirements of how the cells should be laid out here, so the code is a bit convoluted because of that. I've chosen to keep the changes local to only the parsing instead of changing every consumer to understand an alternate format because it would be much more error prone and harder to review.