### PR TITLE
showterm.el: use new magick command by default, fallback to convert

### DIFF
--- a/tools/showterm.el
+++ b/tools/showterm.el
@@ -6,7 +6,7 @@
 ;;
 ;;     - Scryer Prolog
 ;;     - `dot' (from Graphviz)
-;;     - `convert' (from ImageMagick)
+;;     - `convert' or `magick' (from ImageMagick)
 ;;
 ;; Copy showterm.el and showterm.pl to the same directory,
 ;; say ~/scryer-prolog/tools/, and add to your .emacs:
@@ -76,8 +76,9 @@
         (setq str (buffer-string))
         (erase-buffer))
       (let ((proc (let (process-connection-type)
-                    (start-process "convert" (current-buffer)
-                                   "convert"
+                    (start-process "imagemagick" (current-buffer)
+                                   (or (executable-find "magick")
+                                       "convert")
                                    "png:-"
                                    "-gravity" "center"
                                    "-background" "white"

--- a/tools/showterm.el
+++ b/tools/showterm.el
@@ -76,18 +76,16 @@
         (setq str (buffer-string))
         (erase-buffer))
       (let ((proc (let (process-connection-type)
-                    (make-process :name "convert"
-                                  :buffer (current-buffer)
-                                  :stderr " convert-stderr"
-                                  :command `("convert"
-                                             "png:-"
-                                             "-gravity" "center"
-                                             "-background" "white"
-                                             "-scale" ,(format "%dx%d"
-                                                               showterm-pixel-width
-                                                               showterm-pixel-width)
-                                             "-extent" ,(format "%dx" showterm-pixel-width)
-                                             "png:-")))))
+                    (start-process "convert" (current-buffer)
+                                   "convert"
+                                   "png:-"
+                                   "-gravity" "center"
+                                   "-background" "white"
+                                   "-scale" (format "%dx%d"
+                                                    showterm-pixel-width
+                                                    showterm-pixel-width)
+                                   "-extent" (format "%dx" showterm-pixel-width)
+                                   "png:-"))))
         (process-send-string proc str)
         (process-send-eof proc)
         (showterm-wait-for-process proc))


### PR DESCRIPTION
A better fix for https://github.com/mthom/scryer-prolog/issues/3337

I used `"convert"` as a string in the fallback case instead of `(executable-find "convert")` because it provides a more useful error message in case neither command is found.