### PR TITLE
Use backticks when referencing predicate in docs.

### DIFF
--- a/src/lib/clpz.pl
+++ b/src/lib/clpz.pl
@@ -458,7 +458,7 @@ replacements of these low-level arithmetic predicates, often yielding
 more general programs. See [`n_factorial/2`](#clpz-factorial) for an
 example.
 
-This library uses goal_expansion/2 to automatically rewrite
+This library uses `goal_expansion/2` to automatically rewrite
 constraints at compilation time so that low-level arithmetic
 predicates are _automatically_ used whenever possible. For example,
 the predicate:


### PR DESCRIPTION
Trivial change but this prevents the HTML output from being erroneously italicized.

----

Previously it looked like

![image](https://github.com/user-attachments/assets/020bfc10-d087-4475-b769-844a9c375ed9)
