### PR TITLE
Proper backtracking on interrupted socket/http listeners

### DIFF
--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4737,8 +4737,6 @@ impl Machine {
         ) {
             Ok(interruption) => {
                 if interruption {
-                    self.machine_st.throw_interrupt_exception();
-                    self.machine_st.backtrack();
                     // We have extracted control over the Tokio runtime to the calling context for enabling library use case
                     // (see https://github.com/mthom/scryer-prolog/pull/1880)
                     // So we only have access to a runtime handle in here and can't shut it down.
@@ -4855,7 +4853,9 @@ impl Machine {
                     }
                     Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                         if self.interrupt_occured() {
-                            break;
+                            let err = self.machine_st.interrupt_error();
+                            let src = functor_stub(atom!("repl"), 0);
+                            return Err(self.machine_st.error_form(err, src));
                         }
                     }
                   Err(_) => {
@@ -7218,7 +7218,9 @@ impl Machine {
                             Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
                                 std::thread::sleep(std::time::Duration::from_millis(200));
                                 if self.interrupt_occured() {
-                                    break;
+                                    let err = self.machine_st.interrupt_error();
+                                    let src = functor_stub(atom!("repl"), 0);
+                                    return Err(self.machine_st.error_form(err, src));
                                 }
                             }
                             Err(_) => {


### PR DESCRIPTION
The changes in https://github.com/mthom/scryer-prolog/pull/3362 were in the right direction, but the logic that handles the backtracking was wrong as it can be seen in the example below.

The program for the example is the following one:

```prolog
run :-
    $ socket_server_open('127.0.0.1':8080, S),
    $ socket_server_accept(S, _, _, []),
    format("This should be unreachable if the previous line was interrupted with Ctrl+C!", []).
```
On `master`:
```console
$ scryer-prolog a.pl -g run,halt.
call:user:socket_server_open('127.0.0.1':8080,A).
exit:user:socket_server_open('127.0.0.1':8080,'$tcp_listener'('127.0.0.1',8080)).
call:user:socket_server_accept('$tcp_listener'('127.0.0.1',8080),A,B,[]).
^Cexit:user:socket_server_accept('$tcp_listener'('127.0.0.1',8080),A,B,[]).
This should be unreachable if the previous line was interrupted with Ctrl+C!
?-
```

On this branch:
```console
$ scryer-prolog a.pl -g run,halt.
call:user:socket_server_open('127.0.0.1':8080,A).
exit:user:socket_server_open('127.0.0.1':8080,'$tcp_listener'('127.0.0.1',8080)).
call:user:socket_server_accept('$tcp_listener'('127.0.0.1',8080),A,B,[]).
^Cexception:error('$interrupt_thrown',repl/0):user:socket_server_accept('$tcp_listener'('127.0.0.1',8080),A,B,[]).
   error('$interrupt_thrown',repl/0).
?-
```
---------------------------------------------------

For `http_listen/2`, there is a similar error, using this file (taken from the example of the docs):
```prolog
text_handler(_, Response) :-
  http_status_code(Response, 200),
  http_body(Response, text("Welcome to Scryer Prolog!")).

run :- http_listen(7890, [get(echo, text_handler)]).
```

On `master`, execution is allowed to continue and crashes on an instantiation error:
```console
$ scryer-prolog a.pl -g run,halt.
Listening at http://0.0.0.0:7890
^C% CPU time: 0.001s, 177 inferences
   run,halt causes: error(instantiation_error,must_be/2)
?-
```

On this branch, the exception is correctly thrown:
```console
$ scryer-prolog a.pl -g run,halt.
Listening at http://0.0.0.0:7890
Listening at http://0.0.0.0:7890
^C% CPU time: 0.000s, 177 inferences
   run,halt causes: error($interrupt_thrown,repl/0)
?-
```

-----------------------------------------------

I noticed it because my toy server was throwing instantiation errors in tls_server_negotiate when I stop it with SIGINT
```prolog
setup_call_cleanup(
  (
    log_msg("tcp", "Accepting connections...~n", []),
    socket_server_accept(Socket, Client, S0, []),
    log_msg("tcp", "Connected client ~q~n", [Client])
  ),
  with_tls_connection(S0, Context, Kont),
  ( close(S0),
    log_msg("tcp", "Closed connection for client ~q~n", [Client])
  )
)
```
And the log would show that `Client` was unbound, so the Ctrl+C in `socket_server_accept` still allowed execution to continue.