### PR TITLE
Add checked parser, query, and module-load APIs

### DIFF
--- a/src/loader.pl
+++ b/src/loader.pl
@@ -129,6 +129,12 @@ file_load(Stream, Path) :-
     false.        %% Clear the heap.
 file_load(_, _).
 
+% Rust observes loader errors via the exception ball; this intentional failure
+% preserves the heap-clearing backtracking behavior of file_load/2.
+file_load_checked(Stream, Path) :-
+    file_load(Stream, Path, _),
+    false.        %% Clear the heap.
+
 file_load_init(Stream, Evacuable) :-
     load_loop(Stream, Evacuable),
     run_initialization_goals.

--- a/src/loader.pl
+++ b/src/loader.pl
@@ -124,16 +124,10 @@ run_initialization_goals :-
     ;  true
     ).
 
+% Run side-effect-only loaders under double negation so the inner \+ backtracks
+% over temporary heap state, while thrown loader errors still propagate.
 file_load(Stream, Path) :-
-    file_load(Stream, Path, _),
-    false.        %% Clear the heap.
-file_load(_, _).
-
-% Rust observes loader errors via the exception ball; this intentional failure
-% preserves the heap-clearing backtracking behavior of file_load/2.
-file_load_checked(Stream, Path) :-
-    file_load(Stream, Path, _),
-    false.        %% Clear the heap.
+    \+ \+ file_load(Stream, Path, _).
 
 file_load_init(Stream, Evacuable) :-
     load_loop(Stream, Evacuable),
@@ -162,14 +156,15 @@ file_load(Stream, Path, Evacuable) :-
     unload_evacuable(Evacuable).
 
 
+% Same heap cleanup pattern as file_load/2 for stream-only loads.
 load(Stream) :-
-    create_load_context(Stream, Evacuable),
-    catch(loader:file_load_init(Stream, Evacuable),
-          E,
-          loader:file_load_cleanup(Evacuable, E)),
-    unload_evacuable(Evacuable),
-    false.        %% Clear the heap.
-load(_).
+    \+ \+ (
+        create_load_context(Stream, Evacuable),
+        catch(loader:file_load_init(Stream, Evacuable),
+              E,
+              loader:file_load_cleanup(Evacuable, E)),
+        unload_evacuable(Evacuable)
+    ).
 
 
 print_comma_separated_list([VN=_]) :-

--- a/src/machine/heap.rs
+++ b/src/machine/heap.rs
@@ -11,6 +11,7 @@ use std::ptr;
 
 const ALIGN: usize = Heap::heap_cell_alignment();
 
+/// A heap or stack allocation failed.
 #[derive(Debug, Clone)]
 pub struct AllocError;
 

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -647,7 +647,10 @@ impl Machine {
         query: impl Into<String>,
     ) -> Result<QueryState<'_>, RunQueryError> {
         let term = self.parse_query_term(query)?;
+        self.run_query_term_checked(term)
+    }
 
+    fn run_query_term_checked(&mut self, term: ASTTerm) -> Result<QueryState<'_>, RunQueryError> {
         self.allocate_stub_choice_point()?;
 
         // Write parsed term to heap

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -576,8 +576,8 @@ impl Machine {
         parser.read_term(&op_dir, Tokens::Default)
     }
 
-    /// Parses a query string without entering the execution path.
-    pub fn parse_query_checked(&mut self, query: impl Into<String>) -> Result<(), ParserError> {
+    /// Validates a query term without entering the execution path.
+    pub fn validate_query_term(&mut self, query: impl Into<String>) -> Result<(), ParserError> {
         self.parse_query_term(query).map(|_| ())
     }
 
@@ -656,7 +656,7 @@ impl Machine {
             Err(CompilationError::FiniteMemoryInHeap(err)) => {
                 return Err(RunQueryError::Allocation(err));
             }
-            Err(err) => panic!("couldn't write term to heap: {err:?}"),
+            Err(err) => panic!("couldn't write query term to heap: {err:?}"),
         };
 
         let var_names: IndexMap<_, _> = term_write_result

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -11,9 +11,9 @@ use crate::machine::{
     ArenaHeaderTag, BREAK_FROM_DISPATCH_LOOP_LOC, Fixnum, LIB_QUERY_SUCCESS, Number,
 };
 use crate::offset_table::*;
-use crate::parser::ast::{Literal as ParsedLiteral, Term as ParsedTerm, Var, VarPtr};
+use crate::parser::ast::{Var, VarPtr};
 use crate::parser::parser::{Parser, Tokens};
-use crate::read::{TermWriteResult, write_term_to_heap};
+use crate::read::{devour_whitespace, write_term_to_heap, TermWriteResult};
 use crate::types::UntypedArenaPtr;
 
 use dashu::{Integer, Rational};
@@ -57,17 +57,6 @@ pub enum CheckedFacadeStatus {
     MalformedQuery,
     /// Execution or machine setup failed without exposing backend details.
     InternalFailure,
-}
-
-/// Sanitized classification classes for accepted-subset validation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CheckedClassification {
-    /// Parsed term is inside the minimal accepted local-user subset.
-    AcceptedSubset,
-    /// Parsed term uses host, path, network, process, FFI, or terminal surfaces.
-    BoundaryDenied,
-    /// Parsed term is valid Prolog but outside the minimal local-user subset.
-    UnsupportedSubset,
 }
 
 impl LeafAnswer {
@@ -563,43 +552,6 @@ impl Iterator for QueryState<'_> {
 }
 
 impl Machine {
-    /// Parses and classifies a program term without exposing parsed source.
-    pub fn classify_program_term_checked(
-        &mut self,
-        program: impl Into<String>,
-    ) -> Result<CheckedClassification, CheckedFacadeStatus> {
-        let term = self.parse_term_for_checked_classification(
-            program,
-            CheckedFacadeStatus::MalformedProgram,
-        )?;
-        Ok(classify_program_term(&term))
-    }
-
-    /// Parses and classifies a query term without exposing parsed source.
-    pub fn classify_query_term_checked(
-        &mut self,
-        query: impl Into<String>,
-    ) -> Result<CheckedClassification, CheckedFacadeStatus> {
-        let term =
-            self.parse_term_for_checked_classification(query, CheckedFacadeStatus::MalformedQuery)?;
-        Ok(classify_query_term(&term))
-    }
-
-    fn parse_term_for_checked_classification(
-        &mut self,
-        input: impl Into<String>,
-        parse_error: CheckedFacadeStatus,
-    ) -> Result<ParsedTerm, CheckedFacadeStatus> {
-        let mut parser = Parser::new(
-            Stream::from_owned_string(input.into(), &mut self.machine_st.arena),
-            &mut self.machine_st,
-        );
-        let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
-        parser
-            .read_term(&op_dir, Tokens::Default)
-            .map_err(|_| parse_error)
-    }
-
     /// Parses a query and returns only a sanitized checked-facade status.
     pub fn parse_query_checked(
         &mut self,
@@ -622,6 +574,27 @@ impl Machine {
         module_name: &str,
         program: impl Into<String>,
     ) -> Result<CheckedFacadeStatus, CheckedFacadeStatus> {
+        let program = program.into();
+        let mut parser = Parser::new(
+            Stream::from_owned_string(program.clone(), &mut self.machine_st.arena),
+            &mut self.machine_st,
+        );
+        let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
+
+        loop {
+            parser.reset();
+
+            if devour_whitespace(&mut parser.lexer)
+                .map_err(|_| CheckedFacadeStatus::MalformedProgram)?
+            {
+                break;
+            }
+
+            parser
+                .read_term(&op_dir, Tokens::Default)
+                .map_err(|_| CheckedFacadeStatus::MalformedProgram)?;
+        }
+
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             self.load_module_string(module_name, program);
         }));
@@ -793,144 +766,6 @@ impl Machine {
             called: false,
         }
     }
