### PR TITLE
Fix marking of partial string tail in iteration

### DIFF
--- a/src/heap_iter.rs
+++ b/src/heap_iter.rs
@@ -118,8 +118,8 @@ impl<'a> EagerStackfulPreOrderHeapIter<'a> {
                 (HeapCellValueTag::PStrLoc, h) => {
                     let tail_idx = self.heap.scan_slice_to_str(h).tail_idx;
 
-                    self.heap[tail_idx].set_mark_bit(self.mark_phase);
                     self.iter_stack.push(self.heap[tail_idx]);
+                    self.heap[tail_idx].set_mark_bit(self.mark_phase);
                 }
                 _ => {
                 }


### PR DESCRIPTION
Closes #3123, maybe some other things too.

The tail was being marked before putting it into the iterator stack, which meant that it wasn't being checked at all.