### PR TITLE
Document `when/2` Condition

### DIFF
--- a/src/lib/when.pl
+++ b/src/lib/when.pl
@@ -19,6 +19,7 @@ Provides the predicate `when/2`.
 %% when(Condition, Goal).
 %
 % Executes Goal when Condition becomes true.
+% Condition may consist of `ground(T)`, `nonvar(T)`, `C1,C2`, `C1;C2`.
 when(Condition, Goal) :-
     (   when_condition(Condition) ->
         (   Condition ->


### PR DESCRIPTION
It seems like `when/2` can accept an arbitrary goal as a condition. This documents what is expected for that argument.