### PR TITLE
Fix invalid (|) parsing when | is operator

### DIFF
--- a/src/lib/builtins.pl
+++ b/src/lib/builtins.pl
@@ -1466,7 +1466,7 @@ op(Priority, OpSpec, Op) :-
           lists:member(OpSpec, [xfx, xfy, yfx]),
           ( Priority >= 1001 ; Priority == 0 )
        -> '$op'(Priority, OpSpec, Op)
-       ;  throw(error(permission_error(create, operator, (|)), op/3))) % www.complang.tuwien.ac.at/ulrich/iso-prolog/conformity_testing#72
+       ;  throw(error(permission_error(create, operator, '|'), op/3))) % www.complang.tuwien.ac.at/ulrich/iso-prolog/conformity_testing#72
     ;  valid_op(Op), op_priority(Priority), op_specifier(OpSpec) ->
        '$op'(Priority, OpSpec, Op)
     ;  list_of_op_atoms(Op), op_priority(Priority), op_specifier(OpSpec) ->

--- a/src/tests/issue_7_bar_parens.pl
+++ b/src/tests/issue_7_bar_parens.pl
@@ -1,0 +1,21 @@
+:- module(issue_7_bar_parens_tests, []).
+:- use_module(test_framework).
+:- use_module(library(charsio)).
+
+setup :-
+    op(1105, xfy, '|').
+
+throws_syntax_error(Input) :-
+    catch(
+        (read_from_chars(Input, _), fail),
+        error(syntax_error(_), _),
+        true
+    ).
+
+test("(|) alone should error", throws_syntax_error("(|).")).
+test("(|) in curly with space before }", throws_syntax_error("{1*!(|). }.")).
+test("(|) in curly no space", throws_syntax_error("{1*!(|).}.")).
+test("(|) without braces", throws_syntax_error("1*!(|).")).
+test("(|) with + operator", throws_syntax_error("1+!(|).")).
+test("(|) nested in parens", throws_syntax_error("(!(|)).")).
+test("(|) as argument", throws_syntax_error("foo((|)).")).

--- a/tests/scryer/cli/src_tests/issue_7_bar_parens.stdout
+++ b/tests/scryer/cli/src_tests/issue_7_bar_parens.stdout
@@ -1,0 +1,1 @@
+All tests passed

--- a/tests/scryer/cli/src_tests/issue_7_bar_parens.toml
+++ b/tests/scryer/cli/src_tests/issue_7_bar_parens.toml
@@ -1,0 +1,1 @@
+args = ["-f", "--no-add-history", "src/tests/issue_7_bar_parens.pl", "-f", "-g", "use_module(library(issue_7_bar_parens_tests)), issue_7_bar_parens_tests:setup, issue_7_bar_parens_tests:main_quiet(issue_7_bar_parens_tests)"]


### PR DESCRIPTION
## Summary
- Fix bug where `(|)` incorrectly parsed when `|` is defined as an operator (e.g., via `library(dcgs)`)
- Two parser fixes in `compute_arity_in_brackets()` and `reduce_brackets()`
- Update `builtins.pl` to use quoted `'|'` instead of `(|)`

## Bug Report
https://github.com/jjtolton/scryer-prolog/issues/7

## Test Cases
All should throw `syntax_error` when `|` is operator (1105 xfy):
```prolog
"(|)."           % bar alone in parens
"1*!(|)."        % in expression
"{1*!(|). }."    % in curly braces
```

## Fix Details

1. **`compute_arity_in_brackets()`**: Reject `HeadTailSeparator` at term positions
2. **`reduce_brackets()`**: Reject `HeadTailSeparator` in bracket reduction per ISO s#360
3. **`builtins.pl`**: Use `'|'` instead of `(|)` to reference bar operator

Related: PR #3206 (similar fix for `[|]` in lists)