### PR TITLE
Add support for SCRYER_EDIT_MODE environment variable

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -25,7 +25,7 @@ use fxhash::FxBuildHasher;
 #[cfg(feature = "repl")]
 use rustyline::error::ReadlineError;
 #[cfg(feature = "repl")]
-use rustyline::history::DefaultHistory;
+use rustyline::{history::DefaultHistory, EditMode};
 #[cfg(feature = "repl")]
 use rustyline::{Config, Editor};
 
@@ -147,7 +147,19 @@ impl ReadlineStream {
     pub fn new(pending_input: &str, add_history: bool) -> Self {
         #[cfg(feature = "repl")]
         {
-            let config = Config::builder().check_cursor_position(true).build();
+            let edit_mode = match std::env::var("SCRYER_EDIT_MODE") {
+                Ok(mode) => match mode.to_lowercase().as_str() {
+                    "vi" | "vim" => EditMode::Vi,
+                    "emacs" => EditMode::Emacs,
+                    _ => EditMode::Emacs,
+                },
+                Err(_) => EditMode::Emacs,
+            };
+
+            let config = Config::builder()
+                .check_cursor_position(true)
+                .edit_mode(edit_mode)
+                .build();
 
             let helper = Helper::new();
 


### PR DESCRIPTION
This PR adds support for using vi keybindings in the scryer-prolog REPL by setting the `SCRYER_EDIT_MODE` environment variable. This is a minimal change that doesn't affect any existing functionality. The rustyline crate already supports vi mode, this just exposes it through configuration.

## Changes
- Modified `src/read.rs` to check the `SCRYER_EDIT_MODE` environment variable when initializing the rustyline editor
- Uses rustyline's built-in `EditMode::Vi` support
- Falls back to emacs mode (current behavior) if the variable is unset or contains an unrecognized value

## Usage
```bash
# Enable vi mode
SCRYER_EDIT_MODE=vi scryer-prolog

# Or export for the session
export SCRYER_EDIT_MODE=vi
scryer-prolog

# 'vim' and 'emacs' are also supported values of the environment variable.
```
## Testing

This has been tested with SCRYER_EDIT_MODE=vi - vi keybindings work correctly.
Tested with SCRYER_EDIT_MODE=emacs - emacs mode works as expected.
Tested without the variable set - defaults to emacs mode (backward compatible).
Tested with invalid values - gracefully falls back to emacs mode.
