### PR TITLE
make it easier to use Fixnum correctly

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -784,7 +784,9 @@ mod tests {
             _ => { unreachable!() }
         );
 
-        let fixnum_b_cell = fixnum_as_cell!(Fixnum::build_with(1 << 54));
+        let fixnum_b_cell = fixnum_as_cell!(
+            Fixnum::build_with_checked(1i64 << 54).expect("1 << 54 fits in Fixnum")
+        );
 
         assert_eq!(fixnum_b_cell.get_tag(), HeapCellValueTag::Fixnum);
 
@@ -793,41 +795,29 @@ mod tests {
             None => unreachable!(),
         }
 
-        if Fixnum::build_with_checked(1 << 56).is_ok() {
-            unreachable!()
-        }
+        Fixnum::build_with_checked(1i64 << 56).expect_err("1 << 56 is too large for fixnum");
 
-        if Fixnum::build_with_checked(i64::MAX).is_ok() {
-            unreachable!()
-        }
+        Fixnum::build_with_checked(i64::MAX).expect_err("i64::MAX is too large for Fixnum");
+        Fixnum::build_with_checked(i64::MIN).expect_err("i64::MIN is too small for Fixnum");
+        assert_eq!(
+            Fixnum::build_with_checked(-1i64)
+                .expect("-1 fits in fixnum")
+                .get_num(),
+            -1
+        );
 
-        if Fixnum::build_with_checked(i64::MIN).is_ok() {
-            unreachable!()
-        }
+        Fixnum::build_with_checked((1i64 << 55) - 1)
+            .expect("(1 << 55) - 1 is the largest value that fits in Fixnum");
 
-        match Fixnum::build_with_checked(-1) {
-            Ok(n) => assert_eq!(n.get_num(), -1),
-            _ => unreachable!(),
-        }
+        Fixnum::build_with_checked(-(1i64 << 55))
+            .expect("-(1 << 55) is the smallest value that fits in fixnum");
+        Fixnum::build_with_checked(-(1i64 << 55) - 1)
+            .expect_err("-(1<<55) - 1 is too small for Fixnum");
 
-        match Fixnum::build_with_checked((1 << 55) - 1) {
-            Ok(n) => assert_eq!(n.get_num(), (1 << 55) - 1),
-            _ => unreachable!(),
-        }
-
-        match Fixnum::build_with_checked(-(1 << 55)) {
-            Ok(n) => assert_eq!(n.get_num(), -(1 << 55)),
-            _ => unreachable!(),
-        }
-
-        if Fixnum::build_with_checked(-(1 << 55) - 1).is_ok() {
-            unreachable!()
-        }
-
-        match Fixnum::build_with_checked(-1) {
-            Ok(n) => assert_eq!(-n, Fixnum::build_with(1)),
-            _ => unreachable!(),
-        }
+        assert_eq!(
+            -Fixnum::build_with_checked(-1i64).expect("-1 fits in Fixnum"),
+            Fixnum::build_with(1)
+        );
 
         // float
 

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -697,14 +697,14 @@ impl ArenaFrom<isize> for Number {
 impl ArenaFrom<u32> for Number {
     #[inline]
     fn arena_from(value: u32, _arena: &mut Arena) -> Number {
-        Number::Fixnum(Fixnum::build_with(value as i64))
+        Number::Fixnum(Fixnum::build_with(value))
     }
 }
 
 impl ArenaFrom<i32> for Number {
     #[inline]
     fn arena_from(value: i32, _arena: &mut Arena) -> Number {
-        Number::Fixnum(Fixnum::build_with(value as i64))
+        Number::Fixnum(Fixnum::build_with(value))
     }
 }
 

--- a/src/functor_macro.rs
+++ b/src/functor_macro.rs
@@ -78,7 +78,7 @@ macro_rules! build_functor {
      $res_len:expr,
      [$($subfunctor:expr),*]) => ({
          build_functor!([$($dt($($value),*)),*],
-                        [$($res, )* FunctorElement::Cell(fixnum_as_cell!(Fixnum::build_with($e as i64)))],
+                        [$($res, )* FunctorElement::Cell(fixnum_as_cell!(/*FIXME this is not safe*/ unsafe{Fixnum::build_with_unchecked($e as i64)}))],
                         1 + $res_len,
                         [$($subfunctor),*])
     });

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -1500,7 +1500,7 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
 
             self.state_stack.push(TokenOrRedirect::NumberFocus(
                 max_depth,
-                NumberFocus::Unfocused(Number::Fixnum(Fixnum::build_with(port as i64))),
+                NumberFocus::Unfocused(Number::Fixnum(Fixnum::build_with(port))),
                 None,
             ));
             self.state_stack.push(TokenOrRedirect::Comma);
@@ -1527,7 +1527,10 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
 
                 TokenOrRedirect::NumberFocus(
                     max_depth,
-                    NumberFocus::Unfocused(Number::Fixnum(Fixnum::build_with(idx_ptr_p))),
+                    NumberFocus::Unfocused(Number::Fixnum(
+                        /* FIXME this is not safe */
+                        unsafe { Fixnum::build_with_unchecked(idx_ptr_p) },
+                    )),
                     None,
                 )
             };

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -1104,11 +1104,7 @@ pub(crate) fn constant_key_alternatives(constant: Literal) -> Option<Literal> {
         _ => return None,
     };
 
