### PR TITLE
Fix #3156: Reject bracketed terms as functors

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -524,6 +524,12 @@ impl<'a, R: CharRead> Parser<'a, R> {
         if self.stack.len() > 2 * arity {
             let idx = self.stack.len() - 2 * arity - 1;
 
+            // Reject BTERM (bracketed term) used as functor
+            // This prevents patterns like ((a)(b) from being parsed as a(b)
+            if self.stack[idx].spec == BTERM {
+                return false;
+            }
+
             if is_infix!(self.stack[idx].spec)
                 && idx > 0
                 && !is_op!(self.stack[idx - 1].spec)

--- a/tests/scryer/cli/issues/issue_3156_bracketed_term_as_functor.md
+++ b/tests/scryer/cli/issues/issue_3156_bracketed_term_as_functor.md
@@ -1,0 +1,67 @@
+# Issue #3156: Bracketed terms should not be usable as functors
+
+## Test that ((>)(1) throws syntax error
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- use_module(library(charsio)).
+   true.
+?- read_from_chars("((>)(1).",T).
+   error(syntax_error(incomplete_reduction),read_term_from_chars/3:0).
+?- halt.
+```
+
+## Test that ((a)(b) throws syntax error
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- use_module(library(charsio)).
+   true.
+?- read_from_chars("((a)(b).",T).
+   error(syntax_error(incomplete_reduction),read_term_from_chars/3:0).
+?- halt.
+```
+
+## Test that valid functor application still works
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- use_module(library(charsio)).
+   true.
+?- read_from_chars("a(b).",T).
+   T = a(b).
+?- halt.
+```
+
+## Test that simple bracketed terms work
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- use_module(library(charsio)).
+   true.
+?- read_from_chars("(a).",T).
+   T = a.
+?- halt.
+```
+
+## Test that (a) (b) with space throws syntax error
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- use_module(library(charsio)).
+   true.
+?- read_from_chars("(a) (b).",T).
+   error(syntax_error(incomplete_reduction),read_term_from_chars/3:0).
+?- halt.
+```
+
+## Test that bracketed operator works
+
+```trycmd
+$ scryer-prolog -f --no-add-history
+?- use_module(library(charsio)).
+   true.
+?- read_from_chars("((>)).",T).
+   T = (>).
+?- halt.
+```


### PR DESCRIPTION
Fixes #3156

Bracketed terms like `((>)(1)` now correctly throw syntax error instead of parsing incorrectly.

Added BTERM check in `reduce_term()` after `reduce_op()`.