### PR TITLE
move CI  job release from retired ubuntu-20.04 image to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
 
   # Publish binaries when building for a tag
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build-test]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:


### PR DESCRIPTION
the new image is the same as all other ubuntu jobs

fixes #3107 