### PR TITLE
Fix msrv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,20 @@ jobs:
         run: cargo clippy --no-deps --all-targets
         if: ${{ !cancelled() }}
 
+  read-msrv:
+    runs-on: ubuntu-22.04
+    outputs: 
+      msrv: ${{ steps.read-declared-msrv.outputs.msrv }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read-declared-msrv
+        name: Read msrv from Cargo.toml rust_version field
+        run: echo "msrv=$(cargo metadata  --no-deps --format-version  1 | jq -r '.packages[] | select(.name = "scryer-prolog") | ."rust_version"')" >>  "$GITHUB_OUTPUT"
+          
+
   build-test:
     runs-on: ${{ matrix.os }}
+    needs: [read-msrv]
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +61,7 @@ jobs:
           # FIXME(issue #2138): run wasm tests, failing to run since https://github.com/mthom/scryer-prolog/pull/2137 removed wasm-pack
           - { os: ubuntu-22.04,   rust-version: nightly, target: 'wasm32-unknown-unknown',   publish: true, args: '--no-default-features' , test-args: '--no-run --no-default-features', use_swap: true }
           # Cargo.toml rust-version
-          - { os: ubuntu-22.04,   rust-version: "1.87",  target: 'x86_64-unknown-linux-gnu'}
+          - { os: ubuntu-22.04,   rust-version: "${{ needs.read-msrv.outputs.msrv }}" ,  target: 'x86_64-unknown-linux-gnu'}
           - { os: ubuntu-22.04,   rust-version: beta,    target: 'x86_64-unknown-linux-gnu'}
           - { os: ubuntu-22.04,   rust-version: nightly, target: 'x86_64-unknown-linux-gnu', miri: true, components: "miri"} 
     defaults:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "to-syn-value_derive",
  "tokio",
  "trycmd",
+ "version_check",
  "walkdir",
  "warp",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["prolog", "prolog-interpreter", "prolog-system"]
 categories = ["command-line-utilities"]
 build = "build/main.rs"
 # Remember to check CI
-rust-version = "1.87"
+rust-version = "1.85"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -25,6 +25,12 @@ tls = ["dep:native-tls"]
 http = ["dep:warp", "dep:reqwest"]
 crypto-full = []
 
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = [
+    'cfg(rust_version, values("1.87.0"))',
+] }
+
+
 [build-dependencies]
 indexmap = "2.3.0"
 proc-macro2 = "1.0.86"
@@ -34,6 +40,7 @@ strum_macros = "0.26"
 syn = { version = "2.0.72", features = ['full', 'visit', 'extra-traits'] }
 to-syn-value = "0.1.1"
 to-syn-value_derive = "0.1.1"
+version_check = "0.9.5"
 walkdir = "2"
 
 [dependencies]

