### PR TITLE
Make call/N not pollute indices for user predicates

### DIFF
--- a/src/machine/load_state.rs
+++ b/src/machine/load_state.rs
@@ -682,12 +682,11 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
         let code_index_tbl = &mut LS::machine_st(&mut self.payload).arena.code_index_tbl;
 
         if module_name == atom!("user") {
-            *self
-                .wam_prelude
-                .indices
-                .code_dir
-                .entry(key)
-                .or_insert_with(|| CodeIndex::new(IndexPtr::undefined(), code_index_tbl))
+            if let Some(ci) = self.wam_prelude.indices.code_dir.get(&key) {
+                *ci
+            } else {
+                CodeIndex::new(IndexPtr::undefined(), code_index_tbl)
+            }
         } else {
             self.get_or_insert_local_code_index(module_name, key)
         }

--- a/tests-pl/issue3370_current_predicate_call.pl
+++ b/tests-pl/issue3370_current_predicate_call.pl
@@ -1,0 +1,10 @@
+:- use_module(library(format)).
+
+run :-
+    catch(call(foo, 1),_,true),
+    current_predicate(foo/1),
+    format("~s", ["foo/1 defined"]). % shouldn't happen
+
+run.
+
+:- initialization(run).

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -199,3 +199,9 @@ async fn sigint_interrupts_nonterminating_goals() {
 fn discussion3359() {
     load_module_test("tests-pl/discussion3359.pl", "");
 }
+
+
+#[test]
+fn issue3370_call() {
+    load_module_test("tests-pl/issue3370_current_predicate_call.pl", "");
+}

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -200,7 +200,6 @@ fn discussion3359() {
     load_module_test("tests-pl/discussion3359.pl", "");
 }
 
-
 #[test]
 fn issue3370_call() {
     load_module_test("tests-pl/issue3370_current_predicate_call.pl", "");

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -201,6 +201,7 @@ fn discussion3359() {
 }
 
 #[test]
-fn issue3370_call() {
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+fn issue3370_current_predicate_call() {
     load_module_test("tests-pl/issue3370_current_predicate_call.pl", "");
 }


### PR DESCRIPTION
Fixes one of the issues described in #3370:

```prolog
?- call(p, X, Y).
   error(existence_error(procedure,p/2),p/2).
?- current_predicate(p/N).
   N = 2. % unexpected.
```

It is now:

```prolog
?- call(p, X, Y).
   error(existence_error(procedure,p/2),p/2).
?- current_predicate(p/N).
   false.
```