### PR TITLE
adjust regression test for discussion 3359

### DIFF
--- a/tests-pl/discussion3359.pl
+++ b/tests-pl/discussion3359.pl
@@ -1,4 +1,4 @@
-:- use_module(library(clpz)).
+:- use_module(library(dcgs)).
 :- use_module(library(tabling)).
 
 :- table expr//0.

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -186,6 +186,7 @@ async fn sigint_interrupts_nonterminating_goals() {
 
 #[test]
 #[cfg_attr(miri, ignore = "it takes too long to run")]
+// FIXME this shouldn't panic an i686-linux-unknown-gnu, was already broken before d50d42509903dc3cc1841eb757a703753de84754
 #[cfg_attr(
     all(
         target_arch = "x86",
@@ -193,7 +194,7 @@ async fn sigint_interrupts_nonterminating_goals() {
         target_vendor = "unknown",
         target_env = "gnu"
     ),
-    ignore = "FIXME was already broken before d50d42509903dc3cc1841eb757a703753de84754"
+    should_panic
 )]
 fn discussion3359() {
     load_module_test("tests-pl/discussion3359.pl", "");


### PR DESCRIPTION
- incorporate fix from https://github.com/mthom/scryer-prolog/commit/3a2d57db33d49139d13c1e8cfba6eb3d79bcec19#commitcomment-187528793
- mark as should panic rather than ignored, this ensures that the test will be updated should this get fixed