-}
-
-fn classify_program_term(term: &ParsedTerm) -> CheckedClassification {
-    match term {
-        ParsedTerm::Clause(_, name, terms) if &*name.as_str() == ":-" && terms.len() == 2 => {
-            merge_classifications([
-                classify_predicate_head(&terms[0]),
-                classify_body_or_query(&terms[1]),
-            ])
-        }
-        ParsedTerm::Clause(_, name, terms) if &*name.as_str() == ":-" && terms.len() == 1 => {
-            CheckedClassification::UnsupportedSubset
-        }
-        _ => classify_predicate_head(term),
-    }
-}
-
-fn classify_query_term(term: &ParsedTerm) -> CheckedClassification {
-    classify_body_or_query(term)
-}
-
-fn classify_predicate_head(term: &ParsedTerm) -> CheckedClassification {
-    match term {
-        ParsedTerm::Clause(_, name, terms) => classify_callable_name(&*name.as_str())
-            .unwrap_or_else(|| merge_classifications(terms.iter().map(classify_argument))),
-        ParsedTerm::Literal(_, ParsedLiteral::Atom(name)) => {
-            classify_callable_name(&*name.as_str()).unwrap_or(CheckedClassification::AcceptedSubset)
-        }
-        ParsedTerm::Var(..) | ParsedTerm::AnonVar | ParsedTerm::Literal(..) => {
-            CheckedClassification::AcceptedSubset
-        }
-        ParsedTerm::Cons(..) | ParsedTerm::PartialString(..) | ParsedTerm::CompleteString(..) => {
-            CheckedClassification::UnsupportedSubset
-        }
-    }
-}
-
-fn classify_body_or_query(term: &ParsedTerm) -> CheckedClassification {
-    match term {
-        ParsedTerm::Clause(_, name, terms) if &*name.as_str() == "," => {
-            merge_classifications(terms.iter().map(classify_body_or_query))
-        }
-        ParsedTerm::Clause(_, name, terms) => classify_callable_name(&*name.as_str())
-            .unwrap_or_else(|| merge_classifications(terms.iter().map(classify_argument))),
-        ParsedTerm::Literal(_, ParsedLiteral::Atom(name)) => {
-            classify_callable_name(&*name.as_str()).unwrap_or(CheckedClassification::AcceptedSubset)
-        }
-        ParsedTerm::Var(..) | ParsedTerm::AnonVar | ParsedTerm::Literal(..) => {
-            CheckedClassification::AcceptedSubset
-        }
-        ParsedTerm::Cons(..) | ParsedTerm::PartialString(..) | ParsedTerm::CompleteString(..) => {
-            CheckedClassification::UnsupportedSubset
-        }
-    }
-}
-
-fn classify_argument(term: &ParsedTerm) -> CheckedClassification {
-    match term {
-        ParsedTerm::Literal(..) | ParsedTerm::Var(..) | ParsedTerm::AnonVar => {
-            CheckedClassification::AcceptedSubset
-        }
-        ParsedTerm::Clause(_, name, terms) => classify_callable_name(&*name.as_str())
-            .unwrap_or_else(|| merge_classifications(terms.iter().map(classify_argument))),
-        ParsedTerm::Cons(..) | ParsedTerm::PartialString(..) | ParsedTerm::CompleteString(..) => {
-            CheckedClassification::UnsupportedSubset
-        }
-    }
-}
-
-fn classify_callable_name(name: &str) -> Option<CheckedClassification> {
-    if matches!(
-        name,
-        "open"
-            | "absolute_file_name"
-            | "consult"
-            | "load_files"
-            | "use_module"
-            | "shell"
-            | "process_create"
-            | "http_get"
-            | "http_post"
-            | "socket"
-            | "tcp_connect"
-            | "load_foreign_library"
-            | "foreign"
-            | "getenv"
-            | "setenv"
-            | "current_prolog_flag"
-    ) {
-        return Some(CheckedClassification::BoundaryDenied);
-    }
-
-    if matches!(
-        name,
-        "assert"
-            | "asserta"
-            | "assertz"
-            | "retract"
-            | "abolish"
-            | "clause"
-            | "dynamic"
-            | "current_predicate"
-            | "call"
-            | "findall"
-            | "bagof"
-            | "setof"
-            | "listing"
-            | ";"
-            | "!"
-            | "\\+"
-            | "not"
-            | "is"
-            | "->"
-            | "-->"
-            | "{}"
-    ) {
-        return Some(CheckedClassification::UnsupportedSubset);
-    }
-
-    None
-}
-
-fn merge_classifications(
-    classifications: impl IntoIterator<Item = CheckedClassification>,
-) -> CheckedClassification {
-    let mut merged = CheckedClassification::AcceptedSubset;
-
-    for classification in classifications {
-        match classification {
-            CheckedClassification::BoundaryDenied => return CheckedClassification::BoundaryDenied,
-            CheckedClassification::UnsupportedSubset => {
-                merged = CheckedClassification::UnsupportedSubset;
-            }
-            CheckedClassification::AcceptedSubset => {}
-        }
-    }
-
-    merged
 }
 
 #[test]

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -4,8 +4,9 @@ use std::process::ExitCode;
 use std::rc::Rc;
 
 use crate::atom_table;
-use crate::heap_iter::{NonListElider, stackful_post_order_iter};
-use crate::machine::heap::AllocError;
+use crate::heap_iter::{stackful_post_order_iter, NonListElider};
+pub use crate::machine::heap::AllocError;
+use crate::machine::machine_errors::CompilationError;
 use crate::machine::machine_indices::VarKey;
 use crate::machine::mock_wam::CompositeOpDir;
 use crate::machine::{
@@ -59,6 +60,28 @@ impl LeafAnswer {
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct LoadModuleError;
+
+/// A checked query could not be prepared for execution.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum RunQueryError {
+    /// The query string could not be parsed.
+    Parser(ParserError),
+    /// The machine could not allocate memory while preparing the query.
+    Allocation(AllocError),
+}
+
+impl From<ParserError> for RunQueryError {
+    fn from(err: ParserError) -> Self {
+        Self::Parser(err)
+    }
+}
+
+impl From<AllocError> for RunQueryError {
+    fn from(err: AllocError) -> Self {
+        Self::Allocation(err)
+    }
+}
 
 /// Represents a Prolog term.
 #[non_exhaustive]
@@ -622,15 +645,19 @@ impl Machine {
     pub fn run_query_checked(
         &mut self,
         query: impl Into<String>,
-    ) -> Result<QueryState<'_>, ParserError> {
+    ) -> Result<QueryState<'_>, RunQueryError> {
         let term = self.parse_query_term(query)?;
 
-        self.allocate_stub_choice_point()
-            .expect("failed to allocate stub choice point");
+        self.allocate_stub_choice_point()?;
 
         // Write parsed term to heap
-        let term_write_result = write_term_to_heap(&term, &mut self.machine_st.heap)
-            .expect("couldn't write term to heap");
+        let term_write_result = match write_term_to_heap(&term, &mut self.machine_st.heap) {
+            Ok(result) => result,
+            Err(CompilationError::FiniteMemoryInHeap(err)) => {
+                return Err(RunQueryError::Allocation(err));
+            }
+            Err(err) => panic!("couldn't write term to heap: {err:?}"),
+        };
 
         let var_names: IndexMap<_, _> = term_write_result
             .var_dict
@@ -676,8 +703,11 @@ impl Machine {
 
     /// Runs a query.
     pub fn run_query(&mut self, query: impl Into<String>) -> QueryState<'_> {
-        self.run_query_checked(query)
-            .expect("Failed to parse query")
+        match self.run_query_checked(query) {
+            Ok(query_state) => query_state,
+            Err(RunQueryError::Parser(_)) => panic!("Failed to parse query"),
+            Err(RunQueryError::Allocation(_)) => panic!("Failed to allocate query state"),
+        }
     }
 }
 

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 use std::rc::Rc;
 
 use crate::atom_table;
-use crate::heap_iter::{stackful_post_order_iter, NonListElider};
+use crate::heap_iter::{NonListElider, stackful_post_order_iter};
 pub use crate::machine::heap::AllocError;
 use crate::machine::machine_errors::CompilationError;
 use crate::machine::machine_indices::VarKey;
@@ -16,7 +16,7 @@ use crate::offset_table::*;
 pub use crate::parser::ast::ParserError;
 use crate::parser::ast::{Term as ASTTerm, Var, VarPtr};
 use crate::parser::parser::{Parser, Tokens};
-use crate::read::{write_term_to_heap, TermWriteResult};
+use crate::read::{TermWriteResult, write_term_to_heap};
 use crate::types::UntypedArenaPtr;
 
 use dashu::{Integer, Rational};

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
+use std::process::ExitCode;
 use std::rc::Rc;
 
 use crate::atom_table;
@@ -11,9 +12,9 @@ use crate::machine::{
     ArenaHeaderTag, BREAK_FROM_DISPATCH_LOOP_LOC, Fixnum, LIB_QUERY_SUCCESS, Number,
 };
 use crate::offset_table::*;
-use crate::parser::ast::{Var, VarPtr};
+use crate::parser::ast::{ParserErrorKind, Var, VarPtr};
 use crate::parser::parser::{Parser, Tokens};
-use crate::read::{devour_whitespace, write_term_to_heap, TermWriteResult};
+use crate::read::{write_term_to_heap, TermWriteResult};
 use crate::types::UntypedArenaPtr;
 
 use dashu::{Integer, Rational};
@@ -581,27 +582,22 @@ impl Machine {
         );
         let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
 
