### PR TITLE
Add `memory_stream/1` 

### DIFF
--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -245,6 +245,8 @@ enum SystemClauseType {
     CurrentHostname,
     #[strum_discriminants(strum(props(Arity = "1", Name = "$current_input")))]
     CurrentInput,
+    #[strum_discriminants(strum(props(Arity = "1", Name = "$memory_stream")))]
+    MemoryStream,
     #[strum_discriminants(strum(props(Arity = "1", Name = "$current_output")))]
     CurrentOutput,
     #[strum_discriminants(strum(props(Arity = "2", Name = "$directory_files")))]
@@ -1708,6 +1710,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::CallCreatePartialString |
                     &Instruction::CallCurrentHostname |
                     &Instruction::CallCurrentInput |
+                    &Instruction::CallMemoryStream |
                     &Instruction::CallCurrentOutput |
                     &Instruction::CallDirectoryFiles |
                     &Instruction::CallFileSize |
@@ -1946,6 +1949,7 @@ fn generate_instruction_preface() -> TokenStream {
                     &Instruction::ExecuteCreatePartialString |
                     &Instruction::ExecuteCurrentHostname |
                     &Instruction::ExecuteCurrentInput |
+                    &Instruction::ExecuteMemoryStream |
                     &Instruction::ExecuteCurrentOutput |
                     &Instruction::ExecuteDirectoryFiles |
                     &Instruction::ExecuteFileSize |

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -3385,6 +3385,10 @@ impl Machine {
                         try_or_throw!(self.machine_st, self.current_input());
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }
+                    &Instruction::CallMemoryStream => {
+                        try_or_throw!(self.machine_st, self.memory_stream());
+                        step_or_fail!(self, self.machine_st.p += 1);
+                    }
                     &Instruction::ExecuteMemoryStream => {
                         try_or_throw!(self.machine_st, self.memory_stream());
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -3385,6 +3385,10 @@ impl Machine {
                         try_or_throw!(self.machine_st, self.current_input());
                         step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
                     }
+                    &Instruction::ExecuteMemoryStream => {
+                        try_or_throw!(self.machine_st, self.memory_stream());
+                        step_or_fail!(self, self.machine_st.p = self.machine_st.cp);
+                    }
                     &Instruction::CallCurrentOutput => {
                         try_or_throw!(self.machine_st, self.current_output());
                         step_or_fail!(self, self.machine_st.p += 1);

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -16,7 +16,7 @@ use crate::heap_print::*;
 #[cfg(feature = "http")]
 use crate::http::{HttpListener, HttpRequest, HttpRequestData, HttpResponse};
 use crate::instructions::*;
-use crate::machine;
+use crate::{machine, MachineBuilder, StreamConfig};
 use crate::machine::code_walker::*;
 use crate::machine::copier::*;
 use crate::machine::heap::*;
@@ -1889,7 +1889,7 @@ impl Machine {
             (HeapCellValueTag::Cons, cons_ptr) => {
                 match_untyped_arena_ptr!(cons_ptr,
                     (ArenaHeaderTag::Stream, other_stream) => {
-                        self.machine_st.fail = stream != other_stream;
+                        self.machine_st.fail = !stream.eq(&other_stream);
                     }
                     _ => {
                         let stub = functor_stub(atom!("current_input"), 1);
@@ -1913,7 +1913,9 @@ impl Machine {
     #[inline(always)]
     pub(crate) fn memory_stream(&mut self) -> CallResult {
         let addr = self.deref_register(1);
-        let stream = StreamConfig::in_memory();
+        let stream = MachineBuilder::new()
+            .with_streams(StreamConfig::in_memory())
+            .build().user_input;
 
         if let Some(var) = addr.as_var() {
             self.machine_st.bind(var, stream.into());

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -1911,6 +1911,41 @@ impl Machine {
     }
 
     #[inline(always)]
+    pub(crate) fn memory_stream(&mut self) -> CallResult {
+        let addr = self.deref_register(1);
+        let stream = StreamConfig::in_memory();
+
+        if let Some(var) = addr.as_var() {
+            self.machine_st.bind(var, stream.into());
+            return Ok(());
+        }
+
+        read_heap_cell!(addr,
+            (HeapCellValueTag::Cons, cons_ptr) => {
+                match_untyped_arena_ptr!(cons_ptr,
+                    (ArenaHeaderTag::Stream, other_stream) => {
+                        self.machine_st.fail = stream != other_stream;
+                    }
+                    _ => {
+                        let stub = functor_stub(atom!("memory_stream"), 1);
+                        let err = self.machine_st.domain_error(DomainErrorType::Stream, addr);
+
+                        return Err(self.machine_st.error_form(err, stub));
+                    }
+                );
+            }
+            _ => {
+                let stub = functor_stub(atom!("memory_stream"), 1);
+                let err = self.machine_st.domain_error(DomainErrorType::Stream, addr);
+
+                return Err(self.machine_st.error_form(err, stub));
+            }
+        );
+
+        Ok(())
+    }
+
+    #[inline(always)]
     pub(crate) fn current_output(&mut self) -> CallResult {
         let addr = self.deref_register(1);
         let stream = self.user_output;


### PR DESCRIPTION
https://github.com/jjtolton/scryer-memory-stream

Intended usage:

```prolog
:- module(memory_stream, [memory_stream/1]).

memory_stream(Stream) :-
        '$memory_stream'(Stream).
```

Currently, I have implemented this in the dumbest possible way.  Suggestions appreciated.