--- a/build/main.rs
+++ b/build/main.rs
@@ -43,6 +43,10 @@ fn find_prolog_files(path_prefix: &str, current_dir: &Path) -> Vec<(String, Path
 }
 
 fn main() {
+    if version_check::is_min_version("1.87.0").unwrap_or(false) {
+        println!(r#"cargo:rustc-cfg=rust_version="1.87.0""#);
+    }
+
     let has_rustfmt = Command::new("rustfmt")
         .arg("--version")
         .stdin(Stdio::inherit())

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -14,8 +14,6 @@ use ordered_float::OrderedFloat;
 use std::fmt;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
-use std::io::PipeReader;
-use std::io::PipeWriter;
 use std::mem;
 use std::mem::ManuallyDrop;
 use std::net::TcpListener;
@@ -24,6 +22,8 @@ use std::process::Child;
 use std::ptr;
 use std::ptr::addr_of_mut;
 use std::ptr::NonNull;
+
+use crate::machine::streams::{PipeReader, PipeWriter};
 
 macro_rules! arena_alloc {
     ($e:expr, $arena:expr) => {{

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -23,8 +23,6 @@ use std::fmt::Debug;
 use std::fs::{File, OpenOptions};
 use std::hash::Hash;
 use std::io;
-use std::io::PipeReader;
-use std::io::PipeWriter;
 use std::io::{Cursor, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::mem::ManuallyDrop;
 use std::net::{Shutdown, TcpStream};
@@ -39,6 +37,9 @@ use native_tls::TlsStream;
 
 #[cfg(feature = "http")]
 use warp::hyper;
+
+mod compat;
+pub use compat::*;
 
 #[derive(Debug, BitfieldSpecifier, Clone, Copy, PartialEq, Eq, Hash)]
 #[bits = 1]
@@ -1413,14 +1414,14 @@ impl Stream {
         ))
     }
 
-    pub(crate) fn from_pipe_writer(writer: io::PipeWriter, arena: &mut Arena) -> Stream {
+    pub(crate) fn from_pipe_writer(writer: PipeWriter, arena: &mut Arena) -> Stream {
         Stream::PipeWriter(arena_alloc!(
             ManuallyDrop::new(StreamLayout::new(CharReader::new(writer))),
             arena
         ))
     }
 
-    pub(crate) fn from_pipe_reader(reader: io::PipeReader, arena: &mut Arena) -> Stream {
+    pub(crate) fn from_pipe_reader(reader: PipeReader, arena: &mut Arena) -> Stream {
         Stream::PipeReader(arena_alloc!(
             ManuallyDrop::new(StreamLayout::new(CharReader::new(reader))),
             arena

--- a/src/machine/streams/compat.rs
+++ b/src/machine/streams/compat.rs
@@ -1,0 +1,70 @@
+#[cfg(rust_version = "1.87.0")]
+pub use ge_1_87_0::{PipeReader, PipeWriter};
+
+#[cfg(not(rust_version = "1.87.0"))]
+pub use lt_1_87_0::{PipeReader, PipeWriter};
+
+#[cfg(not(rust_version = "1.87.0"))]
+pub(crate) use lt_1_87_0::PipeReaderInner;
+
+#[cfg(not(rust_version = "1.87.0"))]
+mod lt_1_87_0 {
+    use std::process::{ChildStderr, ChildStdout};
+
+    pub type PipeWriter = std::process::ChildStdin;
+
+    #[derive(Debug)]
+    pub struct PipeReader(pub(crate) PipeReaderInner);
+
+    #[derive(Debug)]
+    pub(crate) enum PipeReaderInner {
+        Stdout(ChildStdout),
+        Stderr(ChildStderr),
+    }
+
+    impl std::io::Read for PipeReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            match &mut self.0 {
+                PipeReaderInner::Stdout(child_stdout) => child_stdout.read(buf),
+                PipeReaderInner::Stderr(child_stderr) => child_stderr.read(buf),
+            }
+        }
+
+        fn read_vectored(
+            &mut self,
+            bufs: &mut [std::io::IoSliceMut<'_>],
+        ) -> std::io::Result<usize> {
+            match &mut self.0 {
+                PipeReaderInner::Stdout(child_stdout) => child_stdout.read_vectored(bufs),
+                PipeReaderInner::Stderr(child_stderr) => child_stderr.read_vectored(bufs),
+            }
+        }
+
+        fn read_to_end(&mut self, buf: &mut Vec<u8>) -> std::io::Result<usize> {
+            match &mut self.0 {
+                PipeReaderInner::Stdout(child_stdout) => child_stdout.read_to_end(buf),
+                PipeReaderInner::Stderr(child_stderr) => child_stderr.read_to_end(buf),
+            }
+        }
+
+        fn read_to_string(&mut self, buf: &mut String) -> std::io::Result<usize> {
+            match &mut self.0 {
+                PipeReaderInner::Stdout(child_stdout) => child_stdout.read_to_string(buf),
+                PipeReaderInner::Stderr(child_stderr) => child_stderr.read_to_string(buf),
+            }
+        }
+
+        fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
+            match &mut self.0 {
+                PipeReaderInner::Stdout(child_stdout) => child_stdout.read_exact(buf),
+                PipeReaderInner::Stderr(child_stderr) => child_stderr.read_exact(buf),
+            }
+        }
+    }
+}
+
+#[cfg(rust_version = "1.87.0")]
+mod ge_1_87_0 {
+    pub type PipeReader = std::io::PipeReader;
+    pub type PipeWriter = std::io::PipeWriter;
+}


### PR DESCRIPTION
As I noted in https://github.com/mthom/scryer-prolog/discussions/2784#discussioncomment-14137557
when I made #3009 I forgot that we wanted to keep the MSRV at 1.85 for compatibility with debian trixi.

This fixes that mistake by detecting the current rust version and falling back to a different implementation on rust < 1.87.0.