### PR TITLE
FIXED: correct partial string tail calculation in arg/3

### DIFF
--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -933,7 +933,7 @@ impl MachineState {
                                     if char_iter.next().is_some() {
                                         unify_fn!(*self, pstr_loc_as_cell!(pstr_loc + c.len_utf8()), a3);
                                     } else {
-                                        let tail_idx = Heap::pstr_tail_idx(pstr_loc);
+                                        let tail_idx = Heap::pstr_tail_idx(pstr_loc + c.len_utf8());
                                         unify_fn!(*self, self.heap[tail_idx], a3);
                                     }
 


### PR DESCRIPTION
This addresses another aspect of #2924, found by @haijinSk. Thank you again!

Example:

    ?- "aaaaaaa" = [_,_,_,_,_,_|T], arg(2, T, 2).