### PR TITLE
Update http_server.pl

### DIFF
--- a/src/lib/http/http_server.pl
+++ b/src/lib/http/http_server.pl
@@ -17,6 +17,8 @@ as one HTTP method (in lowercase) and followed by a Route Match and a predicate
 which will handle the call.
 
 ```
+:- use_module(library(http/http_server)).
+
 text_handler(Request, Response) :-
   http_status_code(Response, 200),
   http_body(Response, text("Welcome to Scryer Prolog!")).
@@ -24,10 +26,11 @@ text_handler(Request, Response) :-
 parameter_handler(User, Request, Response) :-
   http_body(Response, text(User)).
 
-http_listen(7890, [
-  get(echo, text_handler),                 % GET /echo
-  post(user/User, parameter_handler(User)) % POST /user/<User>
-]).
+top:-
+  http_listen(7890, [
+    get(echo, text_handler),                 % GET /echo
+    post(user/User, parameter_handler(User)) % POST /user/<User>
+  ]).
 ```
 
 Every handler predicate will have at least 2-arity, with Request and Response.

--- a/src/lib/http/http_server.pl
+++ b/src/lib/http/http_server.pl
@@ -26,7 +26,7 @@ text_handler(Request, Response) :-
 parameter_handler(User, Request, Response) :-
   http_body(Response, text(User)).
 
-top:-
+run:-
   http_listen(7890, [
     get(echo, text_handler),                 % GET /echo
     post(user/User, parameter_handler(User)) % POST /user/<User>


### PR DESCRIPTION
Hi,
I was playing with the example in the library(http/http_server).
Running directly the code popped up a warning about the rewriting of the predicate http_listen/2.
For this reason I suggest the insertion of a top/0 that call the predicate http_listen/2.
In the modification I've inserted an explicit reference to the loading of library(http/http_server).

Hope this could be useful, at least I apologize if I made an unnecessary modification.

Thanks,
Matteo