-        loop {
-            parser.reset();
-
-            if devour_whitespace(&mut parser.lexer)
-                .map_err(|_| CheckedFacadeStatus::MalformedProgram)?
-            {
-                break;
+        if let Err(err) = parser.read_term(&op_dir, Tokens::Default) {
+            if err.is_unexpected_eof() || matches!(err.kind, ParserErrorKind::IncompleteReduction) {
+                return Err(CheckedFacadeStatus::MalformedProgram);
             }
-
-            parser
-                .read_term(&op_dir, Tokens::Default)
-                .map_err(|_| CheckedFacadeStatus::MalformedProgram)?;
         }
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            self.load_module_string(module_name, program);
-        }));
+        self.machine_st.registers[1] =
+            Stream::from_owned_string(program, &mut self.machine_st.arena).into();
+        self.machine_st.registers[2] = atom_as_cell!(atom_table::AtomTable::build_with(
+            &self.machine_st.atom_tbl,
+            module_name
+        ));
 
-        match result {
-            Ok(()) => Ok(CheckedFacadeStatus::ProgramLoaded),
-            Err(_) => Err(CheckedFacadeStatus::MalformedProgram),
+        match self.run_module_predicate(atom!("loader"), (atom!("file_load"), 2)) {
+            ExitCode::SUCCESS => Ok(CheckedFacadeStatus::ProgramLoaded),
+            _ => Err(CheckedFacadeStatus::MalformedProgram),
         }
     }
 
@@ -665,8 +661,8 @@ impl Machine {
 
     /// Loads a module into the [`Machine`] from a string.
     pub fn load_module_string(&mut self, module_name: &str, program: impl Into<String>) {
-        let stream = Stream::from_owned_string(program.into(), &mut self.machine_st.arena);
-        self.load_file(module_name, stream);
+        self.load_module_string_checked(module_name, program)
+            .expect("Failed to load module string");
     }
 
     /// Consults a module into the [`Machine`] from a string.
@@ -709,61 +705,11 @@ impl Machine {
 
     /// Runs a query.
     pub fn run_query(&mut self, query: impl Into<String>) -> QueryState<'_> {
-        let mut parser = Parser::new(
-            Stream::from_owned_string(query.into(), &mut self.machine_st.arena),
-            &mut self.machine_st,
-        );
-        let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
-        let term = parser
-            .read_term(&op_dir, Tokens::Default)
-            .expect("Failed to parse query");
-
-        self.allocate_stub_choice_point()
-            .expect("failed to allocate stub choice point");
-
-        // Write parsed term to heap
-        let term_write_result = write_term_to_heap(&term, &mut self.machine_st.heap)
-            .expect("couldn't write term to heap");
-
-        let var_names: IndexMap<_, _> = term_write_result
-            .var_dict
-            .iter()
-            .map(|(var_key, cell)| match var_key {
-                // NOTE: not the intention behind Var::InSitu here but
-                // we can hijack it to store anonymous variables
-                // without creating problems.
-                VarKey::AnonVar(h) => (*cell, VarPtr::from(Var::InSitu(*h))),
-                VarKey::VarPtr(var_ptr) => (*cell, var_ptr.clone()),
-            })
-            .collect();
-
-        // Write term to heap
-        self.machine_st.registers[1] = self.machine_st.heap[term_write_result.heap_loc];
-
-        self.machine_st.cp = LIB_QUERY_SUCCESS; // BREAK_FROM_DISPATCH_LOOP_LOC;
-        let call_index_p = self
-            .indices
-            .code_dir
-            .get(&(atom!("call"), 1))
-            .cloned()
-            .map(|offset| {
-                self.machine_st
-                    .arena
-                    .code_index_tbl
-                    .get_entry(offset.into())
-                    .p() as usize
-            })
-            .expect("couldn't get code index");
-
-        self.machine_st.execute_at_index(1, call_index_p);
-
-        let stub_b = self.machine_st.b;
-        QueryState {
-            machine: self,
-            term: term_write_result,
-            stub_b,
-            var_names,
-            called: false,
+        match self.run_query_checked(query) {
+            Ok(query_state) => query_state,
+            Err(CheckedFacadeStatus::MalformedQuery) => panic!("Failed to parse query"),
+            Err(CheckedFacadeStatus::InternalFailure) => panic!("Failed to run query"),
+            Err(status) => panic!("Unexpected checked query status: {status:?}"),
         }
     }
 }

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -12,7 +12,8 @@ use crate::machine::{
     ArenaHeaderTag, BREAK_FROM_DISPATCH_LOOP_LOC, Fixnum, LIB_QUERY_SUCCESS, Number,
 };
 use crate::offset_table::*;
-use crate::parser::ast::{ParserErrorKind, Var, VarPtr};
+pub use crate::parser::ast::ParserError;
+use crate::parser::ast::{Term as ASTTerm, Var, VarPtr};
 use crate::parser::parser::{Parser, Tokens};
 use crate::read::{write_term_to_heap, TermWriteResult};
 use crate::types::UntypedArenaPtr;
@@ -45,21 +46,6 @@ pub enum LeafAnswer {
     },
 }
 
-/// Sanitized status classes for an embeddable checked facade.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CheckedFacadeStatus {
-    /// A program string was accepted by the checked facade.
-    ProgramLoaded,
-    /// A query string parsed without entering the execution path.
-    QueryParsed,
-    /// Program parsing or loading failed before a usable module was available.
-    MalformedProgram,
-    /// Query parsing failed before execution.
-    MalformedQuery,
-    /// Execution or machine setup failed without exposing backend details.
-    InternalFailure,
-}
-
 impl LeafAnswer {
     /// Creates a leaf answer with no residual goals.
     pub fn from_bindings<S: Into<String>>(bindings: impl IntoIterator<Item = (S, Term)>) -> Self {
@@ -68,6 +54,11 @@ impl LeafAnswer {
         }
     }
 }
+
+/// A module failed to load from an in-memory program string.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct LoadModuleError;
 
 /// Represents a Prolog term.
 #[non_exhaustive]
