### PR TITLE
http_server test + unignore http_open_hanging

### DIFF
--- a/tests-pl/issue-http_open-hanging.pl
+++ b/tests-pl/issue-http_open-hanging.pl
@@ -3,8 +3,13 @@
 :- use_module(library(iso_ext)).
 :- use_module(library(os)).
 
+prolog_path(Prolog) :-
+    read(Body),
+    term_variables(Body, [Prolog]),
+    Body.
+
 server_start([Process,Out]) :-
-    getenv("PROLOG", Prolog),
+    prolog_path(Prolog),
     process_create(Prolog,
         ["tests-pl/issue-http_open-hanging_server", "-t", "server"],
         [process(Process), stdout(pipe(Out))]).

--- a/tests-pl/issue-http_open-hanging.pl
+++ b/tests-pl/issue-http_open-hanging.pl
@@ -1,5 +1,21 @@
-:- module(http_open_hanging, [submit_request/0]).
+% Server
+:- use_module(library(process)).
+:- use_module(library(iso_ext)).
+:- use_module(library(os)).
 
+server_start([Process,Out]) :-
+    getenv("PROLOG", Prolog),
+    process_create(Prolog,
+        ["tests-pl/issue-http_open-hanging_server", "-t", "server"],
+        [process(Process), stdout(pipe(Out))]).
+
+server_wait_start([_Process, Out]) :-
+    get_char(Out, _C).
+
+server_stop([Process,_Out]) :-
+    process_kill(Process).
+
+% Client 
 :- use_module(library(charsio)).
 :- use_module(library(http/http_open)).
 
@@ -10,14 +26,21 @@ send_request :-
         request_headers([]),
         headers(_)
     ],
-    http_open("https://scryer.pl", _Stream, Options),
+    http_open("http://localhost:8472", _Stream, Options),
     write_term('received response with status code':StatusCode, []), nl.
 
 main :-
-    send_request,
-    send_request,
-    send_request,
-    send_request,
-    send_request.
+    setup_call_cleanup(
+        server_start(Server),
+        (
+            server_wait_start(Server),
+            send_request,
+            send_request,
+            send_request,
+            send_request,
+            send_request
+        ),
+        server_stop(Server)
+    ).
 
 :- initialization(main).

--- a/tests-pl/issue-http_open-hanging_server.pl
+++ b/tests-pl/issue-http_open-hanging_server.pl
@@ -1,0 +1,8 @@
+:- use_module(library(process)).
+:- use_module(library(http/http_server)).
+
+server :-
+    http_listen(8472, [get(/, hello)]).
+
+hello(_Req, Res) :-
+    http_body(Res, text("Ok")).

--- a/tests/scryer/helper.rs
+++ b/tests/scryer/helper.rs
@@ -52,6 +52,25 @@ pub(crate) fn load_module_test_with_tokio_runtime<T: Expectable>(file: &str, exp
     });
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn load_module_test_with_tokio_runtime_and_input<T: Expectable>(
+    file: &str,
+    input: impl Into<Cow<'static, str>>,
+    expected: T
+) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async move {
+        let mut wam = MachineBuilder::default()
+            .with_streams(StreamConfig::in_memory().with_user_input(InputStreamConfig::string(input)))
+            .build();
+        expected.assert_eq(wam.test_load_file(file).as_slice())
+    });
+}
+
 pub(crate) fn load_module_test_with_input<T: Expectable>(
     file: &str,
     input: impl Into<Cow<'static, str>>,

--- a/tests/scryer/helper.rs
+++ b/tests/scryer/helper.rs
@@ -56,7 +56,7 @@ pub(crate) fn load_module_test_with_tokio_runtime<T: Expectable>(file: &str, exp
 pub(crate) fn load_module_test_with_tokio_runtime_and_input<T: Expectable>(
     file: &str,
     input: impl Into<Cow<'static, str>>,
-    expected: T
+    expected: T,
 ) {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -65,7 +65,9 @@ pub(crate) fn load_module_test_with_tokio_runtime_and_input<T: Expectable>(
 
     runtime.block_on(async move {
         let mut wam = MachineBuilder::default()
-            .with_streams(StreamConfig::in_memory().with_user_input(InputStreamConfig::string(input)))
+            .with_streams(
+                StreamConfig::in_memory().with_user_input(InputStreamConfig::string(input)),
+            )
             .build();
         expected.assert_eq(wam.test_load_file(file).as_slice())
     });

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -155,12 +155,14 @@ fn issue_rename_file() {
     load_module_test("tests-pl/issue_rename_file.pl", "file_renamed");
 }
 
+#[serial]
 #[test]
 #[cfg(feature = "http")]
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(miri, ignore = "it takes too long to run")]
-#[cfg_attr(not(miri), ignore = "flaky due to network requests")]
 fn http_open_hanging() {
+    std::env::set_var("PROLOG", env!("CARGO_BIN_EXE_scryer-prolog"));
+
     load_module_test_with_tokio_runtime(
         "tests-pl/issue-http_open-hanging.pl",
             "received response with status code:200\nreceived response with status code:200\nreceived response with status code:200\nreceived response with status code:200\nreceived response with status code:200\n"

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -1,6 +1,6 @@
 use crate::helper::load_module_test;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::helper::load_module_test_with_tokio_runtime;
+use crate::helper::load_module_test_with_tokio_runtime_and_input;
 use serial_test::serial;
 
 // issue #831
@@ -155,16 +155,14 @@ fn issue_rename_file() {
     load_module_test("tests-pl/issue_rename_file.pl", "file_renamed");
 }
 
-#[serial]
 #[test]
 #[cfg(feature = "http")]
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(miri, ignore = "it takes too long to run")]
 fn http_open_hanging() {
-    std::env::set_var("PROLOG", env!("CARGO_BIN_EXE_scryer-prolog"));
-
-    load_module_test_with_tokio_runtime(
+    load_module_test_with_tokio_runtime_and_input(
         "tests-pl/issue-http_open-hanging.pl",
+        format!("PROLOG={:?}.", env!("CARGO_BIN_EXE_scryer-prolog")),
             "received response with status code:200\nreceived response with status code:200\nreceived response with status code:200\nreceived response with status code:200\nreceived response with status code:200\n"
     );
 }


### PR DESCRIPTION
Test for https://github.com/mthom/scryer-prolog/pull/3243.

As suggested by @Skgland, this creates a second Scryer process to host the server. I also decided to combine this with already present but ignored http_open_hanging test, so that it can use local server instead of relying on internet connection.