### PR TITLE
add `release(Bool)` option to `process_wait/3`

### DIFF
--- a/src/lib/process.pl
+++ b/src/lib/process.pl
@@ -95,10 +95,12 @@ process_wait(Process, Status) :- call_with_error_context(process_wait(Process, S
 % `Options` is a a list of the following options
 %
 %  * timeout(Timeout) supported values for `Timeout` are 0 or `infinite`
+%  * release(Bool) supported values for `Bool` are `true` or `false`
 %
 % Each options may be specified at most once, when an option is not specified the following defaults apply:
 %
 % - timeout(infinite)
+% - release(true)
 %
 process_wait(Process, Status, Options) :- call_with_error_context(process_wait_(Process, Status, Options), predicate-process_wait/3).
 
@@ -106,16 +108,28 @@ process_wait_(Process, Status, Options) :-
     valid_process(Process),
     check_options(
         [
-            option([timeout], valid_timeout, timeout(infinite), timeout(Timeout))
+            option([timeout], valid_timeout, timeout(infinite), timeout(Timeout)),
+            option([release], valid_release, release(true), release(Release))
         ],
         Options,
         process_wait_option
     ),
     '$process_wait'(Process, Exit, Timeout),
+    ((true = Release) -> '$process_release'(Process) ; true),
     Exit = Status.
 
 valid_timeout(timeout(infinite)).
 valid_timeout(timeout(0)).
+
+valid_release(release(Arg)) :-
+    ( var(Arg) -> instantiation_error([])
+    ; valid_bool(Arg) -> true
+    ; domain_error(boolean, Arg, [])
+    ).
+
+
+valid_bool(true).
+valid_bool(false).
 
 
 %% process_kill(+Process).
@@ -139,10 +153,9 @@ process_kill_(Process) :-
 %
 process_release(Process) :- call_with_error_context(process_release_(Process), predicate-process_release/1).
 
-process_release_(Process) :- 
+process_release_(Process) :-
     valid_process(Process),
-    process_wait(Process, _),
-    '$process_release'(Process).
+    process_wait(Process, _).
 
 
 must_be_known_options(Valid, Options, Domain) :- call_with_error_context(must_be_known_options_(Valid, [], Options, Domain),predicate-must_be_known_options/3).
@@ -184,9 +197,9 @@ find_option(Names, Found, T) :-
     functor(Found, Name, 1), 
     memberd_t(Name, Names, T).
 
-valid_stdio(IO) :- arg(1, IO, Arg), 
-    ( var(Arg) -> instantiation_error([]) 
-    ; valid_stdio_(Arg) -> true 
+valid_stdio(IO) :- arg(1, IO, Arg),
+    ( var(Arg) -> instantiation_error([])
+    ; valid_stdio_(Arg) -> true
     ; domain_error(stdio_spec, Arg, [])
     ).
 

--- a/tests/scryer/cli/unix/process.md
+++ b/tests/scryer/cli/unix/process.md
@@ -15,20 +15,30 @@ $  scryer-prolog -f --no-add-history -g 'use_module(library(process)), process_c
 ```
 
 
+existence error is expected as the process was released, but the program shouldn't panic, see [issue 3300](https://github.com/mthom/scryer-prolog/issues/3300)
 ```trycmd
 $ scryer-prolog -f --no-add-history -t halt -g 'use_module(library(process)), process_create("false", [], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1)), process_id(P, Pid2), write(pid=Pid2), nl'
-? success
+? failed
 pid=[..]
-pid=[..]
+use_module(library(process)),process_create("false",[],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1)),process_id(P,Pid2),write(pid=Pid2),nl causes: error(existence_error(process,$dropped_value),[predicate-process_id/2|process_id/2])
+
+thread 'main' ([..]) panicked at src/machine/loader.rs:[..]:[..]:
+called `Result::unwrap()` on an `Err` value: ()
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 ```
 
 
-domain error is expected release option doesn't exsist yet
+existence error is expected as the process was released, but the program shouldn't panic, see [issue 3300](https://github.com/mthom/scryer-prolog/issues/3300)
 ```trycmd
 $ scryer-prolog -f --no-add-history -t halt -g 'use_module(library(process)), process_create("false", [], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1), [release(false)]), process_id(P, Pid2), write(pid=Pid2), nl, process_release(P), process_id(P, Pid3), write(pid=Pid3), nl'
-? success
+? failed
 pid=[..]
-use_module(library(process)),process_create("false",[],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1),[release(false)]),process_id(P,Pid2),write(pid=Pid2),nl,process_release(P),process_id(P,Pid3),write(pid=Pid3),nl causes: error(domain_error(process_wait_option,release),[predicate-process_wait/3,predicate-check_options/3,predicate-must_be_known_options/3])
+pid=[..]
+use_module(library(process)),process_create("false",[],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1),[release(false)]),process_id(P,Pid2),write(pid=Pid2),nl,process_release(P),process_id(P,Pid3),write(pid=Pid3),nl causes: error(existence_error(process,$dropped_value),[predicate-process_id/2|process_id/2])
+
+thread 'main' ([..]) panicked at src/machine/loader.rs:[..]:[..]:
+called `Result::unwrap()` on an `Err` value: ()
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 ```

--- a/tests/scryer/cli/unix/process.md
+++ b/tests/scryer/cli/unix/process.md
@@ -1,5 +1,6 @@
 ```trycmd
