### PR TITLE
CI: run clippy even if fmt fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: cargo fmt --check
       - name: Check clippy
         run: cargo clippy --no-deps --all-targets
+        if: ${{ !cancelled() }}
 
   build-test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Even if `fmt` fails, there can be useful deeper insights from clippy.