### PR TITLE
ADDED: variants of errors promoting call_with_error_context/2

### DIFF
--- a/src/lib/error.pl
+++ b/src/lib/error.pl
@@ -9,6 +9,7 @@
                   domain_error/2,
                   type_error/2,
                   representation_error/1,
+                  resource_error/1,
                   instantiation_error/1,
                   domain_error/3,
                   type_error/3,
@@ -235,6 +236,9 @@ type_error(Type, Term) :-
 
 representation_error(Flag) :-
     throw(error(representation_error(Flag), [])).
+
+resource_error(Resource) :-
+    throw(error(resource_error(Resource), [])).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    The variants *with* context would not have been needed if

--- a/src/lib/error.pl
+++ b/src/lib/error.pl
@@ -6,10 +6,11 @@
 :- module(error, [must_be/2,
                   can_be/2,
                   instantiation_error/0,
-                  instantiation_error/1,
                   domain_error/2,
-                  domain_error/3,
                   type_error/2,
+                  representation_error/1,
+                  instantiation_error/1,
+                  domain_error/3,
                   type_error/3,
                   call_with_error_context/2
                   ]).
@@ -221,10 +222,6 @@ list_or_partial_list(Ls) :-
 
    The variants without context promote the use of
    call_with_error_context/2.
-
-   The variants *with* context would not have been needed if
-   call_with_error_context/2 had been found earlier. In the future,
-   we may be able to remove them.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 instantiation_error :-
@@ -236,6 +233,14 @@ domain_error(Type, Term) :-
 type_error(Type, Term) :-
     throw(error(type_error(Type, Term), [])).
 
+representation_error(Flag) :-
+    throw(error(representation_error(Flag), [])).
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   The variants *with* context would not have been needed if
+   call_with_error_context/2 had been found earlier. In the future,
+   we may be able to remove them.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 instantiation_error(Context) :-
     throw(error(instantiation_error, Context)).

--- a/src/lib/error.pl
+++ b/src/lib/error.pl
@@ -5,8 +5,11 @@
 
 :- module(error, [must_be/2,
                   can_be/2,
+                  instantiation_error/0,
                   instantiation_error/1,
+                  domain_error/2,
                   domain_error/3,
+                  type_error/2,
                   type_error/3,
                   call_with_error_context/2
                   ]).
@@ -215,7 +218,24 @@ list_or_partial_list(Ls) :-
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    Shorthands for throwing ISO errors.
+
+   The variants without context promote the use of
+   call_with_error_context/2.
+
+   The variants *with* context would not have been needed if
+   call_with_error_context/2 had been found earlier. In the future,
+   we may be able to remove them.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+instantiation_error :-
+    throw(error(instantiation_error, [])).
+
+domain_error(Type, Term) :-
+    throw(error(domain_error(Type, Term), [])).
+
+type_error(Type, Term) :-
+    throw(error(type_error(Type, Term), [])).
+
 
 instantiation_error(Context) :-
     throw(error(instantiation_error, Context)).


### PR DESCRIPTION
A good example of call_with_error_context/2 was recently provided by @Skgland in d907f86c8d3bf5b5429c9f53187b65473fcbfce0. Many thanks!