-$ scryer-prolog -f --no-add-history -g 'use_module(library(process)), process_create("false", [], [process(P)]), process_wait(P, exit(1)), halt'
+$ scryer-prolog -f --no-add-history -g 'use_module(library(process)), process_create("false", [], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1)), halt'
+pid=[..]
 
 ```
 
@@ -10,5 +11,24 @@ $  scryer-prolog -f --no-add-history -g 'use_module(library(process)), use_modul
 
 ```trycmd
 $  scryer-prolog -f --no-add-history -g 'use_module(library(process)), process_create("sh", ["-c", "sleep 5"], [process(P), stdout(null)]), process_kill(P), process_wait(P, killed(9)), halt'
+
+```
+
+
+```trycmd
+$ scryer-prolog -f --no-add-history -t halt -g 'use_module(library(process)), process_create("false", [], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1)), process_id(P, Pid2), write(pid=Pid2), nl'
+? success
+pid=[..]
+pid=[..]
+
+```
+
+
+domain error is expected release option doesn't exsist yet
+```trycmd
+$ scryer-prolog -f --no-add-history -t halt -g 'use_module(library(process)), process_create("false", [], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1), [release(false)]), process_id(P, Pid2), write(pid=Pid2), nl, process_release(P), process_id(P, Pid3), write(pid=Pid3), nl'
+? success
+pid=[..]
+use_module(library(process)),process_create("false",[],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1),[release(false)]),process_id(P,Pid2),write(pid=Pid2),nl,process_release(P),process_id(P,Pid3),write(pid=Pid3),nl causes: error(domain_error(process_wait_option,release),[predicate-process_wait/3,predicate-check_options/3,predicate-must_be_known_options/3])
 
 ```

--- a/tests/scryer/cli/unix/process.md
+++ b/tests/scryer/cli/unix/process.md
@@ -22,7 +22,7 @@ $ scryer-prolog -f --no-add-history -t halt -g 'use_module(library(process)), pr
 pid=[..]
 use_module(library(process)),process_create("false",[],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1)),process_id(P,Pid2),write(pid=Pid2),nl causes: error(existence_error(process,$dropped_value),[predicate-process_id/2|process_id/2])
 
-thread 'main' ([..]) panicked at src/machine/loader.rs:[..]:[..]:
+thread 'main'[..] panicked at src/machine/loader.rs:[..]:[..]:
 called `Result::unwrap()` on an `Err` value: ()
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
@@ -37,7 +37,7 @@ pid=[..]
 pid=[..]
 use_module(library(process)),process_create("false",[],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1),[release(false)]),process_id(P,Pid2),write(pid=Pid2),nl,process_release(P),process_id(P,Pid3),write(pid=Pid3),nl causes: error(existence_error(process,$dropped_value),[predicate-process_id/2|process_id/2])
 
-thread 'main' ([..]) panicked at src/machine/loader.rs:[..]:[..]:
+thread 'main'[..] panicked at src/machine/loader.rs:[..]:[..]:
 called `Result::unwrap()` on an `Err` value: ()
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 

--- a/tests/scryer/cli/windows/process.md
+++ b/tests/scryer/cli/windows/process.md
@@ -9,17 +9,29 @@ $  scryer-prolog -f --no-add-history -g 'use_module(library(process)), use_modul
 
 ```
 