@@ -553,116 +544,40 @@ impl Iterator for QueryState<'_> {
 }
 
 impl Machine {
-    /// Parses a query and returns only a sanitized checked-facade status.
-    pub fn parse_query_checked(
-        &mut self,
-        query: impl Into<String>,
-    ) -> Result<CheckedFacadeStatus, CheckedFacadeStatus> {
+    fn parse_query_term(&mut self, query: impl Into<String>) -> Result<ASTTerm, ParserError> {
         let mut parser = Parser::new(
             Stream::from_owned_string(query.into(), &mut self.machine_st.arena),
             &mut self.machine_st,
         );
         let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
-        parser
-            .read_term(&op_dir, Tokens::Default)
-            .map(|_| CheckedFacadeStatus::QueryParsed)
-            .map_err(|_| CheckedFacadeStatus::MalformedQuery)
+        parser.read_term(&op_dir, Tokens::Default)
     }
 
-    /// Loads a module from a string while returning only sanitized status.
+    /// Parses a query string without entering the execution path.
+    pub fn parse_query_checked(&mut self, query: impl Into<String>) -> Result<(), ParserError> {
+        self.parse_query_term(query).map(|_| ())
+    }
+
+    /// Loads a module from a string without panicking on loader failure.
     pub fn load_module_string_checked(
         &mut self,
         module_name: &str,
         program: impl Into<String>,
-    ) -> Result<CheckedFacadeStatus, CheckedFacadeStatus> {
-        let program = program.into();
-        let mut parser = Parser::new(
-            Stream::from_owned_string(program.clone(), &mut self.machine_st.arena),
-            &mut self.machine_st,
-        );
-        let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
-
-        if let Err(err) = parser.read_term(&op_dir, Tokens::Default) {
-            if err.is_unexpected_eof() || matches!(err.kind, ParserErrorKind::IncompleteReduction) {
-                return Err(CheckedFacadeStatus::MalformedProgram);
-            }
+    ) -> Result<(), LoadModuleError> {
+        let stream = Stream::from_owned_string(program.into(), &mut self.machine_st.arena);
+        match self.load_file(module_name, stream) {
+            ExitCode::SUCCESS => Ok(()),
+            _ => Err(LoadModuleError),
         }
-
-        self.machine_st.registers[1] =
-            Stream::from_owned_string(program, &mut self.machine_st.arena).into();
-        self.machine_st.registers[2] = atom_as_cell!(atom_table::AtomTable::build_with(
-            &self.machine_st.atom_tbl,
-            module_name
-        ));
-
-        match self.run_module_predicate(atom!("loader"), (atom!("file_load"), 2)) {
-            ExitCode::SUCCESS => Ok(CheckedFacadeStatus::ProgramLoaded),
-            _ => Err(CheckedFacadeStatus::MalformedProgram),
-        }
-    }
-
-    /// Runs a query without relying on the legacy parse-failure panic path.
-    pub fn run_query_checked(
-        &mut self,
-        query: impl Into<String>,
-    ) -> Result<QueryState<'_>, CheckedFacadeStatus> {
-        let mut parser = Parser::new(
-            Stream::from_owned_string(query.into(), &mut self.machine_st.arena),
-            &mut self.machine_st,
-        );
-        let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
-        let term = parser
-            .read_term(&op_dir, Tokens::Default)
-            .map_err(|_| CheckedFacadeStatus::MalformedQuery)?;
-
-        self.allocate_stub_choice_point()
-            .map_err(|_| CheckedFacadeStatus::InternalFailure)?;
-
-        let term_write_result = write_term_to_heap(&term, &mut self.machine_st.heap)
-            .map_err(|_| CheckedFacadeStatus::InternalFailure)?;
-
-        let var_names: IndexMap<_, _> = term_write_result
-            .var_dict
-            .iter()
-            .map(|(var_key, cell)| match var_key {
-                VarKey::AnonVar(h) => (*cell, VarPtr::from(Var::InSitu(*h))),
-                VarKey::VarPtr(var_ptr) => (*cell, var_ptr.clone()),
-            })
-            .collect();
-
-        self.machine_st.registers[1] = self.machine_st.heap[term_write_result.heap_loc];
-
-        self.machine_st.cp = LIB_QUERY_SUCCESS;
-        let call_index_p = self
-            .indices
-            .code_dir
-            .get(&(atom!("call"), 1))
-            .cloned()
-            .map(|offset| {
-                self.machine_st
-                    .arena
-                    .code_index_tbl
-                    .get_entry(offset.into())
-                    .p() as usize
-            })
-            .ok_or(CheckedFacadeStatus::InternalFailure)?;
-
-        self.machine_st.execute_at_index(1, call_index_p);
-
-        let stub_b = self.machine_st.b;
-        Ok(QueryState {
-            machine: self,
-            term: term_write_result,
-            stub_b,
-            var_names,
-            called: false,
-        })
     }
 
     /// Loads a module into the [`Machine`] from a string.
     pub fn load_module_string(&mut self, module_name: &str, program: impl Into<String>) {
-        self.load_module_string_checked(module_name, program)
-            .expect("Failed to load module string");
+        let stream = Stream::from_owned_string(program.into(), &mut self.machine_st.arena);
+        match self.load_file(module_name, stream) {
+            ExitCode::SUCCESS => {}
+            _ => panic!("Failed to load module string"),
+        }
     }
 
     /// Consults a module into the [`Machine`] from a string.
@@ -703,14 +618,66 @@ impl Machine {
         Ok(())
     }
 
+    /// Runs a query without panicking on parse failure.
+    pub fn run_query_checked(
+        &mut self,
+        query: impl Into<String>,
+    ) -> Result<QueryState<'_>, ParserError> {
+        let term = self.parse_query_term(query)?;
+
+        self.allocate_stub_choice_point()
+            .expect("failed to allocate stub choice point");
+
+        // Write parsed term to heap
+        let term_write_result = write_term_to_heap(&term, &mut self.machine_st.heap)
+            .expect("couldn't write term to heap");
+
+        let var_names: IndexMap<_, _> = term_write_result
+            .var_dict
+            .iter()
+            .map(|(var_key, cell)| match var_key {
+                // NOTE: not the intention behind Var::InSitu here but
+                // we can hijack it to store anonymous variables
+                // without creating problems.
+                VarKey::AnonVar(h) => (*cell, VarPtr::from(Var::InSitu(*h))),
+                VarKey::VarPtr(var_ptr) => (*cell, var_ptr.clone()),
+            })
+            .collect();
+
+        // Write term to heap
+        self.machine_st.registers[1] = self.machine_st.heap[term_write_result.heap_loc];
+
+        self.machine_st.cp = LIB_QUERY_SUCCESS; // BREAK_FROM_DISPATCH_LOOP_LOC;
+        let call_index_p = self
+            .indices
+            .code_dir
+            .get(&(atom!("call"), 1))
+            .cloned()
+            .map(|offset| {
+                self.machine_st
+                    .arena
+                    .code_index_tbl
+                    .get_entry(offset.into())
+                    .p() as usize
+            })
+            .expect("couldn't get code index");
+
+        self.machine_st.execute_at_index(1, call_index_p);
+
+        let stub_b = self.machine_st.b;
+        Ok(QueryState {
+            machine: self,
+            term: term_write_result,
+            stub_b,
+            var_names,
+            called: false,
+        })
+    }
+
     /// Runs a query.
     pub fn run_query(&mut self, query: impl Into<String>) -> QueryState<'_> {
-        match self.run_query_checked(query) {
-            Ok(query_state) => query_state,
-            Err(CheckedFacadeStatus::MalformedQuery) => panic!("Failed to parse query"),
-            Err(CheckedFacadeStatus::InternalFailure) => panic!("Failed to run query"),
-            Err(status) => panic!("Unexpected checked query status: {status:?}"),
-        }
+        self.run_query_checked(query)
+            .expect("Failed to parse query")
     }
 }
 

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -11,7 +11,7 @@ use crate::machine::{
     ArenaHeaderTag, BREAK_FROM_DISPATCH_LOOP_LOC, Fixnum, LIB_QUERY_SUCCESS, Number,
 };
 use crate::offset_table::*;
-use crate::parser::ast::{Var, VarPtr};
+use crate::parser::ast::{Literal as ParsedLiteral, Term as ParsedTerm, Var, VarPtr};
 use crate::parser::parser::{Parser, Tokens};
 use crate::read::{TermWriteResult, write_term_to_heap};
 use crate::types::UntypedArenaPtr;
@@ -42,6 +42,32 @@ pub enum LeafAnswer {
         bindings: BTreeMap<String, Term>,
         //residual_goals: Vec<Term>,
     },