-    if let Ok(n) = n.try_into() {
-        Fixnum::build_with_checked(n).map(Literal::Fixnum).ok()
-    } else {
-        None
-    }
+    Fixnum::build_with_checked(n).map(Literal::Fixnum).ok()
 }
 
 #[derive(Debug)]

--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -198,11 +198,10 @@ pub(crate) fn neg(n: Number, arena: &mut Arena) -> Number {
 pub(crate) fn abs(n: Number, arena: &mut Arena) -> Number {
     match n {
         Number::Fixnum(n) => {
-            if let Some(n) = n.get_num().checked_abs() {
-                fixnum!(Number, n, arena)
+            if let Some(n) = n.checked_abs() {
+                Number::Fixnum(n)
             } else {
-                let arena_int = Integer::from(n.get_num());
-                Number::arena_from(arena_int.abs(), arena)
+                Number::arena_from(Integer::from(Fixnum::MAX + 1), arena)
             }
         }
         Number::Integer(n) => {
@@ -1105,7 +1104,7 @@ pub(crate) fn round(num: Number, arena: &mut Arena) -> Result<Number, MachineStu
 
 pub(crate) fn bitwise_complement(n1: Number, arena: &mut Arena) -> Result<Number, MachineStubGen> {
     match n1 {
-        Number::Fixnum(n) => Ok(Number::Fixnum(Fixnum::build_with(!n.get_num()))),
+        Number::Fixnum(n) => Ok(Number::Fixnum(!n)),
         Number::Integer(n1) => Ok(Number::arena_from(Integer::from(!&*n1), arena)),
         _ => {
             let stub_gen = || {

--- a/src/machine/attributed_variables.rs
+++ b/src/machine/attributed_variables.rs
@@ -120,9 +120,21 @@ impl MachineState {
             and_frame[i] = self.registers[i];
         }
 
-        and_frame[arity + 1] = fixnum_as_cell!(Fixnum::build_with(self.b0 as i64));
-        and_frame[arity + 2] = fixnum_as_cell!(Fixnum::build_with(self.num_of_args as i64));
-        and_frame[arity + 3] = fixnum_as_cell!(Fixnum::build_with(self.attr_var_init.cp as i64));
+        and_frame[arity + 1] =
+            fixnum_as_cell!(
+                /* FIXME this is not safe */
+                unsafe { Fixnum::build_with_unchecked(self.b0 as i64) }
+            );
+        and_frame[arity + 2] =
+            fixnum_as_cell!(
+                /* FIXME this is not safe */
+                unsafe { Fixnum::build_with_unchecked(self.num_of_args as i64) }
+            );
+        and_frame[arity + 3] =
+            fixnum_as_cell!(
+                /* FIXME this is not safe */
+                unsafe { Fixnum::build_with_unchecked(self.attr_var_init.cp as i64) }
+            );
 
         self.verify_attributes()?;
 

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -1021,9 +1021,13 @@ impl Machine {
                                         match self.find_living_dynamic_else(p + next_i) {
                                             Some(_) => {
                                                 self.machine_st.registers
-                                                    [self.machine_st.num_of_args + 1] = fixnum_as_cell!(
-                                                    Fixnum::build_with(self.machine_st.cc as i64)
-                                                );
+                                                    [self.machine_st.num_of_args + 1] =
+                                                    fixnum_as_cell!(unsafe {
+                                                        /* FIXME this is not safe */
+                                                        Fixnum::build_with_unchecked(
+                                                            self.machine_st.cc as i64,
+                                                        )
+                                                    });
 
                                                 self.machine_st.num_of_args += 1;
                                                 self.try_me_else(next_i);
@@ -1042,10 +1046,11 @@ impl Machine {
                                             .prelude
                                             .num_cells;
 
-                                        self.machine_st.cc = cell_as_fixnum!(
+                                        self.machine_st.cc = unsafe {
                                             self.machine_st.stack
                                                 [stack_loc!(OrFrame, self.machine_st.b, n - 1)]
-                                        )
+                                            .to_fixnum_or_cut_point_unchecked()
+                                        }
                                         .get_num()
                                             as usize;
 
@@ -1095,7 +1100,12 @@ impl Machine {
                                             Some(_) => {
                                                 self.machine_st.registers
                                                     [self.machine_st.num_of_args + 1] = fixnum_as_cell!(
-                                                    Fixnum::build_with(self.machine_st.cc as i64)
+                                                    /* FIXME this is not safe */
+                                                    unsafe {
+                                                        Fixnum::build_with_unchecked(
+                                                            self.machine_st.cc as i64,
+                                                        )
+                                                    }
                                                 );
 
                                                 self.machine_st.num_of_args += 1;
@@ -1115,10 +1125,11 @@ impl Machine {
                                             .prelude
                                             .num_cells;
 
-                                        self.machine_st.cc = cell_as_fixnum!(
+                                        self.machine_st.cc = unsafe {
                                             self.machine_st.stack
                                                 [stack_loc!(OrFrame, self.machine_st.b, n - 1)]
-                                        )
+                                            .to_fixnum_or_cut_point_unchecked()
+                                        }
                                         .get_num()
                                             as usize;
 
@@ -1174,7 +1185,10 @@ impl Machine {
                     &Instruction::GetLevel(r) => {
                         let b0 = self.machine_st.b0;
 
-                        self.machine_st[r] = fixnum_as_cell!(Fixnum::as_cutpoint(b0 as i64));
+                        self.machine_st[r] = fixnum_as_cell!(
+                            /* FIXME this is not safe */
+                            unsafe { Fixnum::build_with_unchecked(b0 as i64) }.as_cutpoint()
+                        );
                         self.machine_st.p += 1;
                     }
                     &Instruction::GetPrevLevel(r) => {
@@ -1185,12 +1199,18 @@ impl Machine {
                             .prelude
                             .b;
 
-                        self.machine_st[r] = fixnum_as_cell!(Fixnum::as_cutpoint(prev_b as i64));
+                        self.machine_st[r] = fixnum_as_cell!(
+                            /* FIXME this is not safe */
+                            unsafe { Fixnum::build_with_unchecked(prev_b as i64) }.as_cutpoint()
+                        );
                         self.machine_st.p += 1;
                     }
                     &Instruction::GetCutPoint(r) => {
                         self.machine_st[r] =
-                            fixnum_as_cell!(Fixnum::as_cutpoint(self.machine_st.b as i64));
+                            fixnum_as_cell!(/* FIXME this is not safe */ unsafe {
+                                Fixnum::build_with_unchecked(self.machine_st.b as i64)
+                            }
+                            .as_cutpoint());
                         self.machine_st.p += 1;
                     }
                     &Instruction::Cut(r) => {
@@ -3150,10 +3170,14 @@ impl Machine {
                                                 match self.find_living_dynamic(oi, ii + 1) {
                                                     Some(_) => {
                                                         self.machine_st.registers
-                                                            [self.machine_st.num_of_args + 1] =
-                                                            fixnum_as_cell!(Fixnum::build_with(
-                                                                self.machine_st.cc as i64
-                                                            ));
+                                                            [self.machine_st.num_of_args + 1] = fixnum_as_cell!(
+                                                            /* FIXME this is not safe */
+                                                            unsafe {
+                                                                Fixnum::build_with_unchecked(
+                                                                    self.machine_st.cc as i64,
+                                                                )
+                                                            }
+                                                        );
 
                                                         self.machine_st.num_of_args += 1;
                                                         self.indexed_try(offset);
@@ -3175,10 +3199,11 @@ impl Machine {
                                                     .prelude
                                                     .num_cells;
 
-                                                self.machine_st.cc = cell_as_fixnum!(
+                                                self.machine_st.cc = unsafe {
                                                     self.machine_st.stack
                                                         [stack_loc!(OrFrame, b, n - 1)]
-                                                )
+                                                    .to_fixnum_or_cut_point_unchecked()
+                                                }
                                                 .get_num()
                                                     as usize;
 
@@ -5256,8 +5281,11 @@ impl Machine {
                                 .machine_st
                                 .store(self.machine_st.deref(self.machine_st.registers[5]));
 
-                            self.machine_st
-                                .unify_fixnum(Fixnum::build_with(n as i64), r);
+                            self.machine_st.unify_fixnum(
+                                /* FIXME this is not safe */
+                                unsafe { Fixnum::build_with_unchecked(n as i64) },
+                                r,
+                            );
                         }
 
                         self.machine_st.call_at_index(2, p);
@@ -5299,8 +5327,11 @@ impl Machine {
                                 .machine_st
                                 .store(self.machine_st.deref(self.machine_st.registers[5]));
 
-                            self.machine_st
-                                .unify_fixnum(Fixnum::build_with(n as i64), r);
+                            self.machine_st.unify_fixnum(
+                                /* FIXME this is not safe */
+                                unsafe { Fixnum::build_with_unchecked(n as i64) },
+                                r,
+                            );
                         }
 
                         self.machine_st.execute_at_index(2, p);

--- a/src/machine/loader.rs
+++ b/src/machine/loader.rs
@@ -2344,7 +2344,9 @@ impl Machine {
                             MetaSpec::Either => atom_as_cell!(atom!("?")),
                             MetaSpec::Colon => atom_as_cell!(atom!(":")),
                             MetaSpec::RequiresExpansionWithArgument(ref arg_num) => {
-                                fixnum_as_cell!(Fixnum::build_with(*arg_num as i64))
+                                fixnum_as_cell!(/* FIXME this is not safe */ unsafe {
+                                    Fixnum::build_with_unchecked(*arg_num as i64)
+                                })
                             }
                         });
                     }

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -1003,7 +1003,10 @@ impl MachineState {
         arity: HeapCellValue,
     ) -> (Atom, usize) {
         let name = cell_as_atom!(self.store(self.deref(name)));
-        let arity = cell_as_fixnum!(self.store(self.deref(arity)));
+        let arity = unsafe {
+            self.store(self.deref(arity))
+                .to_fixnum_or_cut_point_unchecked()
+        };
 
         (name, usize::try_from(arity.get_num()).unwrap())
     }

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -940,7 +940,7 @@ impl MachineState {
                                     /*
                                     if pstr_atom.len() > offset as usize {
                                         self.heap.push(pstr_offset_as_cell!(h));
-                                        self.heap.push(fixnum_as_cell!(Fixnum::build_with(offset)));
+                                        self.heap.push(fixnum_as_cell!(Fixnum::build_with_unchecked(offset as i64)));
 
                                         unify_fn!(*self, pstr_loc_as_cell!(h_len), a3);
                                     } else {
@@ -973,13 +973,13 @@ impl MachineState {
                             if n == 1 {
                                 self.unify_char(c, self.store(self.deref(self.registers[3])));
                             } else if n == 2 {
-                                let offset = c.len_utf8() as i64;
+                                let offset = c.len_utf8();
                                 let h_len = self.heap.len();
 
-                                if cstr_atom.len() > offset as usize {
+                                if cstr_atom.len() > offset{
                                     self.heap.push(atom_as_cstr_cell!(cstr_atom));
                                     self.heap.push(pstr_offset_as_cell!(h_len));
-                                    self.heap.push(fixnum_as_cell!(Fixnum::build_with(offset)));
+                                    self.heap.push(fixnum_as_cell!(Fixnum::build_with_unchecked(offset as i64)));
 
                                     unify_fn!(*self, pstr_loc_as_cell!(h_len+1), self.registers[3]);
                                 } else {
@@ -1027,7 +1027,11 @@ impl MachineState {
 
         if !self.fail {
             let a3 = self.store(self.deref(self.registers[3]));
-            self.unify_fixnum(Fixnum::build_with(arity as i64), a3);
+            self.unify_fixnum(
+                /* FIXME this is not safe */
+                unsafe { Fixnum::build_with_unchecked(arity as i64) },
+                a3,
+            );
         }
     }
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -1187,8 +1187,10 @@ impl Machine {
                 let (idx, arity) = if self.machine_st.effective_block() > prev_block {
                     (r_c_w_h, 0)
                 } else {
-                    self.machine_st.registers[1] =
-                        fixnum_as_cell!(Fixnum::build_with(b_cutoff as i64));
+                    self.machine_st.registers[1] = fixnum_as_cell!(
+                        /* FIXME this is not safe */
+                        unsafe { Fixnum::build_with_unchecked(b_cutoff as i64) }
+                    );
 
                     (r_c_wo_h, 1)
                 };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,12 +14,6 @@ macro_rules! fixnum_as_cell {
     };
 }
 
-macro_rules! cell_as_fixnum {
-    ($cell:expr) => {
-        Fixnum::from_bytes($cell.into_bytes())
-    };
-}
-
 macro_rules! integer_as_cell {
     ($n: expr) => {{
         match $n {

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -890,7 +890,7 @@ impl<'a, R: CharRead> Lexer<'a, R> {
                 }
 
                 self.get_single_quoted_char()
-                    .map(|c| Token::Literal(Literal::Fixnum(Fixnum::build_with(c as i64))))
+                    .map(|c| Token::Literal(Literal::Fixnum(Fixnum::build_with(c))))
                     .or_else(|err| {
                         match err {
                             ParserError::UnexpectedChar('\'', ..) => {}

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -389,7 +389,7 @@ impl<'a, R: CharRead> Parser<'a, R> {
                         Cell::default(),
                         Box::new(Term::Literal(
                             Cell::default(),
-                            Literal::Fixnum(Fixnum::build_with(c as i64)),
+                            Literal::Fixnum(Fixnum::build_with(c)),
                         )),
                         Box::new(list),
                     );

--- a/src/types.rs
+++ b/src/types.rs
@@ -588,6 +588,16 @@ impl HeapCellValue {
         }
     }
 
+    // FIXME: someone that knows this better should check if this can be split into `to_fixnum_unchecked` and `to_cut_point_unchecked` assuming thats always unambigusly knowable
+    #[inline]
+    pub unsafe fn to_fixnum_or_cut_point_unchecked(self) -> Fixnum {
+        debug_assert!(matches!(
+            self.get_tag(),
+            HeapCellValueTag::Fixnum | HeapCellValueTag::CutPoint
+        ));
+        Fixnum::from_bytes(self.into_bytes())
+    }
+
     #[inline]
     pub fn from_ptr_addr(ptr_bytes: usize) -> Self {
         HeapCellValue::from_bytes((ptr_bytes as u64).to_ne_bytes())


### PR DESCRIPTION
`Fixnum::build_with` was silently truncating out-of-bounds values,
this is now `Fixnum::build_with_unchecked` and `Fixnum::build_with` can only be called with types that are guaranteed valid. This also adds a fallible `Fixnum::build_with_checked` that can be called with types that may be out-of-bounds.
Further this replaces the `call_as_fixnum!` macro with an unsafe function  `HeapCellValue::to_fixnum_or_cut_point_unchecked` (didn't know which should be which so one function for both ).
The added unsafe functions contain `debug_asserts!` so that tests and debug builds should panic if an invalid value is passed to them, instead of silently corrupting the machine state.

This was originally b133ef563bfb47cbc800a60ad8f86c705ad75533 part of #2786