### PR TITLE
Cleanup

### DIFF
--- a/src/atom_table.rs
+++ b/src/atom_table.rs
@@ -128,7 +128,7 @@ impl AtomCell {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Atom {
     pub index: u64,
 }
@@ -147,12 +147,6 @@ impl<'a> From<&'a Atom> for Atom {
     }
 }
 
-impl indexmap::Equivalent<Atom> for str {
-    fn equivalent(&self, key: &Atom) -> bool {
-        &*key.as_str() == self
-    }
-}
-
 impl PartialEq<str> for Atom {
     fn eq(&self, other: &str) -> bool {
         self.as_str().deref() == other
@@ -162,6 +156,37 @@ impl PartialEq<str> for Atom {
 impl PartialEq<&str> for Atom {
     fn eq(&self, &other: &&str) -> bool {
         self.as_str().deref() == other
+    }
+}
+
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct AtomHashByStr(Atom);
+
+impl Deref for AtomHashByStr {
+    type Target = Atom;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Atom> for AtomHashByStr {
+    fn from(value: Atom) -> Self {
+        Self(value)
+    }
+}
+
+impl indexmap::Equivalent<AtomHashByStr> for str {
+    fn equivalent(&self, key: &AtomHashByStr) -> bool {
+        &*key.0.as_str() == self
+    }
+}
+
+impl Hash for AtomHashByStr {
+    #[inline]
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.as_str().hash(hasher)
     }
 }
 
@@ -210,13 +235,6 @@ pub struct AtomData {
 impl AtomHeader {
     fn build_with(len: u64) -> Self {
         AtomHeader::new().with_len(len).with_m(false)
-    }
-}
-
-impl Hash for Atom {
-    #[inline]
-    fn hash<H: Hasher>(&self, hasher: &mut H) {
-        self.as_str().hash(hasher)
     }
 }
 
@@ -410,7 +428,7 @@ impl Ord for Atom {
 #[derive(Debug)]
 pub struct InnerAtomTable {
     block: RawBlock<AtomTable>,
-    pub table: Arcu<IndexSet<Atom>, GlobalEpochCounterPool>,
+    pub table: Arcu<IndexSet<AtomHashByStr>, GlobalEpochCounterPool>,
 }
 
 #[derive(Debug)]
@@ -428,7 +446,7 @@ impl InnerAtomTable {
         STATIC_ATOMS_MAP
             .get(string)
             .cloned()
-            .or_else(|| self.table.read().get(string).cloned())
+            .or_else(|| self.table.read().get(string).map(|ahbs| &**ahbs).cloned())
     }
 }
 
@@ -466,7 +484,7 @@ impl AtomTable {
         global_atom_table().read().unwrap().upgrade().unwrap()
     }
 
-    pub fn active_table(&self) -> RcuRef<IndexSet<Atom>, IndexSet<Atom>> {
+    pub fn active_table(&self) -> RcuRef<IndexSet<AtomHashByStr>, IndexSet<AtomHashByStr>> {
         self.inner.read().table.read()
     }
 
@@ -534,7 +552,7 @@ impl AtomTable {
                     .get_name();
 
                 let mut table = table_epoch.clone();
-                table.insert(atom);
+                table.insert(atom.into());
                 block_epoch.table.replace(table);
 
                 // explicit drop to ensure we don't accidentally drop it early

--- a/src/debray_allocator.rs
+++ b/src/debray_allocator.rs
@@ -26,12 +26,12 @@ pub struct BranchOccurrences {
     pub deep_safety: BitSet<usize>,
     pub num_branches: usize,
     pub current_branch_idx: usize,
-    pub current_branch_num: Arc<BranchNumber>,
+    pub current_branch_num: BranchNumber,
     pub subsumed_hits: SubsumedBranchHits,
 }
 
 impl BranchOccurrences {
-    fn new(current_branch_num: Arc<BranchNumber>, num_branches: usize) -> Self {
+    fn new(current_branch_num: BranchNumber, num_branches: usize) -> Self {
         Self {
             hits: BranchHits::with_hasher(FxBuildHasher::default()),
             shallow_safety: BitSet::default(),
@@ -99,7 +99,7 @@ impl BranchStack {
         }
     }
 
-    pub(crate) fn add_branch_stack(&mut self, branch_num: Arc<BranchNumber>, num_branches: usize) {
+    pub(crate) fn add_branch_stack(&mut self, branch_num: BranchNumber, num_branches: usize) {
         self.push(BranchOccurrences::new(branch_num, num_branches));
     }
 
@@ -113,7 +113,7 @@ impl BranchStack {
     }
 
     #[inline]
-    pub(crate) fn incr_current_branch(&mut self, branch_num: Arc<BranchNumber>) {
+    pub(crate) fn incr_current_branch(&mut self, branch_num: BranchNumber) {
         let branch_occurrences = self.last_mut().unwrap();
         branch_occurrences.current_branch_idx += 1;
         branch_occurrences.current_branch_num = branch_num;

--- a/src/debray_allocator.rs
+++ b/src/debray_allocator.rs
@@ -531,7 +531,7 @@ impl DebrayAllocator {
     }
 
     fn mark_safe_var(&mut self, var_num: usize, lvl: Level, term_loc: GenContext) {
-        let branch_designator = Arc::new(self.branch_stack.current_branch_designator());
+        let branch_designator = self.branch_stack.current_branch_designator();
 
         match &mut self.var_data.records[var_num].allocation {
             VarAlloc::Perm(
@@ -575,7 +575,7 @@ impl DebrayAllocator {
         r: RegType,
         arg_c: usize,
     ) -> Instruction {
-        let branch_designator = Arc::new(self.branch_stack.current_branch_designator());
+        let branch_designator = self.branch_stack.current_branch_designator();
 
         match &mut self.var_data.records[var_num].allocation {
             VarAlloc::Perm(

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -26,6 +26,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{AddAssign, Deref, DerefMut};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 pub type PredicateKey = (Atom, usize); // name, arity.
 
@@ -125,67 +126,95 @@ impl ChunkType {
     }
 }
 
-#[derive(Debug, Clone)] //, PartialOrd, PartialEq, Eq, Hash)]
-pub(crate) struct BranchNumber {
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub(crate) struct BranchNumber(pub(crate) Arc<BranchNumberInner>);
+
+impl Default for BranchNumber {
+    fn default() -> Self {
+        static DEFAULT_BRANCH_NUMBER: LazyLock<BranchNumber> = LazyLock::new(|| {
+            BranchNumber(Arc::new(BranchNumberInner {
+                branch_num: Rational::from(0),
+                delta: Rational::from(1u64 << 31),
+            }))
+        });
+        DEFAULT_BRANCH_NUMBER.clone()
+    }
+}
+
+impl Deref for BranchNumber {
+    type Target = BranchNumberInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl BranchNumber {
+    pub(crate) fn split(&self) -> Self {
+        Self(Arc::new(self.0.split()))
+    }
+
+    pub(crate) fn incr_by_delta(&self) -> Self {
+        Self(Arc::new(self.0.incr_by_delta()))
+    }
+
+    pub(crate) fn halve_delta(&self) -> Self {
+        Self(Arc::new(self.0.halve_delta()))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BranchNumberInner {
     pub(crate) branch_num: Rational,
     pub(crate) delta: Rational,
 }
 
-impl Default for BranchNumber {
-    fn default() -> Self {
-        Self {
-            branch_num: Rational::from(0),
-            delta: Rational::from(1u64 << 31),
-        }
-    }
-}
-
-impl PartialEq<BranchNumber> for BranchNumber {
+impl PartialEq for BranchNumberInner {
     #[inline]
-    fn eq(&self, rhs: &BranchNumber) -> bool {
+    fn eq(&self, rhs: &Self) -> bool {
         self.branch_num == rhs.branch_num
     }
 }
 
-impl Eq for BranchNumber {}
+impl Eq for BranchNumberInner {}
 
-impl Hash for BranchNumber {
+impl Hash for BranchNumberInner {
     #[inline(always)]
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         self.branch_num.hash(hasher)
     }
 }
 
-impl PartialOrd<BranchNumber> for BranchNumber {
+impl PartialOrd<BranchNumberInner> for BranchNumberInner {
     #[inline]
-    fn partial_cmp(&self, rhs: &BranchNumber) -> Option<Ordering> {
+    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
         self.branch_num.partial_cmp(&rhs.branch_num)
     }
 }
 
-impl BranchNumber {
+impl BranchNumberInner {
     pub(crate) fn has_as_subbranch(&self, other: &Self) -> bool {
         other.delta <= self.delta
             && other.branch_num >= self.branch_num
             && other.branch_num < &self.branch_num + &self.delta
     }
 
-    pub(crate) fn split(&self) -> BranchNumber {
-        BranchNumber {
+    pub(crate) fn split(&self) -> BranchNumberInner {
+        BranchNumberInner {
             branch_num: self.branch_num.clone() + &self.delta / Rational::from(2),
             delta: &self.delta / Rational::from(4),
         }
     }
 
-    pub(crate) fn incr_by_delta(&self) -> BranchNumber {
-        BranchNumber {
+    pub(crate) fn incr_by_delta(&self) -> BranchNumberInner {
+        BranchNumberInner {
             branch_num: self.branch_num.clone() + &self.delta,
             delta: self.delta.clone(),
         }
     }
 
-    pub(crate) fn halve_delta(&self) -> BranchNumber {
-        BranchNumber {
+    pub(crate) fn halve_delta(&self) -> BranchNumberInner {
+        BranchNumberInner {
             branch_num: self.branch_num.clone(),
             delta: &self.delta / Rational::from(2),
         }
@@ -195,7 +224,7 @@ impl BranchNumber {
 #[derive(Debug)]
 pub enum ChunkedTerms {
     Branch {
-        branch_nums: Vec<Arc<BranchNumber>>,
+        branch_nums: Vec<BranchNumber>,
         arms: Vec<VecDeque<ChunkedTerms>>,
     },
     Chunk {

--- a/src/heap_iter.rs
+++ b/src/heap_iter.rs
@@ -987,7 +987,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "it takes too long to run")]
     fn heap_stackless_iter_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -1880,7 +1880,6 @@ mod tests {
     use crate::machine::mock_wam::*;
 
     #[test]
-    #[cfg_attr(miri, ignore = "it takes too long to run")]
     fn term_printing_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -7,7 +7,6 @@ use std::cell::Cell;
 use std::collections::VecDeque;
 use std::iter::*;
 use std::rc::Rc;
-use std::sync::Arc;
 use std::vec::Vec;
 
 #[allow(clippy::borrowed_box)]
@@ -321,7 +320,7 @@ pub(crate) fn breadth_first_iter(
 enum ClauseIteratorState<'a> {
     RemainingChunks(&'a VecDeque<ChunkedTerms>, usize),
     RemainingBranches(
-        &'a Vec<Arc<BranchNumber>>,
+        &'a Vec<BranchNumber>,
         &'a Vec<VecDeque<ChunkedTerms>>,
         usize,
     ),
@@ -330,11 +329,11 @@ enum ClauseIteratorState<'a> {
 #[derive(Debug, Clone)]
 pub(crate) enum ClauseItem<'a> {
     FirstBranch {
-        branch_num: &'a Arc<BranchNumber>,
+        branch_num: &'a BranchNumber,
         num_branches: usize,
     },
     NextBranch {
-        branch_num: &'a Arc<BranchNumber>,
+        branch_num: &'a BranchNumber,
     },
     BranchEnd {
         depth: usize,

--- a/src/machine/disjuncts.rs
+++ b/src/machine/disjuncts.rs
@@ -35,12 +35,12 @@ pub struct ChunkInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BranchInfo {
-    branch_num: Arc<BranchNumber>,
+    branch_num: BranchNumber,
     chunks: Vec<ChunkInfo>,
 }
 
 impl BranchInfo {
-    fn new(branch_num: Arc<BranchNumber>) -> Self {
+    fn new(branch_num: BranchNumber) -> Self {
         Self {
             branch_num,
             chunks: vec![],
@@ -69,7 +69,7 @@ impl DerefMut for BranchMap {
     }
 }
 
-type RootSet = IndexSet<Arc<BranchNumber>>;
+type RootSet = IndexSet<BranchNumber>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ClassifyInfo {
@@ -93,14 +93,14 @@ enum TraversalState {
     Term(Term),
     OverrideGlobalCutVar(usize),
     ResetGlobalCutVarOverride(Option<usize>),
-    AddBranchNum(Arc<BranchNumber>), // set current_branch_num, add it to the root set
-    RepBranchNum(Arc<BranchNumber>), // replace current_branch_num and the latest in the root set
+    AddBranchNum(BranchNumber), // set current_branch_num, add it to the root set
+    RepBranchNum(BranchNumber), // replace current_branch_num and the latest in the root set
 }
 
 #[derive(Debug)]
 pub struct VariableClassifier {
     call_policy: CallPolicy,
-    current_branch_num: Arc<BranchNumber>,
+    current_branch_num: BranchNumber,
     current_chunk_num: usize,
     current_chunk_type: ChunkType,
     branch_map: BranchMap,
@@ -157,7 +157,7 @@ pub type ClassifyFactResult = (Term, VarData);
 pub type ClassifyRuleResult = (Term, ChunkedTermVec, VarData);
 
 fn merge_branch_seq(branches: impl Iterator<Item = BranchInfo>) -> BranchInfo {
-    let mut branch_info = BranchInfo::new(Arc::new(BranchNumber::default()));
+    let mut branch_info = BranchInfo::new(BranchNumber::default());
 
     for mut branch in branches {
         branch_info.branch_num = branch.branch_num;
@@ -166,17 +166,17 @@ fn merge_branch_seq(branches: impl Iterator<Item = BranchInfo>) -> BranchInfo {
 
     let new_delta = branch_info.branch_num.delta.clone() * Integer::from(2);
 
-    branch_info.branch_num = Arc::new(BranchNumber {
+    branch_info.branch_num = BranchNumber(Arc::new(BranchNumberInner {
         branch_num: branch_info.branch_num.branch_num.clone() - &new_delta,
         delta: new_delta,
-    });
+    }));
 
     branch_info
 }
 
 fn flatten_into_disjunct(
     build_stack: &mut ChunkedTermVec,
-    branch_num: Arc<BranchNumber>,
+    branch_num: BranchNumber,
     preceding_len: usize,
 ) {
     let branch_vec = build_stack.drain(preceding_len + 1..).collect();
@@ -193,7 +193,7 @@ impl VariableClassifier {
     pub fn new(call_policy: CallPolicy) -> Self {
         Self {
             call_policy,
-            current_branch_num: Arc::new(BranchNumber::default()),
+            current_branch_num: BranchNumber::default(),
             current_chunk_num: 0,
             current_chunk_type: ChunkType::Head,
             branch_map: BranchMap(BranchMapInt::new()),
@@ -547,7 +547,7 @@ impl VariableClassifier {
                             let tail = terms.pop().unwrap();
                             let head = terms.pop().unwrap();
 
-                            let first_branch_num = Arc::new(self.current_branch_num.split());
+                            let first_branch_num = self.current_branch_num.split();
                             let branches: Vec<_> = std::iter::once(head)
                                 .chain(unfold_by_str(tail, atom!(";")))
                                 .collect();
@@ -558,18 +558,18 @@ impl VariableClassifier {
                                 let succ_branch_number = branch_numbers[idx - 1].incr_by_delta();
 
                                 branch_numbers.push(if idx + 1 < branches.len() {
-                                    Arc::new(succ_branch_number.split())
+                                    succ_branch_number.split()
                                 } else {
-                                    Arc::new(succ_branch_number)
+                                    succ_branch_number
                                 });
                             }
 
                             let build_stack_len = build_stack.len();
                             build_stack.reserve_branch(branches.len());
 
-                            state_stack.push(TraversalState::RepBranchNum(Arc::new(
+                            state_stack.push(TraversalState::RepBranchNum(
                                 self.current_branch_num.halve_delta(),
-                            )));
+                            ));
 
                             let iter = branches.into_iter().zip(branch_numbers);
                             let final_disjunct_loc = state_stack.len();
@@ -624,14 +624,14 @@ impl VariableClassifier {
                             let not_term = terms.pop().unwrap();
                             let build_stack_len = build_stack.len();
 
-                            let first_branch_num = Arc::new(self.current_branch_num.split());
-                            let second_branch_num = Arc::new(first_branch_num.incr_by_delta());
+                            let first_branch_num = self.current_branch_num.split();
+                            let second_branch_num = first_branch_num.incr_by_delta();
 
                             build_stack.reserve_branch(2);
 
-                            state_stack.push(TraversalState::RepBranchNum(Arc::new(
+                            state_stack.push(TraversalState::RepBranchNum(
                                 self.current_branch_num.halve_delta(),
-                            )));
+                            ));
                             state_stack.push(TraversalState::BuildFinalDisjunct(build_stack_len));
                             state_stack.push(TraversalState::Term(Term::Clause(
                                 Cell::default(),

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic;
+
 use crate::arena::*;
 use crate::atom_table::*;
 use crate::functor_macro::*;
@@ -289,39 +291,31 @@ impl MachineState {
         )
     }
 
-    fn check_for_interrupt(&mut self) {
-        let interrupted = INTERRUPT.load(std::sync::atomic::Ordering::Relaxed);
+    #[inline(always)]
+    pub(crate) fn check_for_interrupt(&mut self) -> bool {
+        if INTERRUPT.swap(false, atomic::Ordering::Relaxed) {
+            self.throw_interrupt_exception();
+            self.backtrack();
 
-        match INTERRUPT.compare_exchange(
-            interrupted,
-            false,
-            std::sync::atomic::Ordering::Relaxed,
-            std::sync::atomic::Ordering::Relaxed,
-        ) {
-            Ok(interruption) => {
-                if interruption {
-                    self.throw_interrupt_exception();
-                    self.backtrack();
+            // We have extracted control over the Tokio runtime to the calling context for enabling library use case
+            // (see https://github.com/mthom/scryer-prolog/pull/1880)
+            // So we only have access to a runtime handle in here and can't shut it down.
+            // Since I'm not aware of the consequences of deactivating this new code which came in while PR 1880
+            // was not merged, I'm only deactivating it for now.
 
-                    // We have extracted control over the Tokio runtime to the calling context for enabling library use case
-                    // (see https://github.com/mthom/scryer-prolog/pull/1880)
-                    // So we only have access to a runtime handle in here and can't shut it down.
-                    // Since I'm not aware of the consequences of deactivating this new code which came in while PR 1880
-                    // was not merged, I'm only deactivating it for now.
+            //#[cfg(not(target_arch = "wasm32"))]
+            //let runtime = tokio::runtime::Runtime::new().unwrap();
+            //#[cfg(target_arch = "wasm32")]
+            //let runtime = tokio::runtime::Builder::new_current_thread()
+            //    .enable_all()
+            //    .build()
+            //    .unwrap();
 
-                    //#[cfg(not(target_arch = "wasm32"))]
-                    //let runtime = tokio::runtime::Runtime::new().unwrap();
-                    //#[cfg(target_arch = "wasm32")]
-                    //let runtime = tokio::runtime::Builder::new_current_thread()
-                    //    .enable_all()
-                    //    .build()
-                    //    .unwrap();
-
-                    //let old_runtime = tokio::runtime::Handle::current();
-                    //old_runtime.shutdown_background();
-                }
-            }
-            Err(_) => unreachable!(),
+            //let old_runtime = tokio::runtime::Handle::current();
+            //old_runtime.shutdown_background();
+            true
+        } else {
+            false
         }
     }
 

--- a/src/machine/partial_string.rs
+++ b/src/machine/partial_string.rs
@@ -242,7 +242,6 @@ mod test {
     use crate::machine::mock_wam::*;
 
     #[test]
-    #[cfg_attr(miri, ignore = "it takes too long to run")]
     fn pstr_iter_tests() {
         let mut wam = MockWAM::new();
 

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4725,36 +4725,6 @@ impl Machine {
         Ok(())
     }
 
-    #[inline(always)]
-    fn interrupt_occured(&mut self) -> bool {
-        let interrupted = machine::INTERRUPT.load(std::sync::atomic::Ordering::Relaxed);
-
-        match machine::INTERRUPT.compare_exchange(
-            interrupted,
-            false,
-            std::sync::atomic::Ordering::Relaxed,
-            std::sync::atomic::Ordering::Relaxed,
-        ) {
-            Ok(interruption) => {
-                if interruption {
-                    self.machine_st.throw_interrupt_exception();
-                    self.machine_st.backtrack();
-                    // We have extracted control over the Tokio runtime to the calling context for enabling library use case
-                    // (see https://github.com/mthom/scryer-prolog/pull/1880)
-                    // So we only have access to a runtime handle in here and can't shut it down.
-                    // Since I'm not aware of the consequences of deactivating this new code which came in while PR 1880
-                    // was not merged, I'm only deactivating it for now.
-                    //let old_runtime = std::mem::replace(&mut self.runtime, tokio::runtime::Runtime::new().unwrap());
-                    //old_runtime.shutdown_background();
-                    return true;
-                }
-            }
-            Err(_) => unreachable!(),
-        }
-
-        false
-    }
-
     #[cfg(feature = "http")]
     #[inline(always)]
     pub(crate) fn http_accept(&mut self) -> CallResult {
@@ -4854,7 +4824,7 @@ impl Machine {
                         break
                     }
                     Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                        if self.interrupt_occured() {
+                        if self.machine_st.check_for_interrupt() {
                             break;
                         }
                     }
@@ -7217,7 +7187,7 @@ impl Machine {
                              }
                             Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
                                 std::thread::sleep(std::time::Duration::from_millis(200));
-                                if self.interrupt_occured() {
+                                if self.machine_st.check_for_interrupt() {
                                     break;
                                 }
                             }

--- a/src/repl_helper.rs
+++ b/src/repl_helper.rs
@@ -74,6 +74,7 @@ impl Completer for Helper {
 
             let mut matching = index_set
                 .iter()
+                .map(|ahbs| &**ahbs)
                 .chain(STATIC_ATOMS_MAP.values())
                 .map(|a| a.as_str())
                 .filter(|a| a.starts_with(sub_str))

--- a/src/variable_records.rs
+++ b/src/variable_records.rs
@@ -7,7 +7,6 @@ use indexmap::{IndexMap, IndexSet};
 use num_order::NumOrd;
 
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct TempVarData {
@@ -18,13 +17,13 @@ pub struct TempVarData {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BranchDesignator {
-    pub branch_num: Arc<BranchNumber>,
+    pub branch_num: BranchNumber,
 }
 
 impl BranchDesignator {
     #[inline]
     pub fn is_sub_branch(&self) -> bool {
-        self.branch_num.branch_num.num_gt(&0)
+        self.branch_num.0.branch_num.num_gt(&0)
     }
 }
 
@@ -49,7 +48,7 @@ impl VarSafetyStatus {
     pub(crate) fn needed_if(needed: bool, branch_designator: &BranchDesignator) -> Self {
         if needed {
             VarSafetyStatus::Needed
-        } else if branch_designator.branch_num.branch_num.num_eq(&0) {
+        } else if branch_designator.branch_num.0.branch_num.is_zero() {
             VarSafetyStatus::GloballyUnneeded
         } else {
             VarSafetyStatus::LocallyUnneeded(branch_designator.clone())


### PR DESCRIPTION
- a96cee67f5580eebd5229455dae97bf1220c2092 remove two unnecessary usages of `Arc`
- 16da0f7611032bf0a7dac34bb34468a19d6571f2 move `Arc` from around `BranchNumber` to inside of it 
  -  this way the `Arc` for the default value can be allocated once, reused and is never deallocated
- 39381ad848be0fdde84acaded8d0693582657620 Hash Atoms by their index by default
  - this means outside the AtomTable hashing doesn't need to lookup the String value in the AtomTable
  - in the AtomTable use a wrapper that hashes Atoms by their String value so that we can still map Strings to already existing Atoms
 - 89a9b5b097c86acde24f8b2d09f4f16f10828b3c re-enable three tests in miri that were disabled due to being too slow
   - they appeared sufficiently fast in local testing
 - 8ad74f006a08f730c20fd5c114146731eac82413 de-dup interrupt checking logic and fix a race-condition that could result in a panic
   - race was between atomic load and atomic compare exchange 
     if the interrupt happens to flip the flag from false to true between the load and the compare exchange the compare exchange would fail and reach the `unreachable!` in the `Err` branch