### PR TITLE
Update actions

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: dtolnay/rust-toolchain@master
+  - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
     id: toolchain
     with:
       toolchain: ${{ inputs.rust-version }}
@@ -33,7 +33,7 @@ runs:
       echo "CC=clang" >> $GITHUB_ENV
       echo "PKG_CONFIG_SYSROOT_DIR=/" >> $GITHUB_ENV
 
-  - uses: actions/cache@v4
+  - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
     with:
       path: |
         ~/.cargo/bin/
@@ -46,7 +46,7 @@ runs:
   # Remove build artifacts for the current crate, since it will be rebuilt every
   # run anyway, but keep dependency artifacts to cache them.
   # Must be placed after actions/cache so its post step runs first.
-  - uses: pyTooling/Actions/with-post-step@v4.1.0
+  - uses: pyTooling/Actions/with-post-step@679ec24c80c6736efa7099a11c19086263a6beba # v4.1.0
     with:
       main: bash ./.github/actions/setup-rust/cleanup.sh
       post: bash ./.github/actions/setup-rust/cleanup.sh

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -46,7 +46,7 @@ runs:
   # Remove build artifacts for the current crate, since it will be rebuilt every
   # run anyway, but keep dependency artifacts to cache them.
   # Must be placed after actions/cache so its post step runs first.
-  - uses: pyTooling/Actions/with-post-step@679ec24c80c6736efa7099a11c19086263a6beba # v4.1.0
+  - uses: pyTooling/Actions/with-post-step@41aed3e559cbf69bfdb46abb25d7c535900ed5b6 # v7.7.0
     with:
       main: bash ./.github/actions/setup-rust/cleanup.sh
       post: bash ./.github/actions/setup-rust/cleanup.sh

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -33,7 +33,7 @@ runs:
       echo "CC=clang" >> $GITHUB_ENV
       echo "PKG_CONFIG_SYSROOT_DIR=/" >> $GITHUB_ENV
 
-  - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+  - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
     with:
       path: |
         ~/.cargo/bin/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+
