### PR TITLE
load_xml was returning a single term instead of a list of nodes

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -8450,7 +8450,12 @@ impl Machine {
             match roxmltree::Document::parse(&string.as_str()) {
                 Ok(doc) => {
                     let result = self.xml_node_to_term(doc.root_element())?;
-                    unify!(self.machine_st, self.machine_st.registers[2], result);
+                    let list = sized_iter_to_heap_list(
+                        &mut self.machine_st.heap,
+                        1, // just one root element
+                        std::iter::once(result),
+                    )?;
+                    unify!(self.machine_st, self.machine_st.registers[2], list);
                 }
                 _ => {
                     self.machine_st.fail = true;

--- a/tests-pl/issue3256.pl
+++ b/tests-pl/issue3256.pl
@@ -1,0 +1,5 @@
+:- use_module(library(sgml)).
+
+test :- load_xml("<foo><bar>hello</bar></foo>", Es, []), write(Es).
+
+:- initialization(test).

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -22,6 +22,15 @@ fn issue2588_load_html() {
 
 #[test]
 #[cfg_attr(miri, ignore = "unsupported operation when isolation is enabled")]
+fn issue3256_load_xml_returns_list() {
+    load_module_test(
+        "tests-pl/issue3256.pl",
+        "[element(foo,[],[element(bar,[],[[h,e,l,l,o]])])]",
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "unsupported operation when isolation is enabled")]
 fn issue2949_load_html() {
     load_module_test("tests-pl/issue2949.pl", "[doctype([h,t,m,l]),element(html,[],[element(head,[],[element(title,[],[[H,e,l,l,o,!]])]),element(body,[],[])])][doctype([h,t,m,l]),element(html,[],[element(head,[],[element(title,[],[[H,e,l,l,o,!]]),comment([ ,c,o,m,m,e,n,t, ])]),element(body,[],[])])][comment([]),element(html,[],[element(head,[],[]),element(body,[],[])])]");
 }


### PR DESCRIPTION
Fixes #3256

load_xml was returning a single term instead of a list of nodes, so unification failed

```
?- use_module(library(sgml)).
   true.
?- load_xml("<i>hello</i>", E, []).
   E = [element(i,[],["hello"])].
```

as per #1249