+}
+
+/// Sanitized status classes for an embeddable checked facade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckedFacadeStatus {
+    /// A program string was accepted by the checked facade.
+    ProgramLoaded,
+    /// A query string parsed without entering the execution path.
+    QueryParsed,
+    /// Program parsing or loading failed before a usable module was available.
+    MalformedProgram,
+    /// Query parsing failed before execution.
+    MalformedQuery,
+    /// Execution or machine setup failed without exposing backend details.
+    InternalFailure,
+}
+
+/// Sanitized classification classes for accepted-subset validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckedClassification {
+    /// Parsed term is inside the minimal accepted local-user subset.
+    AcceptedSubset,
+    /// Parsed term uses host, path, network, process, FFI, or terminal surfaces.
+    BoundaryDenied,
+    /// Parsed term is valid Prolog but outside the minimal local-user subset.
+    UnsupportedSubset,
 }
 
 impl LeafAnswer {
@@ -537,6 +563,133 @@ impl Iterator for QueryState<'_> {
 }
 
 impl Machine {
+    /// Parses and classifies a program term without exposing parsed source.
+    pub fn classify_program_term_checked(
+        &mut self,
+        program: impl Into<String>,
+    ) -> Result<CheckedClassification, CheckedFacadeStatus> {
+        let term = self.parse_term_for_checked_classification(
+            program,
+            CheckedFacadeStatus::MalformedProgram,
+        )?;
+        Ok(classify_program_term(&term))
+    }
+
+    /// Parses and classifies a query term without exposing parsed source.
+    pub fn classify_query_term_checked(
+        &mut self,
+        query: impl Into<String>,
+    ) -> Result<CheckedClassification, CheckedFacadeStatus> {
+        let term =
+            self.parse_term_for_checked_classification(query, CheckedFacadeStatus::MalformedQuery)?;
+        Ok(classify_query_term(&term))
+    }
+
+    fn parse_term_for_checked_classification(
+        &mut self,
+        input: impl Into<String>,
+        parse_error: CheckedFacadeStatus,
+    ) -> Result<ParsedTerm, CheckedFacadeStatus> {
+        let mut parser = Parser::new(
+            Stream::from_owned_string(input.into(), &mut self.machine_st.arena),
+            &mut self.machine_st,
+        );
+        let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
+        parser
+            .read_term(&op_dir, Tokens::Default)
+            .map_err(|_| parse_error)
+    }
+
+    /// Parses a query and returns only a sanitized checked-facade status.
+    pub fn parse_query_checked(
+        &mut self,
+        query: impl Into<String>,
+    ) -> Result<CheckedFacadeStatus, CheckedFacadeStatus> {
+        let mut parser = Parser::new(
+            Stream::from_owned_string(query.into(), &mut self.machine_st.arena),
+            &mut self.machine_st,
+        );
+        let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
+        parser
+            .read_term(&op_dir, Tokens::Default)
+            .map(|_| CheckedFacadeStatus::QueryParsed)
+            .map_err(|_| CheckedFacadeStatus::MalformedQuery)
+    }
+
+    /// Loads a module from a string while returning only sanitized status.
+    pub fn load_module_string_checked(
+        &mut self,
+        module_name: &str,
+        program: impl Into<String>,
+    ) -> Result<CheckedFacadeStatus, CheckedFacadeStatus> {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.load_module_string(module_name, program);
+        }));
+
+        match result {
+            Ok(()) => Ok(CheckedFacadeStatus::ProgramLoaded),
+            Err(_) => Err(CheckedFacadeStatus::MalformedProgram),
+        }
+    }
+
+    /// Runs a query without relying on the legacy parse-failure panic path.
+    pub fn run_query_checked(
+        &mut self,
+        query: impl Into<String>,
+    ) -> Result<QueryState<'_>, CheckedFacadeStatus> {
+        let mut parser = Parser::new(
+            Stream::from_owned_string(query.into(), &mut self.machine_st.arena),
+            &mut self.machine_st,
+        );
+        let op_dir = CompositeOpDir::new(&self.indices.op_dir, None);
+        let term = parser
+            .read_term(&op_dir, Tokens::Default)
+            .map_err(|_| CheckedFacadeStatus::MalformedQuery)?;
+
+        self.allocate_stub_choice_point()
+            .map_err(|_| CheckedFacadeStatus::InternalFailure)?;
+
+        let term_write_result = write_term_to_heap(&term, &mut self.machine_st.heap)
+            .map_err(|_| CheckedFacadeStatus::InternalFailure)?;
+
+        let var_names: IndexMap<_, _> = term_write_result
+            .var_dict
+            .iter()
+            .map(|(var_key, cell)| match var_key {
+                VarKey::AnonVar(h) => (*cell, VarPtr::from(Var::InSitu(*h))),
+                VarKey::VarPtr(var_ptr) => (*cell, var_ptr.clone()),
+            })
+            .collect();
+
+        self.machine_st.registers[1] = self.machine_st.heap[term_write_result.heap_loc];
+
+        self.machine_st.cp = LIB_QUERY_SUCCESS;
+        let call_index_p = self
+            .indices
+            .code_dir
+            .get(&(atom!("call"), 1))
+            .cloned()
+            .map(|offset| {
+                self.machine_st
+                    .arena
+                    .code_index_tbl
+                    .get_entry(offset.into())
+                    .p() as usize
+            })
+            .ok_or(CheckedFacadeStatus::InternalFailure)?;
+
+        self.machine_st.execute_at_index(1, call_index_p);
+
+        let stub_b = self.machine_st.b;
+        Ok(QueryState {
+            machine: self,
+            term: term_write_result,
+            stub_b,
+            var_names,
+            called: false,
+        })
+    }
+
     /// Loads a module into the [`Machine`] from a string.
     pub fn load_module_string(&mut self, module_name: &str, program: impl Into<String>) {
         let stream = Stream::from_owned_string(program.into(), &mut self.machine_st.arena);
@@ -640,6 +793,144 @@ impl Machine {
             called: false,
         }
     }