+updates:
+  # Enable version updates for cargo
+  - package-ecosystem: "cargo"
+    # Look for `Cargo.toml` and `Cargo.lock` files in the `root` directory
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: "7"
+    groups:
+      cargo-incompatible:
+        applies-to: version-updates
+        # TODO: use incompatible update-type once available
+        # see issue https://github.com/dependabot/dependabot-core/issues/9681
+        update-types:
+          - "major"
+          - "minor" # pre-1.0 dependencies
+      cargo-compatible:
+        applies-to: version-updates
+        # TODO: use compatible update-type once available
+        # see issue https://github.com/dependabot/dependabot-core/issues/9681
+        update-types:
+          - "patch"
+    ignore:
+      # ignore all cargo updates for now while dependabot does not respect msrv/rust-version
+      # see issue https://github.com/dependabot/dependabot-core/issues/5423
+      - dependency-name: "*"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: "7"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: "7"
+    ignore:
+      # these actions doesn't have proper version tags
+      - dependency-name: "dtolnay/rust-toolchain"
+      - dependency-name: "logtalk-actions/setup-logtalk"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   style:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -39,7 +39,7 @@ jobs:
     outputs: 
       msrv: ${{ steps.read-declared-msrv.outputs.msrv }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: read-declared-msrv
         name: Read msrv from Cargo.toml rust_version field
         run: echo "msrv=$(cargo metadata  --no-deps --format-version  1 | jq -r '.packages[] | select(.name = "scryer-prolog") | ."rust_version"')" >>  "$GITHUB_OUTPUT"
@@ -68,7 +68,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actionhippie/swap-space@v1
         if: matrix.use_swap
         with:
@@ -167,7 +167,7 @@ jobs:
   report:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   style:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -39,7 +39,7 @@ jobs:
     outputs: 
       msrv: ${{ steps.read-declared-msrv.outputs.msrv }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: read-declared-msrv
         name: Read msrv from Cargo.toml rust_version field
         run: echo "msrv=$(cargo metadata  --no-deps --format-version  1 | jq -r '.packages[] | select(.name = "scryer-prolog") | ."rust_version"')" >>  "$GITHUB_OUTPUT"
@@ -68,8 +68,8 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6
-      - uses: actionhippie/swap-space@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actionhippie/swap-space@0cffa893f224708cfb6b011690d8ba819d69c10f # v1.1.0
         if: matrix.use_swap
         with:
           size: 10G
@@ -110,7 +110,7 @@ jobs:
         
       - name: Publish release binary artifact
         if: matrix.publish
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: |
             target/${{ matrix.target }}/release/scryer-prolog*
@@ -123,14 +123,14 @@ jobs:
     needs: [build-test]
     steps:
       # Download prebuilt ubuntu binary from build-test job, setup logtalk
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           name: scryer-prolog_ubuntu-22.04_x86_64-unknown-linux-gnu
       - run: |
           chmod +x release/scryer-prolog
           echo "$PWD/release" >> "$GITHUB_PATH"
       - name: Install Logtalk
-        uses: logtalk-actions/setup-logtalk@master
+        uses: logtalk-actions/setup-logtalk@4ea002fe3037199afcf1c6c91bf1f57de0f995e6 # master
         with:
           logtalk-version: "3.70.0"
           logtalk-tool-dependencies: false
@@ -147,17 +147,17 @@ jobs:
             || echo "::warning ::logtalk compliance suite failed"
             # -u "https://github.com/LogtalkDotOrg/logtalk3/tree/$LOGTALK_GIT_HASH/tests/prolog/" \
       - name: Publish Logtalk test logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: logtalk-test-logs
           path: '${{ env.LOGTALKUSER }}/tests/prolog/logtalk_tester_logs'
       - name: Publish Logtalk test results artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: logtalk-test-results
           path: '${{ env.LOGTALKUSER }}/tests/prolog/**/*.xml'
       - name: Publish Logtalk test summary
-        uses: EnricoMi/publish-unit-test-result-action/composite@master
+        uses: EnricoMi/publish-unit-test-result-action/composite@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           check_name: Logtalk test summary
           files: '${{ env.LOGTALKUSER }}/tests/prolog/**/*.xml'
@@ -167,7 +167,7 @@ jobs:
   report:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -187,12 +187,12 @@ jobs:
         run: |
           RUSTC_BOOTSTRAP=1 cargo test --all -- -Z unstable-options --format json --report-time | cargo2junit > cargo_test_results.xml
       - name: Publish cargo test results artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cargo-test-results
           path: cargo_test_results.xml
       - name: Publish cargo test summary
-        uses: EnricoMi/publish-unit-test-result-action/composite@master
+        uses: EnricoMi/publish-unit-test-result-action/composite@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           check_name: Cargo test summary
           files: cargo_test_results.xml
@@ -206,7 +206,7 @@ jobs:
       - run: cargo bench --bench run_criterion -- --profile-time 60
 
       - name: Publish benchmark results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results
           path: |
@@ -220,7 +220,7 @@ jobs:
     needs: [build-test]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
       - name: Zip binaries for release
         run: |
           zip scryer-prolog_macos-latest.zip ./scryer-prolog_macos-latest_x86_64-apple-darwin/scryer-prolog
@@ -229,7 +229,7 @@ jobs:
           zip scryer-prolog_windows-latest.zip ./scryer-prolog_windows-latest_x86_64-pc-windows-msvc/scryer-prolog.exe
           zip scryer-prolog_wasm32.zip ./scryer-prolog_ubuntu-22.04_wasm32-unknown-unknown/scryer-prolog.wasm
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           files: |
             scryer-prolog_macos-latest.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     needs: [build-test]
     steps:
       # Download prebuilt ubuntu binary from build-test job, setup logtalk
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: scryer-prolog_ubuntu-22.04_x86_64-unknown-linux-gnu
       - run: |
@@ -220,7 +220,7 @@ jobs:
     needs: [build-test]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
       - name: Zip binaries for release
         run: |
           zip scryer-prolog_macos-latest.zip ./scryer-prolog_macos-latest_x86_64-apple-darwin/scryer-prolog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         
       - name: Publish release binary artifact
         if: matrix.publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: |
             target/${{ matrix.target }}/release/scryer-prolog*
@@ -147,12 +147,12 @@ jobs:
             || echo "::warning ::logtalk compliance suite failed"
             # -u "https://github.com/LogtalkDotOrg/logtalk3/tree/$LOGTALK_GIT_HASH/tests/prolog/" \
       - name: Publish Logtalk test logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logtalk-test-logs
           path: '${{ env.LOGTALKUSER }}/tests/prolog/logtalk_tester_logs'
       - name: Publish Logtalk test results artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logtalk-test-results
           path: '${{ env.LOGTALKUSER }}/tests/prolog/**/*.xml'
@@ -187,7 +187,7 @@ jobs:
         run: |
           RUSTC_BOOTSTRAP=1 cargo test --all -- -Z unstable-options --format json --report-time | cargo2junit > cargo_test_results.xml
       - name: Publish cargo test results artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-test-results
           path: cargo_test_results.xml
@@ -206,7 +206,7 @@ jobs:
       - run: cargo bench --bench run_criterion -- --profile-time 60
 
       - name: Publish benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results
           path: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Extract Docker metadata
         id: meta
         # https://github.com/docker/metadata-action
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/scryer-prolog
           tags: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       # Login against Docker registry
       - name: Log into registry
         # https://github.com/docker/login-action
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and push Docker image
         id: build-and-push
         # https://github.com/docker/build-push-action
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         # v4 adds SLSA Provenance attestation which is 
         # - unsupported by AWS Lambda 
         # - limited support by Google Cloud Run 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,17 +14,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         # https://github.com/docker/setup-buildx-action
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       # Login against Docker registry
       - name: Log into registry
         # https://github.com/docker/login-action
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
       - name: Extract Docker metadata
         id: meta
         # https://github.com/docker/metadata-action
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/scryer-prolog
           tags: |
@@ -47,8 +47,8 @@ jobs:
       - name: Build and push Docker image
         id: build-and-push
         # https://github.com/docker/build-push-action
-        uses: docker/build-push-action@v7
-        # v4 adds SLSA Provenance attestation which is 
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        # v4 adds SLSA Provenance attestation which is
         # - unsupported by AWS Lambda 
         # - limited support by Google Cloud Run 
         #   > If deploying a multi-architecture image, the manifest list must include linux/amd64.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ jobs:
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         # https://github.com/docker/setup-buildx-action
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Login against Docker registry
       - name: Log into registry


### PR DESCRIPTION
fixes #3288

- updates several actions
- pin 3rd party actions to a full SHA following githubs recommendations
- add a dependabot config to help keeping things updated
