### PR TITLE
Fix #3156: Reject bracketed terms as functors

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -524,6 +524,12 @@ impl<'a, R: CharRead> Parser<'a, R> {
         if self.stack.len() > 2 * arity {
             let idx = self.stack.len() - 2 * arity - 1;
 
+            // Reject BTERM (bracketed term) used as functor
+            // This prevents patterns like ((a)(b) from being parsed as a(b)
+            if self.stack[idx].spec == BTERM {
+                return false;
+            }
+
             if is_infix!(self.stack[idx].spec)
                 && idx > 0
                 && !is_op!(self.stack[idx - 1].spec)

--- a/src/tests/issue_3156.pl
+++ b/src/tests/issue_3156.pl
@@ -1,0 +1,17 @@
+:- module(issue_3156_tests, []).
+:- use_module(test_framework).
+:- use_module(library(charsio)).
+
+throws_syntax_error(Input) :-
+    catch(
+        (read_from_chars(Input, _), fail),
+        error(syntax_error(_), _),
+        true
+    ).
+
+test("((>)(1) throws syntax error", throws_syntax_error("((>)(1).")).
+test("((a)(b) throws syntax error", throws_syntax_error("((a)(b).")).
+test("(a) (b) throws syntax error", throws_syntax_error("(a) (b).")).
+test("a(b) parses correctly", (read_from_chars("a(b).", T), T == a(b))).
+test("(a) parses correctly", (read_from_chars("(a).", T), T == a)).
+test("((>)) parses correctly", (read_from_chars("((>)).", T), T == (>))).

--- a/tests/scryer/cli/src_tests/issue_3156.stdout
+++ b/tests/scryer/cli/src_tests/issue_3156.stdout
@@ -1,0 +1,1 @@
+All tests passed

--- a/tests/scryer/cli/src_tests/issue_3156.toml
+++ b/tests/scryer/cli/src_tests/issue_3156.toml
@@ -1,0 +1,1 @@
+args = ["-f", "--no-add-history", "src/tests/issue_3156.pl", "-f", "-g", "use_module(library(issue_3156_tests)), issue_3156_tests:main_quiet(issue_3156_tests)"]


### PR DESCRIPTION
## Summary
Fixes #3156 - Prevents patterns like `((>)(1)` from incorrectly parsing as `>(1)`.

A bracketed term (BTERM) cannot be used as a functor name - only atoms can be functors per ISO Prolog syntax rules.

## Changes
- Added check in `reduce_term()` to reject BTERM as functor
- Added 6 tests covering the bug cases and valid syntax

## Test Cases
| Input | Expected | Before Fix | After Fix |
|-------|----------|------------|-----------|
| `((>)(1).` | syntax_error | `>(1)` ❌ | syntax_error ✓ |
| `((a)(b).` | syntax_error | `a(b)` ❌ | syntax_error ✓ |
| `(a) (b).` | syntax_error | syntax_error ✓ | syntax_error ✓ |
| `a(b).` | `a(b)` | `a(b)` ✓ | `a(b)` ✓ |
| `(a).` | `a` | `a` ✓ | `a` ✓ |
| `((>)).` | `(>)` | `(>)` ✓ | `(>)` ✓ |

## Testing
All 36 tests pass.