### PR TITLE
fix char_type lower performing reverse operation

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -3093,7 +3093,7 @@ impl Machine {
                         let reg = self.machine_st.deref(self.machine_st.heap[s+1]);
                         let lower_str = step_or_resource_error!(
                             self.machine_st,
-                            self.machine_st.heap.allocate_cstr(&c.to_uppercase().to_string())
+                            self.machine_st.heap.allocate_cstr(&c.to_lowercase().to_string())
                         );
 
                         unify!(self.machine_st, reg, lower_str);


### PR DESCRIPTION
I ran into the same issue as https://github.com/mthom/scryer-prolog/issues/3351

It seems like `to_lowercase()` was inadvertently changed to `to_uppercase()` as part of a large commit here https://github.com/mthom/scryer-prolog/commit/c0f72704eca9f5ca9904048082e11f16c022cfac#diff-91d75468206c8711115d7727ed17c2a0c1f60dae276bbbf08c132a9138157240L3088

After patch:
```
?- use_module(library(charsio)).
   true.
?- char_type('a', lower(X)).
   X = "a".
?- char_type('A', lower(X)).
   X = "a".
?- char_type('a', upper(X)).
   X = "A".
?- char_type('A', upper(X)).
   X = "A".
```