+existence error is expected as the process has been released, but the panic is unexpected see [issue 3300](https://github.com/mthom/scryer-prolog/issues/3300)
 ```trycmd
 $ scryer-prolog -f --no-add-history -t halt -g 'use_module(library(process)), process_create("cmd", ["/C", "exit", "1"], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1)), process_id(P, Pid2), write(pid=Pid2), nl'
+? failed
 pid=[..]
-pid=[..]
+use_module(library(process)),process_create("cmd",["/C","exit","1"],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1)),process_id(P,Pid2),write(pid=Pid2),nl causes: error(existence_error(process,$dropped_value),[predicate-process_id/2|process_id/2])
+
+thread 'main' ([..]) panicked at src/machine/loader.rs:[..]:[..]:
+called `Result::unwrap()` on an `Err` value: ()
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 ```
 
-domain error is expected as the release option has not yet been added
+existence error is expected as the process has been released, but the panic is unexpected see [issue 3300](https://github.com/mthom/scryer-prolog/issues/3300)
 ```trycmd
 $ scryer-prolog -f --no-add-history -t halt -g 'use_module(library(process)), process_create("cmd", ["/C", "exit", "1"], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1), [release(false)]), process_id(P, Pid2), write(pid=Pid2), nl, process_release(P), process_id(P, Pid3), write(pid=Pid3), nl'
+? failed
 pid=[..]
-use_module(library(process)),process_create("cmd",["/C","exit","1"],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1),[release(false)]),process_id(P,Pid2),write(pid=Pid2),nl,process_release(P),process_id(P,Pid3),write(pid=Pid3),nl causes: error(domain_error(process_wait_option,release),[predicate-process_wait/3,predicate-check_options/3,predicate-must_be_known_options/3])
+pid=[..]
+use_module(library(process)),process_create("cmd",["/C","exit","1"],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1),[release(false)]),process_id(P,Pid2),write(pid=Pid2),nl,process_release(P),process_id(P,Pid3),write(pid=Pid3),nl causes: error(existence_error(process,$dropped_value),[predicate-process_id/2|process_id/2])
+
+thread 'main' ([..]) panicked at src/machine/loader.rs:[..]:[..]:
+called `Result::unwrap()` on an `Err` value: ()
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 ```

--- a/tests/scryer/cli/windows/process.md
+++ b/tests/scryer/cli/windows/process.md
@@ -1,9 +1,25 @@
 ```trycmd
-$ scryer-prolog -f --no-add-history -g 'use_module(library(process)), process_create("cmd", ["/C", "exit", "1"], [process(P)]), process_wait(P, exit(1)), halt'
+$ scryer-prolog -f --no-add-history -g 'use_module(library(process)), process_create("cmd", ["/C", "exit", "1"], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1)), halt'
+pid=[..]
 
 ```
 
 ```trycmd
 $  scryer-prolog -f --no-add-history -g 'use_module(library(process)), use_module(library(format)), process_create("cmd", [], [process(P), stdout(null), stdin(pipe(S))]), format(S, "exit 1~n", []), process_wait(P, exit(1)), halt'
+
+```
+
+```trycmd
+$ scryer-prolog -f --no-add-history -t halt -g 'use_module(library(process)), process_create("cmd", ["/C", "exit", "1"], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1)), process_id(P, Pid2), write(pid=Pid2), nl'
+pid=[..]
+pid=[..]
+
+```
+
+domain error is expected as the release option has not yet been added
+```trycmd
+$ scryer-prolog -f --no-add-history -t halt -g 'use_module(library(process)), process_create("cmd", ["/C", "exit", "1"], [process(P)]), process_id(P, Pid), write(pid=Pid), nl, process_wait(P, exit(1), [release(false)]), process_id(P, Pid2), write(pid=Pid2), nl, process_release(P), process_id(P, Pid3), write(pid=Pid3), nl'
+pid=[..]
+use_module(library(process)),process_create("cmd",["/C","exit","1"],[process(P)]),process_id(P,Pid),write(pid=Pid),nl,process_wait(P,exit(1),[release(false)]),process_id(P,Pid2),write(pid=Pid2),nl,process_release(P),process_id(P,Pid3),write(pid=Pid3),nl causes: error(domain_error(process_wait_option,release),[predicate-process_wait/3,predicate-check_options/3,predicate-must_be_known_options/3])
 
 ```


### PR DESCRIPTION
This changes the behavior of `process_wait/2` and `process_wait/3`.

The default for `release(Bool)` is `release(true)` matching sictus, but the old behavior was that of `release(false)`.

The added tests run into #3300 due to the `asserta` at Line 184 of the toplevel 
https://github.com/mthom/scryer-prolog/blob/8dffd72db541d2c82606697bf8efedc8aa186493/src/toplevel.pl#L179-L189


cc #3308 