### PR TITLE
Remove obsolete compatibility for Rust<1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ hostname = ["dep:hostname"]
 tls = ["dep:native-tls"]
 http = ["dep:warp", "dep:reqwest"]
 crypto-full = []
-"rust-version-1.80" = []
 
 [build-dependencies]
 indexmap = "2.3.0"

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -118,32 +118,6 @@ fn current_dir() -> PathBuf {
     }
 }
 
-#[cfg(not(feature = "rust-version-1.80"))]
-mod libraries {
-    use indexmap::IndexMap;
-    use std::sync::OnceLock;
-
-    fn libraries() -> &'static IndexMap<&'static str, &'static str> {
-        static LIBRARIES: OnceLock<IndexMap<&'static str, &'static str>> = OnceLock::new();
-        LIBRARIES.get_or_init(|| {
-            let mut m = IndexMap::new();
-
-            include!(concat!(env!("OUT_DIR"), "/libraries.rs"));
-
-            m
-        })
-    }
-
-    pub(crate) fn contains(name: &str) -> bool {
-        libraries().contains_key(name)
-    }
-
-    pub(crate) fn get(name: &str) -> Option<&'static str> {
-        libraries().get(name).copied()
-    }
-}
-
-#[cfg(feature = "rust-version-1.80")]
 mod libraries {
     use indexmap::IndexMap;
     use std::sync::LazyLock;


### PR DESCRIPTION
This code was introduced in #2457 to use `LazyLock`, introduced in Rust 1.80. The targeted Rust version was 1.77 in Cargo.toml. Now that Cargo.toml lists the minimum version as 1.85, this compilation flag is no longer necessary.