### PR TITLE
Allow using pipes that close in phrase_from_stream

### DIFF
--- a/src/lib/pio.pl
+++ b/src/lib/pio.pl
@@ -140,11 +140,17 @@ buffer_prepare_for_n(Stream, BufferId, BufferPosId, BufferLenId, N) :-
             ;   chars_to_read(CharsToRead),
                 get_n_chars(Stream, CharsToRead, Chars),
                 length(Chars, NChars),
-                partial_string(Chars, BufferTail, _),
-                bb_put(BufferId, Buffer),
-                BufferLen1 is BufferLen + NChars,
-                bb_put(BufferLenId, BufferLen1),
-                buffer_prepare_for_n(Stream, BufferId, BufferPosId, BufferLenId, N)
+                (   NChars =:= 0 ->
+                    % get_n_chars returning [] means EOF, even on streams
+                    % whose at_end_of_stream/1 never reports true (pipes).
+                    BufferTail = [],
+                    bb_put(BufferId, Buffer)
+                ;   partial_string(Chars, BufferTail, _),
+                    bb_put(BufferId, Buffer),
+                    BufferLen1 is BufferLen + NChars,
+                    bb_put(BufferLenId, BufferLen1),
+                    buffer_prepare_for_n(Stream, BufferId, BufferPosId, BufferLenId, N)
+                )
             )
         ;   true
         )


### PR DESCRIPTION
The Prolog standard says in `7.10.2.9 End position of a stream`: 

> A stream need not have an end, in which case its stream position is never end-of-stream or past-end-of-stream.

And this is in line with what happens with pipes. As they don't have an end, they never reach `at_end_of_stream/1`.

However this makes `pio` unusable with pipes. Which means that `run/1` in this program never terminates:

```prolog
:- use_module(library(process)).
:- use_module(library(pio)).
:- use_module(library(dcgs)).

run(X) :-
    process_create("echo", ["1"], [stdout(pipe(POut))]),
    phrase_from_stream(seq(X), POut).
```

With the fix in this PR, it is the case that we can reason about piped outputs from processes:

```console
$ ./scryer-prolog-fix a.pl   # the patched scryer-prolog
?- run(X).
   X = "1\n"
;  ... .
?- 
$ ./scryer-prolog/target/release/scryer-prolog a.pl  # current `master`
?- run(X).
^C   error('$interrupt_thrown',repl/0).
?- 
```