### PR TITLE
ISO: Implement the include/1 directive

### DIFF
--- a/src/toplevel.pl
+++ b/src/toplevel.pl
@@ -222,7 +222,9 @@ expand_op_list([Op | OtherOps], Pri, Spec, [(:- op(Pri, Spec, Op)) | OtherResult
 
 % Implement the include/1 directive via term expansion.
 
-user:term_expansion((:- include(File0)), Clauses) :-
+user:term_expansion((:- Include), Clauses) :-
+        nonvar(Include),
+        Include = include(File0),
         (   si:atom_si(File0) ->
             atom_chars(File0, File),
             format("% Warning: include/1: atom arguments are deprecated. Use chars for file paths:~n", []),


### PR DESCRIPTION
Quoting from the standard:

    7.4.2.7 include/1

    If F is an implementation defined ground term designating
    a Prolog text unit, then Prolog text P1 which contains
    a directive include(F) is identical to a Prolog text P2
    obtained by replacing the directive include(F) in P1 by
    the Prolog text denoted by F.

Example:

    :- include("hello.pl").

This addresses #583 and #634.