### PR TITLE
Make `WasmQueryState` Iterable in JavaScript

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -78,6 +78,7 @@ impl WasmMachine {
             ),
         }
         .into();
+        self_iterable(&query_state);
 
         Ok(query_state)
     }
@@ -172,6 +173,21 @@ impl WasmQueryState {
         } = self.inner.take().unwrap().into_heads();
         drop_channel.send(machine).unwrap();
     }
+}
+
+/// Sets a [JsValue] as the `Symbol.iterator` property of the [JsValue].
+///
+/// If the [JsValue] conforms to the [JavaScript iterator interface](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators),
+/// this function will make the [JsValue] iterable.
+#[wasm_bindgen(inline_js = "
+    export function self_iterable(obj) {
+        obj[Symbol.iterator] = function () {
+            return this;
+        };
+    }
+")]
+extern "C" {
+    fn self_iterable(obj: &JsValue);
 }
 
 impl From<LeafAnswer> for JsValue {


### PR DESCRIPTION
This PR makes [`WasmQueryState`](https://github.com/mthom/scryer-prolog/blob/8558bd22142220c4de4992dc0f4b3f46502b42d8/src/wasm.rs#L113) an [Iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators#iterables), enabling the use of the `for...of` construct in JavaScript to iterate over query results.

I explored the possibility of achieving this using `js_sys::Reflect::set`, but was unable to define a function that could be correctly bound to JavaScript and return the appropriate `this` context from a `WasmQueryState` instance.

Related to #2873
