### PR TITLE
Fix invalid [|] parsing when | is operator

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -645,7 +645,9 @@ impl<'a, R: CharRead> Parser<'a, R> {
         for (i, desc) in self.stack.iter().rev().enumerate() {
             if i % 2 == 0 {
                 // expect a term or non-comma operator.
-                if let TokenType::Comma = desc.tt {
+                // HeadTailSeparator at a term position means [|...] with nothing before |
+                // which is invalid regardless of whether | is an operator.
+                if desc.tt == TokenType::Comma || desc.tt == TokenType::HeadTailSeparator {
                     return None;
                 } else if is_term!(desc.spec) || is_op!(desc.spec) || is_negate!(desc.spec) {
                     arity += 1;

--- a/src/tests/issue_5_bar_list.pl
+++ b/src/tests/issue_5_bar_list.pl
@@ -1,0 +1,23 @@
+:- module(issue_5_bar_list_tests, []).
+:- use_module(test_framework).
+:- use_module(library(charsio)).
+
+setup :-
+    op(1105, xfy, '|').
+
+throws_syntax_error(Input) :-
+    catch(
+        (read_from_chars(Input, _), fail),
+        error(syntax_error(_), _),
+        true
+    ).
+
+test("[|] in curly with space before }", throws_syntax_error("{1*[|]. }.")).
+test("[|] in curly with spaces throughout", throws_syntax_error("{ ! * [ | ] * ! }.")).
+test("[|] in curly no spaces", throws_syntax_error("{!*[|]*!}.")).
+test("[|] without braces", throws_syntax_error("!*[|]*!.")).
+test("[|] with parens", throws_syntax_error("(!*[|]*!).")).
+test("[|] ending with number", throws_syntax_error("!*[|]*1.")).
+test("[|] ending with variable", throws_syntax_error("!*[|]*A.")).
+test("[|] simple case with space", throws_syntax_error("{1*[|]. }.")).
+test("[|] simple case no space", throws_syntax_error("{1*[|].}.")).

--- a/tests/scryer/cli/src_tests/issue_5_bar_list.stdout
+++ b/tests/scryer/cli/src_tests/issue_5_bar_list.stdout
@@ -1,0 +1,1 @@
+All tests passed

--- a/tests/scryer/cli/src_tests/issue_5_bar_list.toml
+++ b/tests/scryer/cli/src_tests/issue_5_bar_list.toml
@@ -1,0 +1,1 @@
+args = ["-f", "--no-add-history", "src/tests/issue_5_bar_list.pl", "-f", "-g", "use_module(library(issue_5_bar_list_tests)), issue_5_bar_list_tests:setup, issue_5_bar_list_tests:main_quiet(issue_5_bar_list_tests)"]


### PR DESCRIPTION
## Summary
- Fix bug where `[|]` inside expressions like `1*[|]` incorrectly parsed when `|` is defined as an operator (e.g., via `library(dcgs)`)
- The `|` with XFY spec was being treated as a term in `compute_arity_in_list()`, causing it to steal terms from before the `[` bracket

## Bug Report
https://github.com/jjtolton/scryer-prolog/issues/5

## Test Cases
All should throw `syntax_error` when `|` is operator (1105 xfy):
```prolog
"{1*[|]. }."         % space before }
"{ ! * [ | ] * ! }." % spaces throughout  
"{!*[|]*!}."         % no spaces
"!*[|]*!."           % without braces
"(!*[|]*!)."         % with parens
"!*[|]*1."           % ending with number
"!*[|]*A."           % ending with variable
```

## Fix
Explicitly reject `HeadTailSeparator` at term positions in `compute_arity_in_list()`, since `[|...]` with nothing before `|` is always invalid.