### PR TITLE
Fix #3161: malformed list syntax in curly braces

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -645,6 +645,10 @@ impl<'a, R: CharRead> Parser<'a, R> {
         for (i, desc) in self.stack.iter().rev().enumerate() {
             if i % 2 == 0 {
                 // expect a term or non-comma operator.
+                // HeadTailSeparator is NEVER valid as a term, even if its spec suggests otherwise
+                if let TokenType::HeadTailSeparator = desc.tt {
+                    return None;
+                }
                 if let TokenType::Comma = desc.tt {
                     return None;
                 } else if is_term!(desc.spec) || is_op!(desc.spec) || is_negate!(desc.spec) {

--- a/tests/scryer/cli/issues/issue_3161_malformed_list_syntax.md
+++ b/tests/scryer/cli/issues/issue_3161_malformed_list_syntax.md
@@ -1,0 +1,68 @@
+# Issue 3161: Malformed List Syntax in Curly Braces
+
+Tests for the parser bug where malformed list syntax like `[|]` was incorrectly
+accepted inside curly braces when preceded by specific operator patterns.
+
+## Test that {!*[|]*} throws syntax error
+
+Before the fix, this incorrectly evaluated to `T = {*}`.
+After the fix, it should throw a syntax error.
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- use_module(library(dcgs)).
+   true.
+?- {!*[|]*}=T.
+error(syntax_error(incomplete_reduction),read_term/3:1).
+?- halt.
+```
+
+## Test that {!+[|]+} throws syntax error
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- use_module(library(dcgs)).
+   true.
+?- {!+[|]+}=T.
+error(syntax_error(incomplete_reduction),read_term/3:1).
+?- halt.
+```
+
+## Test that {[|]} throws syntax error
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- {[|]}=T.
+error(syntax_error(incomplete_reduction),read_term/3:1).
+?- halt.
+```
+
+## Test that valid list syntax still works
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- {[a,b,c]}=T, write(T), nl.
+{[a,b,c]}
+   T = {"abc"}.
+?- halt.
+```
+
+## Test that empty list in curly braces works
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- {[]}=T, write(T), nl.
+{[]}
+   T = {[]}.
+?- halt.
+```
+
+## Test that cut in curly braces works
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- {!}=T, write(T), nl.
+{!}
+   T = {!}.
+?- halt.
+```


### PR DESCRIPTION
Fixes #3161

`{!*[|]*}` was incorrectly evaluating to `{*}` instead of syntax error.

Fixed in `compute_arity_in_list()` by rejecting HeadTailSeparator at term positions.

Tests added.

~ J.J.'s robot