### PR TITLE
Improvements to predicate_property/2

### DIFF
--- a/src/loader.pl
+++ b/src/loader.pl
@@ -669,25 +669,14 @@ load_context(Module) :-
 :- non_counted_backtracking predicate_property/2.
 
 predicate_property(Callable, Property) :-
-    (  var(Callable) ->
+    strip_module(Callable, Module, Goal),
+    (  ( var(Module) ; var(Goal) ) ->
        instantiation_error(predicate_property/2)
-    ;  functor(Callable, (:), 2),
-       arg(1, Callable, Module),
-       arg(2, Callable, Callable0),
-       atom(Module),
-       nonvar(Callable0) ->
-       functor(Callable0, Name, Arity),
+    ;  functor(Goal, Name, Arity),
        (  atom(Name) ->
           extract_predicate_property(Property, PropertyType),
           check_predicate_property(PropertyType, Module, Name, Arity, Property)
-       ;  type_error(callable, Callable0, predicate_property/2)
-       )
-    ;  functor(Callable, Name, Arity),
-       (  atom(Name) ->
-          extract_predicate_property(Property, PropertyType),
-          load_context(Module),
-          check_predicate_property(PropertyType, Module, Name, Arity, Property)
-       ;  type_error(callable, Callable, predicate_property/2)
+       ;  type_error(callable, Goal, predicate_property/2)
        )
     ).
 

--- a/src/loader.pl
+++ b/src/loader.pl
@@ -670,7 +670,7 @@ load_context(Module) :-
 
 predicate_property(Callable, Property) :-
     strip_module(Callable, Module, Goal),
-    (  ( var(Module) ; var(Goal) ) ->
+    (  ( false, /* disabled branch */ var(Module) ; var(Goal) ) ->
        instantiation_error(predicate_property/2)
     ;  functor(Goal, Name, Arity),
        (  atom(Name) ->


### PR DESCRIPTION
The motivation for this is #2898.

However, throwing instantiation errors for variable module leads to Scryer crashing on startup. This must be addressed before merging.

If anyone has any input on this, I would greatly appreciate it. Thank you a lot!