### PR TITLE
use nonterminal indicators, correct meta_predicate/1 for higher-order phrase//N

### DIFF
--- a/src/lib/dcgs.pl
+++ b/src/lib/dcgs.pl
@@ -12,8 +12,8 @@ to learn more about them.
           [op(1105, xfy, '|'),
            phrase/2,
            phrase/3,
-           phrase/4,
-           phrase/5,
+           phrase//2,
+           phrase//3,
            seq//1,
            seqq//1,
            ... //0,
@@ -29,9 +29,9 @@ to learn more about them.
 
 :- meta_predicate phrase(2, ?, ?).
 
-:- meta_predicate phrase(2, ?, ?, ?).
+:- meta_predicate(phrase(3, ?, ?, ?)).
 
-:- meta_predicate phrase(2, ?, ?, ?, ?).
+:- meta_predicate(phrase(4, ?, ?, ?, ?)).
 
 :- meta_predicate(','(2, 2, ?, ?)).
 


### PR DESCRIPTION
Noted by @UWN in https://github.com/mthom/scryer-prolog/discussions/2872.

Many thanks!