### PR TITLE
use BTree{Map,Set} to ensure a stable order based on the key/entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ function_casts_as_integer = "deny"
 
 
 [build-dependencies]
-indexmap = "2.3.0"
 proc-macro2 = "1.0.86"
 quote = "1.0.36"
 strum = "0.26"

--- a/build/main.rs
+++ b/build/main.rs
@@ -4,6 +4,7 @@ mod static_string_indexing;
 use instructions_template::generate_instructions_rs;
 use static_string_indexing::index_static_strings;
 
+use std::collections::BTreeMap;
 use std::env;
 use std::fs::File;
 use std::io::Write;
@@ -13,11 +14,12 @@ use std::path::MAIN_SEPARATOR_STR;
 use std::process::{Command, Stdio};
 
 fn find_prolog_files(path_prefix: &str, current_dir: &Path) -> Vec<(String, PathBuf)> {
-    let mut libraries = vec![];
+    // use a BTreeMap to get a stable order independent of fs enumeration order
+    let mut libraries = BTreeMap::new();
 
     let entries = match current_dir.read_dir() {
         Ok(entries) => entries,
-        Err(_) => return libraries,
+        Err(_) => return vec![],
     };
 
     for entry in entries.filter_map(Result::ok).map(|e| e.path()) {
@@ -34,12 +36,12 @@ fn find_prolog_files(path_prefix: &str, current_dir: &Path) -> Vec<(String, Path
                 let name = entry.file_stem().unwrap().to_str().unwrap();
                 let lib_name = format!("{path_prefix}{name}");
 
-                libraries.push((lib_name, entry));
+                libraries.insert(lib_name, entry);
             }
         }
     }
 
-    libraries
+    libraries.into_iter().collect()
 }
 
 fn main() {

--- a/build/static_string_indexing.rs
+++ b/build/static_string_indexing.rs
@@ -1,18 +1,18 @@
+use std::collections::BTreeSet;
+
 use proc_macro2::TokenStream;
 use syn::parse::*;
 use syn::visit::*;
 use syn::*;
 
-use indexmap::IndexSet;
-
 struct StaticStrVisitor {
-    static_strs: IndexSet<String>,
+    static_strs: BTreeSet<String>,
 }
 
 impl StaticStrVisitor {
     fn new() -> Self {
         Self {
-            static_strs: IndexSet::new(),
+            static_strs: BTreeSet::new(),
         }
     }
 }
@@ -166,17 +166,15 @@ pub fn index_static_strings(instruction_rs_path: &std::path::Path) -> TokenStrea
         visitor.visit_file(&syntax)
     }
 
-    let mut static_str_keys = vec![];
-    let mut static_strs = vec![];
-    let mut static_str_indices = vec![];
+    let static_str_keys: Vec<_> = visitor.static_strs.iter().collect();
+    let mut static_strs = Vec::with_capacity(static_str_keys.len());
+    let mut static_str_indices = Vec::with_capacity(static_str_keys.len());
 
     let indices: Vec<u64> = visitor
         .static_strs
         .iter()
         .map(|string| {
             let index = static_string_index(string, static_strs.len());
-
-            static_str_keys.push(string);
 
             if index & 1 == 1 {
                 index


### PR DESCRIPTION
independent of the order that files/folder are enumerated

this should help with reproducibility