### PR TITLE
CI: run clippy even if fmt fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: cargo fmt --check
       - name: Check clippy
         run: cargo clippy --no-deps --all-targets
+        if: ${{ !cancelled() }}
 
   build-test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Same as #3003, but targeting rebis-dev. Should make CI more informative and helpful when iterating.