+}
+
+fn classify_program_term(term: &ParsedTerm) -> CheckedClassification {
+    match term {
+        ParsedTerm::Clause(_, name, terms) if &*name.as_str() == ":-" && terms.len() == 2 => {
+            merge_classifications([
+                classify_predicate_head(&terms[0]),
+                classify_body_or_query(&terms[1]),
+            ])
+        }
+        ParsedTerm::Clause(_, name, terms) if &*name.as_str() == ":-" && terms.len() == 1 => {
+            CheckedClassification::UnsupportedSubset
+        }
+        _ => classify_predicate_head(term),
+    }
+}
+
+fn classify_query_term(term: &ParsedTerm) -> CheckedClassification {
+    classify_body_or_query(term)
+}
+
+fn classify_predicate_head(term: &ParsedTerm) -> CheckedClassification {
+    match term {
+        ParsedTerm::Clause(_, name, terms) => classify_callable_name(&*name.as_str())
+            .unwrap_or_else(|| merge_classifications(terms.iter().map(classify_argument))),
+        ParsedTerm::Literal(_, ParsedLiteral::Atom(name)) => {
+            classify_callable_name(&*name.as_str()).unwrap_or(CheckedClassification::AcceptedSubset)
+        }
+        ParsedTerm::Var(..) | ParsedTerm::AnonVar | ParsedTerm::Literal(..) => {
+            CheckedClassification::AcceptedSubset
+        }
+        ParsedTerm::Cons(..) | ParsedTerm::PartialString(..) | ParsedTerm::CompleteString(..) => {
+            CheckedClassification::UnsupportedSubset
+        }
+    }
+}
+
+fn classify_body_or_query(term: &ParsedTerm) -> CheckedClassification {
+    match term {
+        ParsedTerm::Clause(_, name, terms) if &*name.as_str() == "," => {
+            merge_classifications(terms.iter().map(classify_body_or_query))
+        }
+        ParsedTerm::Clause(_, name, terms) => classify_callable_name(&*name.as_str())
+            .unwrap_or_else(|| merge_classifications(terms.iter().map(classify_argument))),
+        ParsedTerm::Literal(_, ParsedLiteral::Atom(name)) => {
+            classify_callable_name(&*name.as_str()).unwrap_or(CheckedClassification::AcceptedSubset)
+        }
+        ParsedTerm::Var(..) | ParsedTerm::AnonVar | ParsedTerm::Literal(..) => {
+            CheckedClassification::AcceptedSubset
+        }
+        ParsedTerm::Cons(..) | ParsedTerm::PartialString(..) | ParsedTerm::CompleteString(..) => {
+            CheckedClassification::UnsupportedSubset
+        }
+    }
+}
+
+fn classify_argument(term: &ParsedTerm) -> CheckedClassification {
+    match term {
+        ParsedTerm::Literal(..) | ParsedTerm::Var(..) | ParsedTerm::AnonVar => {
+            CheckedClassification::AcceptedSubset
+        }
+        ParsedTerm::Clause(_, name, terms) => classify_callable_name(&*name.as_str())
+            .unwrap_or_else(|| merge_classifications(terms.iter().map(classify_argument))),
+        ParsedTerm::Cons(..) | ParsedTerm::PartialString(..) | ParsedTerm::CompleteString(..) => {
+            CheckedClassification::UnsupportedSubset
+        }
+    }
+}
+
+fn classify_callable_name(name: &str) -> Option<CheckedClassification> {
+    if matches!(
+        name,
+        "open"
+            | "absolute_file_name"
+            | "consult"
+            | "load_files"
+            | "use_module"
+            | "shell"
+            | "process_create"
+            | "http_get"
+            | "http_post"
+            | "socket"
+            | "tcp_connect"
+            | "load_foreign_library"
+            | "foreign"
+            | "getenv"
+            | "setenv"
+            | "current_prolog_flag"
+    ) {
+        return Some(CheckedClassification::BoundaryDenied);
+    }
+
+    if matches!(
+        name,
+        "assert"
+            | "asserta"
+            | "assertz"
+            | "retract"
+            | "abolish"
+            | "clause"
+            | "dynamic"
+            | "current_predicate"
+            | "call"
+            | "findall"
+            | "bagof"
+            | "setof"
+            | "listing"
+            | ";"
+            | "!"
+            | "\\+"
+            | "not"
+            | "is"
+            | "->"
+            | "-->"
+            | "{}"
+    ) {
+        return Some(CheckedClassification::UnsupportedSubset);
+    }
+
+    None
+}
+
+fn merge_classifications(
+    classifications: impl IntoIterator<Item = CheckedClassification>,
+) -> CheckedClassification {
+    let mut merged = CheckedClassification::AcceptedSubset;
+
+    for classification in classifications {
+        match classification {
+            CheckedClassification::BoundaryDenied => return CheckedClassification::BoundaryDenied,
+            CheckedClassification::UnsupportedSubset => {
+                merged = CheckedClassification::UnsupportedSubset;
+            }
+            CheckedClassification::AcceptedSubset => {}
+        }
+    }
+
+    merged
 }
 
 #[test]

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -157,6 +157,55 @@ fn checked_facade_loads_program_status_only() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+fn checked_facade_repeated_loads_keep_heap_and_atoms_stable() {
+    fn probe_atom_count(machine: &crate::Machine) -> usize {
+        // The atom table is process-global; count only this test's long
+        // dynamic atoms so parallel tests cannot perturb the assertion.
+        machine
+            .machine_st
+            .atom_tbl
+            .active_table()
+            .iter()
+            .filter(|atom| atom.as_str().starts_with("checked_loader_probe_"))
+            .count()
+    }
+
+    let mut machine = MachineBuilder::default().build();
+    let program = r#"
+        :- discontiguous(checked_loader_probe_predicate/2).
+        checked_loader_probe_predicate(
+            checked_loader_probe_subject,
+            checked_loader_probe_object).
+        "#;
+
+    machine
+        .load_module_string_checked("facts", program)
+        .expect("warm-up load should succeed");
+
+    let heap_len = machine.machine_st.heap.cell_len();
+    let atom_count = probe_atom_count(&machine);
+    assert!(atom_count > 0);
+
+    for _ in 0..100 {
+        machine
+            .load_module_string_checked("facts", program)
+            .expect("repeated load should succeed");
+        assert_eq!(machine.machine_st.heap.cell_len(), heap_len);
+        assert_eq!(probe_atom_count(&machine), atom_count);
+    }
+
+    let answers = machine
+        .run_query_checked(
+            "checked_loader_probe_predicate(checked_loader_probe_subject, checked_loader_probe_object).",
+        )
+        .expect("checked query should parse")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("checked query should execute");
+    assert_eq!(answers, [LeafAnswer::True]);
+}
+
+#[test]
 fn checked_facade_maps_loader_failure_without_panicking() {
     let mut machine = MachineBuilder::default().build();
     let status: Result<(), LoadModuleError> =

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -101,20 +101,21 @@ fn repeated_float_loads_keep_float_table_stable() {
 #[test]
 fn checked_facade_maps_malformed_query_without_panicking() {
     let mut machine = MachineBuilder::default().build();
-    let status = machine.parse_query_checked("parent(");
-    assert_eq!(status, Err(CheckedFacadeStatus::MalformedQuery));
+    let parse_status: Result<(), ParserError> = machine.parse_query_checked("parent(");
+    assert!(parse_status.is_err());
 
-    let status = machine.run_query_checked("parent(");
-    assert_eq!(status.err(), Some(CheckedFacadeStatus::MalformedQuery));
+    match machine.run_query_checked("parent(") {
+        Err(err) => {
+            let _: ParserError = err;
+        }
+        Ok(_) => panic!("malformed query should not run"),
+    };
 }
 
 #[test]
 fn checked_facade_runs_valid_query() {
     let mut machine = MachineBuilder::default().build();
-    assert_eq!(
-        machine.parse_query_checked("true."),
-        Ok(CheckedFacadeStatus::QueryParsed)
-    );
+    assert!(machine.parse_query_checked("true.").is_ok());
 
     let answers = machine
         .run_query_checked("true.")
@@ -127,24 +128,31 @@ fn checked_facade_runs_valid_query() {
 #[test]
 fn checked_facade_loads_program_status_only() {
     let mut machine = MachineBuilder::default().build();
-    let status = machine.load_module_string_checked("facts", "parent(alice, bob).");
-    assert_eq!(status, Ok(CheckedFacadeStatus::ProgramLoaded));
+    let status: Result<(), LoadModuleError> =
+        machine.load_module_string_checked("facts", "parent(alice, bob).");
+    assert!(status.is_ok());
+
+    let answers = machine
+        .run_query_checked("parent(alice, bob).")
+        .expect("checked query should parse")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("checked query should execute");
+    assert_eq!(answers, [LeafAnswer::True]);
 }
 
 #[test]
-fn checked_facade_maps_malformed_program_without_panicking() {
+fn checked_facade_maps_loader_failure_without_panicking() {
     let mut machine = MachineBuilder::default().build();
-    assert_eq!(
-        machine.load_module_string_checked("facts", "parent("),
-        Err(CheckedFacadeStatus::MalformedProgram)
-    );
+    let status: Result<(), LoadModuleError> =
+        machine.load_module_string_checked("facts", ":- throw(load_failed).");
+    assert!(status.is_err());
 }
 
 #[test]
 #[should_panic(expected = "Failed to load module string")]
-fn load_module_string_panics_on_malformed_program() {
+fn load_module_string_panics_on_loader_failure() {
     let mut machine = MachineBuilder::default().build();
-    machine.load_module_string("facts", "parent(");
+    machine.load_module_string("facts", ":- throw(load_failed).");
 }
 
 #[test]

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -141,6 +141,13 @@ fn checked_facade_maps_malformed_program_without_panicking() {
 }
 
 #[test]
+#[should_panic(expected = "Failed to load module string")]
+fn load_module_string_panics_on_malformed_program() {
+    let mut machine = MachineBuilder::default().build();
+    machine.load_module_string("facts", "parent(");
+}
+
+#[test]
 #[cfg_attr(miri, ignore = "it takes too long to run")]
 fn programmatic_query() {
     let mut machine = MachineBuilder::default().build();

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -105,9 +105,10 @@ fn checked_facade_maps_malformed_query_without_panicking() {
     assert!(parse_status.is_err());
 
     match machine.run_query_checked("parent(") {
-        Err(err) => {
+        Err(RunQueryError::Parser(err)) => {
             let _: ParserError = err;
         }
+        Err(RunQueryError::Allocation(_)) => panic!("malformed query should not allocate"),
         Ok(_) => panic!("malformed query should not run"),
     };
 }
@@ -123,6 +124,21 @@ fn checked_facade_runs_valid_query() {
         .collect::<Result<Vec<_>, _>>()
         .expect("checked query should execute");
     assert_eq!(answers, [LeafAnswer::True]);
+}
+
+#[test]
+fn checked_query_error_type_exposes_allocation_errors() {
+    fn assert_error_type<'a>(
+        result: Result<QueryState<'a>, RunQueryError>,
+    ) -> Result<QueryState<'a>, RunQueryError> {
+        result
+    }
+
+    let mut machine = MachineBuilder::default().build();
+    assert!(assert_error_type(machine.run_query_checked("true.")).is_ok());
+
+    let allocation_error = RunQueryError::Allocation(AllocError);
+    let _ = format!("{allocation_error:?}");
 }
 
 #[test]

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -99,6 +99,148 @@ fn repeated_float_loads_keep_float_table_stable() {
 }
 
 #[test]
+fn checked_facade_maps_malformed_query_without_panicking() {
+    let mut machine = MachineBuilder::default().build();
+    let status = machine.parse_query_checked("parent(");
+    assert_eq!(status, Err(CheckedFacadeStatus::MalformedQuery));
+
+    let status = machine.run_query_checked("parent(");
+    assert_eq!(status.err(), Some(CheckedFacadeStatus::MalformedQuery));
+}
+
+#[test]
+fn checked_facade_runs_valid_query() {
+    let mut machine = MachineBuilder::default().build();
+    assert_eq!(
+        machine.parse_query_checked("true."),
+        Ok(CheckedFacadeStatus::QueryParsed)
+    );
+
+    let answers = machine
+        .run_query_checked("true.")
+        .expect("checked query should parse")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("checked query should execute");
+    assert_eq!(answers, [LeafAnswer::True]);
+}
+
+#[test]
+fn checked_facade_loads_program_status_only() {
+    let mut machine = MachineBuilder::default().build();
+    let status = machine.load_module_string_checked("facts", "parent(alice, bob).");
+    assert_eq!(status, Ok(CheckedFacadeStatus::ProgramLoaded));
+}
+
+#[test]
+fn checked_facade_classification_uses_query_status_for_query_parse_errors() {
+    let mut machine = MachineBuilder::default().build();
+
+    assert_eq!(
+        machine.classify_query_term_checked("parent("),
+        Err(CheckedFacadeStatus::MalformedQuery)
+    );
+    assert_eq!(
+        machine.classify_program_term_checked("parent("),
+        Err(CheckedFacadeStatus::MalformedProgram)
+    );
+}
+
+#[test]
+fn checked_facade_classifies_accepted_subset_terms() {
+    let mut machine = MachineBuilder::default().build();
+
+    for program in [
+        "parent(alice, bob).",
+        "ancestor(X, Y) :- parent(X, Y).",
+        "ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y).",
+    ] {
+        assert_eq!(
+            machine.classify_program_term_checked(program),
+            Ok(CheckedClassification::AcceptedSubset),
+            "program should classify as accepted subset"
+        );
+    }
+
+    for query in ["true.", "parent(X, bob).", "parent(X, Y), ancestor(Y, Z)."] {
+        assert_eq!(
+            machine.classify_query_term_checked(query),
+            Ok(CheckedClassification::AcceptedSubset),
+            "query should classify as accepted subset"
+        );
+    }
+}
+
+#[test]
+fn checked_facade_classifies_boundary_denied_terms() {
+    let mut machine = MachineBuilder::default().build();
+
+    for query in [
+        "open(file, read, Stream).",
+        "absolute_file_name(foo, Path).",
+        "consult(file).",
+        "load_files(file).",
+        "use_module(library(lists)).",
+        "shell(cmd).",
+        "process_create(path, args, opts).",
+        "http_get(url, Body, Options).",
+        "http_post(url, Data, Reply, Options).",
+        "socket(Address).",
+        "tcp_connect(Host, Port).",
+        "load_foreign_library(lib).",
+        "foreign(symbol).",
+        "getenv(name, Value).",
+        "setenv(name, Value).",
+        "current_prolog_flag(hostname, Host).",
+    ] {
+        assert_eq!(
+            machine.classify_query_term_checked(query),
+            Ok(CheckedClassification::BoundaryDenied),
+            "query should classify as boundary denied"
+        );
+    }
+}
+
+#[test]
+fn checked_facade_classifies_unsupported_subset_terms() {
+    let mut machine = MachineBuilder::default().build();
+
+    for query in [
+        "assert(foo).",
+        "asserta(foo).",
+        "assertz(foo).",
+        "retract(foo).",
+        "abolish(foo, 1).",
+        "clause(foo, Body).",
+        "dynamic(foo/1).",
+        "current_predicate(foo/1).",
+        "call(foo).",
+        "findall(X, foo(X), Xs).",
+        "bagof(X, foo(X), Xs).",
+        "setof(X, foo(X), Xs).",
+        "listing(foo).",
+        "foo ; bar.",
+        "!.",
+        "\\+ foo.",
+        "not(foo).",
+        "X is 1 + 1.",
+        "foo -> bar.",
+        "member(X, [a]).",
+        "{tag: value}.",
+    ] {
+        assert_eq!(
+            machine.classify_query_term_checked(query),
+            Ok(CheckedClassification::UnsupportedSubset),
+            "query should classify as unsupported subset"
+        );
+    }
+
+    assert_eq!(
+        machine.classify_program_term_checked("phrase(foo, X) --> [a]."),
+        Ok(CheckedClassification::UnsupportedSubset)
+    );
+}
+
+#[test]
 #[cfg_attr(miri, ignore = "it takes too long to run")]
 fn programmatic_query() {
     let mut machine = MachineBuilder::default().build();

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -101,8 +101,8 @@ fn repeated_float_loads_keep_float_table_stable() {
 #[test]
 fn checked_facade_maps_malformed_query_without_panicking() {
     let mut machine = MachineBuilder::default().build();
-    let parse_status: Result<(), ParserError> = machine.parse_query_checked("parent(");
-    assert!(parse_status.is_err());
+    let validation_status: Result<(), ParserError> = machine.validate_query_term("parent(");
+    assert!(validation_status.is_err());
 
     match machine.run_query_checked("parent(") {
         Err(RunQueryError::Parser(err)) => {
@@ -116,7 +116,7 @@ fn checked_facade_maps_malformed_query_without_panicking() {
 #[test]
 fn checked_facade_runs_valid_query() {
     let mut machine = MachineBuilder::default().build();
-    assert!(machine.parse_query_checked("true.").is_ok());
+    assert!(machine.validate_query_term("true.").is_ok());
 
     let answers = machine
         .run_query_checked("true.")

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::arena::ArenaHeaderTag;
 use crate::MachineBuilder;
+use crate::arena::ArenaHeaderTag;
 
 const REPEATED_LOAD_PROBE_PROGRAM: &str = r#"
     :- discontiguous(repeated_loader_probe_predicate/2).
@@ -142,6 +142,10 @@ fn checked_query_error_type_exposes_allocation_errors() {
 }
 
 #[test]
+#[cfg_attr(
+    miri,
+    ignore = "loader setup accesses the filesystem under Miri isolation"
+)]
 fn checked_module_load_loads_program_status_only() {
     let mut machine = MachineBuilder::default().build();
     let status: Result<(), LoadModuleError> =
@@ -157,6 +161,10 @@ fn checked_module_load_loads_program_status_only() {
 }
 
 #[test]
+#[cfg_attr(
+    miri,
+    ignore = "loader setup accesses the filesystem under Miri isolation"
+)]
 fn checked_module_load_maps_loader_failure_without_panicking() {
     let mut machine = MachineBuilder::default().build();
     let status: Result<(), LoadModuleError> =
@@ -165,6 +173,10 @@ fn checked_module_load_maps_loader_failure_without_panicking() {
 }
 
 #[test]
+#[cfg_attr(
+    miri,
+    ignore = "loader setup accesses the filesystem under Miri isolation"
+)]
 #[should_panic(expected = "Failed to load module string")]
 fn load_module_string_panics_on_loader_failure() {
     let mut machine = MachineBuilder::default().build();

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -99,7 +99,7 @@ fn repeated_float_loads_keep_float_table_stable() {
 }
 
 #[test]
-fn checked_facade_maps_malformed_query_without_panicking() {
+fn checked_query_maps_malformed_query_without_panicking() {
     let mut machine = MachineBuilder::default().build();
     let validation_status: Result<(), ParserError> = machine.validate_query_term("parent(");
     assert!(validation_status.is_err());
@@ -114,7 +114,7 @@ fn checked_facade_maps_malformed_query_without_panicking() {
 }
 
 #[test]
-fn checked_facade_runs_valid_query() {
+fn checked_query_runs_valid_query() {
     let mut machine = MachineBuilder::default().build();
     assert!(machine.validate_query_term("true.").is_ok());
 
@@ -142,7 +142,7 @@ fn checked_query_error_type_exposes_allocation_errors() {
 }
 
 #[test]
-fn checked_facade_loads_program_status_only() {
+fn checked_module_load_loads_program_status_only() {
     let mut machine = MachineBuilder::default().build();
     let status: Result<(), LoadModuleError> =
         machine.load_module_string_checked("facts", "parent(alice, bob).");
@@ -157,7 +157,7 @@ fn checked_facade_loads_program_status_only() {
 }
 
 #[test]
-fn checked_facade_maps_loader_failure_without_panicking() {
+fn checked_module_load_maps_loader_failure_without_panicking() {
     let mut machine = MachineBuilder::default().build();
     let status: Result<(), LoadModuleError> =
         machine.load_module_string_checked("facts", ":- throw(load_failed).");

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -99,6 +99,10 @@ fn repeated_float_loads_keep_float_table_stable() {
 }
 
 #[test]
+#[cfg_attr(
+    miri,
+    ignore = "loader setup accesses the filesystem under Miri isolation"
+)]
 fn checked_query_maps_malformed_query_without_panicking() {
     let mut machine = MachineBuilder::default().build();
     let validation_status: Result<(), ParserError> = machine.validate_query_term("parent(");
@@ -114,6 +118,10 @@ fn checked_query_maps_malformed_query_without_panicking() {
 }
 
 #[test]
+#[cfg_attr(
+    miri,
+    ignore = "loader setup accesses the filesystem under Miri isolation"
+)]
 fn checked_query_runs_valid_query() {
     let mut machine = MachineBuilder::default().build();
     assert!(machine.validate_query_term("true.").is_ok());
@@ -128,15 +136,6 @@ fn checked_query_runs_valid_query() {
 
 #[test]
 fn checked_query_error_type_exposes_allocation_errors() {
-    fn assert_error_type<'a>(
-        result: Result<QueryState<'a>, RunQueryError>,
-    ) -> Result<QueryState<'a>, RunQueryError> {
-        result
-    }
-
-    let mut machine = MachineBuilder::default().build();
-    assert!(assert_error_type(machine.run_query_checked("true.")).is_ok());
-
     let allocation_error = RunQueryError::Allocation(AllocError);
     let _ = format!("{allocation_error:?}");
 }

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -157,55 +157,6 @@ fn checked_facade_loads_program_status_only() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore = "it takes too long to run")]
-fn checked_facade_repeated_loads_keep_heap_and_atoms_stable() {
-    fn probe_atom_count(machine: &crate::Machine) -> usize {
-        // The atom table is process-global; count only this test's long
-        // dynamic atoms so parallel tests cannot perturb the assertion.
-        machine
-            .machine_st
-            .atom_tbl
-            .active_table()
-            .iter()
-            .filter(|atom| atom.as_str().starts_with("checked_loader_probe_"))
-            .count()
-    }
-
-    let mut machine = MachineBuilder::default().build();
-    let program = r#"
-        :- discontiguous(checked_loader_probe_predicate/2).
-        checked_loader_probe_predicate(
-            checked_loader_probe_subject,
-            checked_loader_probe_object).
-        "#;
-
-    machine
-        .load_module_string_checked("facts", program)
-        .expect("warm-up load should succeed");
-
-    let heap_len = machine.machine_st.heap.cell_len();
-    let atom_count = probe_atom_count(&machine);
-    assert!(atom_count > 0);
-
-    for _ in 0..100 {
-        machine
-            .load_module_string_checked("facts", program)
-            .expect("repeated load should succeed");
-        assert_eq!(machine.machine_st.heap.cell_len(), heap_len);
-        assert_eq!(probe_atom_count(&machine), atom_count);
-    }
-
-    let answers = machine
-        .run_query_checked(
-            "checked_loader_probe_predicate(checked_loader_probe_subject, checked_loader_probe_object).",
-        )
-        .expect("checked query should parse")
-        .collect::<Result<Vec<_>, _>>()
-        .expect("checked query should execute");
-    assert_eq!(answers, [LeafAnswer::True]);
-}
-
-#[test]
 fn checked_facade_maps_loader_failure_without_panicking() {
     let mut machine = MachineBuilder::default().build();
     let status: Result<(), LoadModuleError> =

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -132,111 +132,11 @@ fn checked_facade_loads_program_status_only() {
 }
 
 #[test]
-fn checked_facade_classification_uses_query_status_for_query_parse_errors() {
+fn checked_facade_maps_malformed_program_without_panicking() {
     let mut machine = MachineBuilder::default().build();
-
     assert_eq!(
-        machine.classify_query_term_checked("parent("),
-        Err(CheckedFacadeStatus::MalformedQuery)
-    );
-    assert_eq!(
-        machine.classify_program_term_checked("parent("),
+        machine.load_module_string_checked("facts", "parent("),
         Err(CheckedFacadeStatus::MalformedProgram)
-    );
-}
-
-#[test]
-fn checked_facade_classifies_accepted_subset_terms() {
-    let mut machine = MachineBuilder::default().build();
-
-    for program in [
-        "parent(alice, bob).",
-        "ancestor(X, Y) :- parent(X, Y).",
-        "ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y).",
-    ] {
-        assert_eq!(
-            machine.classify_program_term_checked(program),
-            Ok(CheckedClassification::AcceptedSubset),
-            "program should classify as accepted subset"
-        );
-    }
-
-    for query in ["true.", "parent(X, bob).", "parent(X, Y), ancestor(Y, Z)."] {
-        assert_eq!(
-            machine.classify_query_term_checked(query),
-            Ok(CheckedClassification::AcceptedSubset),
-            "query should classify as accepted subset"
-        );
-    }
-}
-
-#[test]
-fn checked_facade_classifies_boundary_denied_terms() {
-    let mut machine = MachineBuilder::default().build();
-
-    for query in [
-        "open(file, read, Stream).",
-        "absolute_file_name(foo, Path).",
-        "consult(file).",
-        "load_files(file).",
-        "use_module(library(lists)).",
-        "shell(cmd).",
-        "process_create(path, args, opts).",
-        "http_get(url, Body, Options).",
-        "http_post(url, Data, Reply, Options).",
-        "socket(Address).",
-        "tcp_connect(Host, Port).",
-        "load_foreign_library(lib).",
-        "foreign(symbol).",
-        "getenv(name, Value).",
-        "setenv(name, Value).",
-        "current_prolog_flag(hostname, Host).",
-    ] {
-        assert_eq!(
-            machine.classify_query_term_checked(query),
-            Ok(CheckedClassification::BoundaryDenied),
-            "query should classify as boundary denied"
-        );
-    }
-}
-
-#[test]
-fn checked_facade_classifies_unsupported_subset_terms() {
-    let mut machine = MachineBuilder::default().build();
-
-    for query in [
-        "assert(foo).",
-        "asserta(foo).",
-        "assertz(foo).",
-        "retract(foo).",
-        "abolish(foo, 1).",
-        "clause(foo, Body).",
-        "dynamic(foo/1).",
-        "current_predicate(foo/1).",
-        "call(foo).",
-        "findall(X, foo(X), Xs).",
-        "bagof(X, foo(X), Xs).",
-        "setof(X, foo(X), Xs).",
-        "listing(foo).",
-        "foo ; bar.",
-        "!.",
-        "\\+ foo.",
-        "not(foo).",
-        "X is 1 + 1.",
-        "foo -> bar.",
-        "member(X, [a]).",
-        "{tag: value}.",
-    ] {
-        assert_eq!(
-            machine.classify_query_term_checked(query),
-            Ok(CheckedClassification::UnsupportedSubset),
-            "query should classify as unsupported subset"
-        );
-    }
-
-    assert_eq!(
-        machine.classify_program_term_checked("phrase(foo, X) --> [a]."),
-        Ok(CheckedClassification::UnsupportedSubset)
     );
 }
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -288,12 +288,21 @@ impl Machine {
         unreachable!();
     }
 
-    fn load_file(&mut self, path: &str, stream: Stream) {
+    fn load_file(&mut self, path: &str, stream: Stream) -> ExitCode {
         self.machine_st.registers[1] = stream.into();
         self.machine_st.registers[2] =
             atom_as_cell!(AtomTable::build_with(&self.machine_st.atom_tbl, path));
 
-        self.run_module_predicate(atom!("loader"), (atom!("file_load"), 2));
+        let exit_code = self.run_module_predicate(atom!("loader"), (atom!("file_load_checked"), 2));
+        let load_failed = !self.machine_st.ball.stub.is_empty();
+        self.machine_st.fail = false;
+
+        if load_failed {
+            self.machine_st.ball.reset();
+            ExitCode::FAILURE
+        } else {
+            exit_code
+        }
     }
 
     fn load_top_level(&mut self, program: Cow<'static, str>) {

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -235,7 +235,10 @@ impl Machine {
     }
 
     /// Runs the predicate `key` in `module_name` until completion.
-    /// Silently ignores failure, thrown errors and choice points.
+    ///
+    /// The returned `ExitCode` does not describe Prolog failure, thrown errors,
+    /// or choice points. Low-level callers that care about throw state must
+    /// inspect `machine_st` before clearing it.
     ///
     /// Consider using [`Machine::run_query`] if you wish to handle
     /// predicates that may fail, leave a choice point or throw.
@@ -293,7 +296,9 @@ impl Machine {
         self.machine_st.registers[2] =
             atom_as_cell!(AtomTable::build_with(&self.machine_st.atom_tbl, path));
 
-        let exit_code = self.run_module_predicate(atom!("loader"), (atom!("file_load_checked"), 2));
+        let exit_code = self.run_module_predicate(atom!("loader"), (atom!("file_load"), 2));
+        // run_module_predicate backtracks to its stub; after that, thrown loader
+        // errors are observable via the exception ball rather than `fail`.
         let load_failed = !self.machine_st.ball.stub.is_empty();
         self.machine_st.fail = false;
 
@@ -1290,5 +1295,8 @@ mod tests {
             .build();
 
         machine.run_module_predicate(atom!("$toplevel"), (atom!("repl"), 0));
+
+        assert!(!machine.machine_st.ball.stub.is_empty());
+        assert!(!machine.machine_st.fail);
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -437,6 +437,7 @@ impl Location {
     }
 }
 
+/// An error produced while parsing Prolog source.
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct ParserError {


### PR DESCRIPTION
## Summary

This adds small checked APIs for embedders that need parse/load/query status without relying on panic containment or diagnostic text:

- `validate_query_term` checks query text and returns `ParserError` on malformed input
- `run_query_checked` runs query text and returns `RunQueryError` for parser/allocation failures
- `load_module_string_checked` loads in-memory module text and reports loader failure via `LoadModuleError`
- existing panicking paths preserve their current behavior while sharing the checked implementation where practical
- focused library tests cover malformed query handling, valid query execution, checked module loading, loader failure mapping, and allocation error exposure

The broader Rust-side policy/classification layer from the first draft was removed so this PR stays focused on embeddable Rust building blocks.

Closes #3393.

## Related Work

- #3241: this PR now exposes `ParserError` directly for query parsing instead of wrapping parser failures in a custom status enum.
- #3236: `run_query` delegates through the checked query path, and checked query setup is shared instead of duplicated.
- #3145: this PR does not add the public Term-taking API discussed there, but the private parsed-term helper keeps the checked query setup compatible with that likely future direction.
- #3396: repeated-load resource stability work was split out so the allocation-growth questions can be reviewed independently.

## Validation

Ran locally:

```bash
cargo fmt --check
cargo test --no-default-features --lib checked_query
cargo test --no-default-features --lib checked_module_load
cargo test --no-default-features --lib
git diff --check
```

The broader no-default library suite passed with the existing warning set: unused imports in `system_calls.rs` and a dead `raw_block.rs` method.

## Notes

The API changes are intentionally additive. They do not add dependencies or change default features.
