### PR TITLE
fix #2949

### DIFF
--- a/src/lib/sgml.pl
+++ b/src/lib/sgml.pl
@@ -96,14 +96,14 @@ is_sgml_source([]).
 is_sgml_source([C|Cs]) :- must_be(chars, [C|Cs]).
 
 load_structure_([], [], _, _).
-load_structure_([C|Cs], [E], Options, What) :-
-        load_(What, [C|Cs], E, Options).
-load_structure_(file(Fs), [E], Options, What) :-
+load_structure_([C|Cs], [E|Es], Options, What) :-
+        load_(What, [C|Cs], [E|Es], Options).
+load_structure_(file(Fs), [E|Es], Options, What) :-
         once(phrase_from_file(seq(Cs), Fs)),
-        load_(What, Cs, E, Options).
-load_structure_(stream(Stream), [E], Options, What) :-
+        load_(What, Cs, [E|Es], Options).
+load_structure_(stream(Stream), [E|Es], Options, What) :-
         get_n_chars(Stream, _, Cs),
-        load_(What, Cs, E, Options).
+        load_(What, Cs, [E|Es], Options).
 
 load_(html, Cs, E, Options) :- '$load_html'(Cs, E, Options).
 load_(xml, Cs, E, Options) :- '$load_xml'(Cs, E, Options).

--- a/tests-pl/issue2949.pl
+++ b/tests-pl/issue2949.pl
@@ -1,0 +1,11 @@
+:- use_module(library(sgml)).
+
+test :- 
+    load_html("<!DOCTYPE html><html><head><title>Hello!</title></head></html>", Es, []), 
+    write(Es),
+    load_html("<!DOCTYPE html><html><head><title>Hello!</title><!-- comment --></head></html>", Es2, []), 
+    write(Es2),
+    load_html("<!", Es3, []), 
+    write(Es3).
+
+:- initialization(test).

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -20,6 +20,12 @@ fn issue2588_load_html() {
     load_module_test("tests-pl/issue2588.pl", "[element(html,[],[element(head,[],[element(title,[],[[H,e,l,l,o,!]])]),element(body,[],[])])]");
 }
 
+#[test]
+#[cfg_attr(miri, ignore = "unsupported operation when isolation is enabled")]
+fn issue2949_load_html() {
+    load_module_test("tests-pl/issue2949.pl", "[doctype([h,t,m,l]),element(html,[],[element(head,[],[element(title,[],[[H,e,l,l,o,!]])]),element(body,[],[])])][doctype([h,t,m,l]),element(html,[],[element(head,[],[element(title,[],[[H,e,l,l,o,!]]),comment([ ,c,o,m,m,e,n,t, ])]),element(body,[],[])])][comment([]),element(html,[],[element(head,[],[]),element(body,[],[])])]");
+}
+
 // issue #2361
 #[serial]
 #[test]


### PR DESCRIPTION
- properly handle html documents with more than one root child
- handle doctype (#2949), comments and processing instructions