### PR TITLE
Use make-process to call imagemagick in showterm.el

### DIFF
--- a/tools/showterm.el
+++ b/tools/showterm.el
@@ -76,16 +76,18 @@
         (setq str (buffer-string))
         (erase-buffer))
       (let ((proc (let (process-connection-type)
-                    (start-process "convert" (current-buffer)
-                                   "convert"
-                                   "png:-"
-                                   "-gravity" "center"
-                                   "-background" "white"
-                                   "-scale" (format "%dx%d"
-                                                    showterm-pixel-width
-                                                    showterm-pixel-width)
-                                   "-extent" (format "%dx" showterm-pixel-width)
-                                   "png:-"))))
+                    (make-process :name "convert"
+                                  :buffer (current-buffer)
+                                  :stderr " convert-stderr"
+                                  :command `("convert"
+                                             "png:-"
+                                             "-gravity" "center"
+                                             "-background" "white"
+                                             "-scale" ,(format "%dx%d"
+                                                               showterm-pixel-width
+                                                               showterm-pixel-width)
+                                             "-extent" ,(format "%dx" showterm-pixel-width)
+                                             "png:-")))))
         (process-send-string proc str)
         (process-send-eof proc)
         (showterm-wait-for-process proc))


### PR DESCRIPTION
A possible fix for https://github.com/mthom/scryer-prolog/issues/3337

Recommended by the documentation for `start-process`:

> If you want to separate standard output from standard error, use
> ‘make-process’ or invoke the command through a shell and redirect
> one of them using the shell syntax.