### PR TITLE
Migrate to strict and exposed provenance

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -611,12 +611,12 @@ mod tests {
         let mut wam = MockWAM::new();
         #[cfg(target_pointer_width = "32")]
         let const_value = HeapCellValue::from(ConsPtr::build_with(
-            0x0000_0431 as *const _,
+            std::ptr::without_provenance(0x0000_0431),
             ConsPtrMaskTag::Cons,
         ));
         #[cfg(target_pointer_width = "64")]
         let const_value = HeapCellValue::from(ConsPtr::build_with(
-            0x0000_5555_ff00_0431 as *const _,
+            std::ptr::without_provenance(0x0000_5555_ff00_0431),
             ConsPtrMaskTag::Cons,
         ));
 

--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -516,12 +516,12 @@ impl AtomTable {
                     }
                 };
 
-                let ptr_base = block_epoch.block.base as usize;
+                let ptr_base = block_epoch.block.base.addr();
 
                 write_to_ptr(string, len_ptr);
 
                 let atom = AtomCell::new()
-                    .with_name((STRINGS.len() + len_ptr as usize - ptr_base) as u64)
+                    .with_name((STRINGS.len() + len_ptr.addr() - ptr_base) as u64)
                     .with_arity(0)
                     .with_f(false)
                     .with_m(false)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -507,7 +507,7 @@ impl Value {
     fn as_ptr(&mut self) -> Result<*mut c_void, FFIError> {
         match self {
             Value::CString(ref mut cstr) => Ok(&mut *cstr as *mut _ as *mut c_void),
-            Value::Int(n) => Ok(*n as *mut c_void),
+            Value::Int(n) => Ok(std::ptr::with_exposed_provenance_mut(*n as usize)),
             _ => Err(FFIError::ValueCast),
         }
     }

--- a/src/functor_macro.rs
+++ b/src/functor_macro.rs
@@ -131,6 +131,7 @@ macro_rules! build_functor {
                        [$($subfunctor),*])
     });
     ([string($s:expr) $(, $dt:ident($($value:tt),*))*], [$($res:expr),*], $res_len:expr, [$($subfunctor:expr),*]) => ({
+        #[allow(unused_parens)]
         let string = $s;
         let pstr_len = cell_index!(Heap::compute_pstr_size(&string)) as u64;
         let result_len = 1 + count!($($dt)*) + $res_len;

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -984,7 +984,7 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
 
     #[inline]
     fn print_raw_ptr(&mut self, ptr: *const ArenaHeader) {
-        append_str!(self, &format!("0x{:x}", ptr as *const u8 as usize));
+        append_str!(self, &format!("0x{:x}", ptr.addr()));
     }
 
     fn print_number(&mut self, max_depth: usize, n: NumberFocus, op: &Option<DirectedOp>) {

--- a/src/machine/heap.rs
+++ b/src/machine/heap.rs
@@ -97,7 +97,7 @@ unsafe fn scan_slice_to_str(heap_slice: &[u8]) -> HeapStringScan {
         .unwrap_or(heap_slice.len());
     let zero_byte_addr = heap_slice.as_ptr().add(string_len);
 
-    let sentinel_len = pstr_sentinel_length(zero_byte_addr as usize);
+    let sentinel_len = pstr_sentinel_length(zero_byte_addr.addr());
     let tail_idx = cell_index!(
         (string_len + sentinel_len).next_multiple_of(ALIGN)
             + if sentinel_len <= 1 { heap_index!(1) } else { 0 }

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -297,7 +297,7 @@ impl Term {
                                     Term::atom(alias.as_str().to_string())
                                 } else {
                                     Term::compound("$stream", [
-                                        Term::integer(stream.as_ptr() as usize)
+                                        Term::integer(stream.as_ptr().addr())
                                     ])
                                 };
                                 term_stack.push(stream_term);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -146,10 +146,11 @@ macro_rules! typed_arena_ptr_as_cell {
 macro_rules! raw_ptr_as_cell {
     ($ptr:expr) => {{
         // Cell is 64-bit, but raw ptr is 32-bit in 32-bit systems
-        // TODO use <*{const,mut} _>::addr instead of as when the strict_provenance feature is stable rust-lang/rust#95228
-        // we might need <*{const,mut} _>::expose_provenance for strict provenance, depending on how we recreate a pointer later
-        let ptr : *const _ = $ptr;
-        HeapCellValue::from_ptr_addr(ptr as usize)
+        let ptr: *const _ = $ptr;
+        // This needs to expose provenance because it needs to be turned back into a pointer
+        // in contexts where there is no available provenance locally. For example, in
+        // `ConsPtr::as_ptr`.
+        HeapCellValue::from_ptr_addr(ptr.expose_provenance())
     }};
 }
 

--- a/src/offset_table.rs
+++ b/src/offset_table.rs
@@ -141,9 +141,8 @@ where
 
         ptr::write(ptr as *mut T, value);
 
-        let value = <OffsetTableImpl<T> as OffsetTable>::Offset::from(
-            ptr as usize - block_epoch.base as usize,
-        );
+        let value =
+            <OffsetTableImpl<T> as OffsetTable>::Offset::from(ptr.addr() - block_epoch.base.addr());
 
         // AtomTable would have to update the index table at this point
         // explicit drop to ensure we don't accidentally drop it early
@@ -270,7 +269,7 @@ where
     #[inline(always)]
     pub fn as_offset(&self) -> <OffsetTableImpl<T> as OffsetTable>::Offset {
         <OffsetTableImpl<T> as OffsetTable>::Offset::from(
-            self.0.get() as usize - RcuRef::get_root(&self.0).base as usize,
+            self.0.get().addr() - RcuRef::get_root(&self.0).base.addr(),
         )
     }
 }

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -66,8 +66,8 @@ impl<T: RawBlockTraits> RawBlock<T> {
                 false
             } else {
                 self.base = new_base;
-                self.top = (self.base as usize + size * 2) as *const _;
-                *self.ptr.get_mut() = (self.base as usize + size) as *mut _;
+                self.top = self.base.add(size * 2);
+                *self.ptr.get_mut() = self.base.add(size).cast_mut();
                 true
             }
         }
@@ -83,7 +83,7 @@ impl<T: RawBlockTraits> RawBlock<T> {
                 // allocation failed
                 None
             } else {
-                let allocated = (*self.ptr.get()) as usize - self.base as usize;
+                let allocated = (*self.ptr.get()).addr() - self.base.addr();
                 self.base.copy_to(new_block.base.cast_mut(), allocated);
                 *new_block.ptr.get_mut() = new_block.base.add(allocated).cast_mut();
                 Some(new_block)
@@ -93,7 +93,7 @@ impl<T: RawBlockTraits> RawBlock<T> {
 
     #[inline]
     pub fn size(&self) -> usize {
-        self.top as usize - self.base as usize
+        self.top.addr() - self.base.addr()
     }
 
     #[inline(always)]
@@ -105,7 +105,7 @@ impl<T: RawBlockTraits> RawBlock<T> {
             self.base
         );
 
-        self.top as usize - (*self.ptr.get()) as usize
+        self.top.addr() - (*self.ptr.get()).addr()
     }
 
     pub unsafe fn alloc(&self, size: usize) -> *mut u8 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -93,7 +93,7 @@ impl ConsPtr {
     #[inline(always)]
     pub fn build_with(ptr: *const ArenaHeader, tag: ConsPtrMaskTag) -> Self {
         ConsPtr::new()
-            .with_ptr(ptr as *const u8 as u64)
+            .with_ptr(ptr.expose_provenance() as u64)
             .with_f(false)
             .with_m(false)
             .with_tag(tag)
@@ -102,7 +102,7 @@ impl ConsPtr {
     #[inline(always)]
     pub fn as_ptr(self) -> *mut u8 {
         let addr: u64 = self.ptr();
-        addr as usize as *mut _
+        std::ptr::with_exposed_provenance_mut(addr as usize)
     }
 
     #[inline(always)]
@@ -377,7 +377,7 @@ where
 {
     #[inline]
     fn from(arena_ptr: TypedArenaPtr<T>) -> HeapCellValue {
-        HeapCellValue::from(arena_ptr.header_ptr() as u64)
+        HeapCellValue::from(arena_ptr.header_ptr().expose_provenance() as u64)
     }
 }
 
@@ -402,7 +402,7 @@ impl From<ConsPtr> for HeapCellValue {
     #[inline(always)]
     fn from(cons_ptr: ConsPtr) -> HeapCellValue {
         HeapCellValue::from_bytes(
-            ConsPtr::from(cons_ptr.as_ptr() as u64)
+            ConsPtr::from(cons_ptr.as_ptr().expose_provenance() as u64)
                 .with_tag(ConsPtrMaskTag::Cons)
                 .with_m(false)
                 .into_bytes(),
@@ -723,14 +723,14 @@ const_assert!(mem::size_of::<UntypedArenaPtr>() == 8);
 impl From<*const ArenaHeader> for UntypedArenaPtr {
     #[inline]
     fn from(ptr: *const ArenaHeader) -> UntypedArenaPtr {
-        UntypedArenaPtr::build_with(ptr as usize)
+        UntypedArenaPtr::build_with(ptr.expose_provenance())
     }
 }
 
 impl From<*const IndexPtr> for UntypedArenaPtr {
     #[inline]
     fn from(ptr: *const IndexPtr) -> UntypedArenaPtr {
-        UntypedArenaPtr::build_with(ptr as usize)
+        UntypedArenaPtr::build_with(ptr.expose_provenance())
     }
 }
 
@@ -750,7 +750,7 @@ impl UntypedArenaPtr {
     #[inline]
     pub fn get_ptr(self) -> *const u8 {
         let addr: u64 = self.ptr();
-        addr as usize as *const u8
+        std::ptr::with_exposed_provenance(addr as usize)
     }
 
     #[inline]


### PR DESCRIPTION
Now that MSRV is 1.85 and we have access to it, this migrates completely from integer-pointer casts to strict provenance, or to exposed provenance where it wasn't sufficient. This already makes Miri go deeper, but it still can't really help a lot after `with_exposed_provenance` is called. At least now we have easily greppable problem spots in the code to eventually get to full strict provenance (any place with `expose_provenance` and `with_exposed_provenance`). I've added comments explaining the trickier spots where exposed provenance is needed (mostly the stack).

In theory if there are no `with_exposed_provenance` calls in the code, then there isn't a need for any `expose_provenance` either, so these spots should be the focus going forward.

The flaky tests pass Miri without even any warnings, so I now believe they are caused by logic bugs and not UB, though it certainly can _trigger_ UB because they put the heap in an unexpected state for other unsafe parts of the codebase. 