### PR TITLE
Test repeated module load resource stability

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -494,6 +494,24 @@ impl Arena {
             code_index_tbl: CodeIndexTable::new()?,
         })
     }
+
+    #[cfg(test)]
+    pub(crate) fn slab_count_by_tag(&self, tag: ArenaHeaderTag) -> usize {
+        let mut count = 0;
+        let mut slab = self.base.as_ref();
+
+        while let Some(current_slab) = slab {
+            let current_slab = unsafe { current_slab.slab.as_ref() };
+
+            if current_slab.header.get_tag() == tag {
+                count += 1;
+            }
+
+            slab = current_slab.next.as_ref();
+        }
+
+        count
+    }
 }
 
 unsafe fn drop_slab_in_place(value: NonNull<AllocSlab>, tag: ArenaHeaderTag) {

--- a/src/loader.pl
+++ b/src/loader.pl
@@ -153,7 +153,7 @@ file_load(Stream, Path, Evacuable) :-
     catch(loader:file_load_init(Stream, Evacuable),
           E,
           loader:file_load_cleanup(Evacuable, E)),
-    '$pop_load_context'.
+    unload_evacuable(Evacuable).
 
 
 load(Stream) :-
@@ -161,7 +161,7 @@ load(Stream) :-
     catch(loader:file_load_init(Stream, Evacuable),
           E,
           loader:file_load_cleanup(Evacuable, E)),
-    '$pop_load_context',
+    unload_evacuable(Evacuable),
     false.        %% Clear the heap.
 load(_).
 

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -1,5 +1,102 @@
 use super::*;
+use crate::arena::ArenaHeaderTag;
 use crate::MachineBuilder;
+
+const REPEATED_LOAD_PROBE_PROGRAM: &str = r#"
+    :- discontiguous(repeated_loader_probe_predicate/2).
+    repeated_loader_probe_predicate(
+        repeated_loader_probe_subject,
+        repeated_loader_probe_object).
+    "#;
+
+const REPEATED_LOAD_FLOAT_PROGRAM: &str = r#"
+    repeated_float_probe_value(1.25).
+    "#;
+
+fn repeated_loader_probe_atom_count(machine: &crate::Machine) -> usize {
+    // The atom table is process-global; count only this test's long
+    // dynamic atoms so parallel tests cannot perturb the assertion.
+    machine
+        .machine_st
+        .atom_tbl
+        .active_table()
+        .iter()
+        .filter(|atom| atom.as_str().starts_with("repeated_loader_probe_"))
+        .count()
+}
+
+fn inactive_load_state_count(machine: &crate::Machine) -> usize {
+    machine
+        .machine_st
+        .arena
+        .slab_count_by_tag(ArenaHeaderTag::InactiveLoadState)
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+fn repeated_module_loads_keep_heap_and_atoms_stable() {
+    let mut machine = MachineBuilder::default().build();
+
+    machine.load_module_string("facts", REPEATED_LOAD_PROBE_PROGRAM);
+
+    let heap_len = machine.machine_st.heap.cell_len();
+    let atom_count = repeated_loader_probe_atom_count(&machine);
+    assert!(atom_count > 0);
+
+    for _ in 0..100 {
+        machine.load_module_string("facts", REPEATED_LOAD_PROBE_PROGRAM);
+        assert_eq!(machine.machine_st.heap.cell_len(), heap_len);
+        assert_eq!(repeated_loader_probe_atom_count(&machine), atom_count);
+    }
+
+    let answers = machine
+        .run_query(
+            "repeated_loader_probe_predicate(repeated_loader_probe_subject, repeated_loader_probe_object).",
+        )
+        .collect::<Result<Vec<_>, _>>()
+        .expect("query should execute");
+    assert_eq!(answers, [LeafAnswer::True]);
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+fn repeated_module_loads_keep_loader_state_and_stack_stable() {
+    let mut machine = MachineBuilder::default().build();
+
+    machine.load_module_string("facts", REPEATED_LOAD_PROBE_PROGRAM);
+
+    let stack_top = machine.machine_st.stack.top();
+    let trail_entries = machine.machine_st.trail.len();
+    let load_contexts = machine.load_contexts.len();
+    let inactive_load_states = inactive_load_state_count(&machine);
+
+    for _ in 0..100 {
+        machine.load_module_string("facts", REPEATED_LOAD_PROBE_PROGRAM);
+        assert_eq!(machine.machine_st.stack.top(), stack_top);
+        assert_eq!(machine.machine_st.trail.len(), trail_entries);
+        assert_eq!(machine.load_contexts.len(), load_contexts);
+        assert_eq!(inactive_load_state_count(&machine), inactive_load_states);
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+fn repeated_float_loads_keep_float_table_stable() {
+    let mut machine = MachineBuilder::default().build();
+
+    machine.load_module_string("facts", REPEATED_LOAD_FLOAT_PROGRAM);
+
+    let float_entries = machine.machine_st.arena.f64_tbl.entry_count();
+    assert!(float_entries > 0);
+
+    for _ in 0..100 {
+        machine.load_module_string("facts", REPEATED_LOAD_FLOAT_PROGRAM);
+        assert_eq!(
+            machine.machine_st.arena.f64_tbl.entry_count(),
+            float_entries
+        );
+    }
+}
 
 #[test]
 #[cfg_attr(miri, ignore = "it takes too long to run")]

--- a/src/machine/loader.rs
+++ b/src/machine/loader.rs
@@ -1788,13 +1788,15 @@ impl Machine {
 
         read_heap_cell!(load_state_payload,
             (HeapCellValueTag::Cons, cons_ptr) => {
-                match_untyped_arena_ptr!(cons_ptr,
-                    (ArenaHeaderTag::LiveLoadState, payload) => {
-                        let mut payload = payload;
-                        payload.drop_payload()
+                // Successful live loaders are evacuated by retagging the payload
+                // inactive before Prolog calls this cleanup predicate.
+                match cons_ptr.get_tag() {
+                    ArenaHeaderTag::LiveLoadState | ArenaHeaderTag::InactiveLoadState => {
+                        let mut payload = unsafe { cons_ptr.as_typed_ptr::<LiveLoadState>() };
+                        payload.drop_payload();
                     }
                     _ => {}
-                );
+                }
             }
             _ => {}
         );

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -258,10 +258,30 @@ impl Machine {
                     return ExitCode::FAILURE;
                 }
 
+                let stub_b = self.machine_st.b;
                 self.machine_st.cp = BREAK_FROM_DISPATCH_LOOP_LOC;
                 self.machine_st.p = p;
 
-                return self.dispatch_loop();
+                let exit_code = self.dispatch_loop();
+
+                if self.machine_st.b == stub_b {
+                    // The synthetic choice point is only a dispatch-loop sentinel
+                    // for this deterministic call; do not retain its stack frame.
+                    let stub_frame = self.machine_st.stack.index_or_frame(stub_b);
+                    let b = stub_frame.prelude.b;
+                    let b0 = stub_frame.prelude.b0;
+                    let tr = stub_frame.prelude.tr;
+                    let h = stub_frame.prelude.h;
+
+                    self.machine_st.b = b;
+                    self.machine_st.b0 = b0;
+                    self.machine_st.tr = tr;
+                    self.machine_st.trail.truncate(tr);
+                    self.machine_st.hb = h;
+                    self.machine_st.stack.truncate(stub_b);
+                }
+
+                return exit_code;
             }
         }
 

--- a/src/offset_table.rs
+++ b/src/offset_table.rs
@@ -432,6 +432,14 @@ impl F64Table {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn entry_count(&self) -> usize {
+        match self {
+            F64Table::Serial(serial_tbl) => serial_tbl.indirection_tbl.len(),
+            F64Table::Concurrent(concurrent_tbl) => concurrent_tbl.indirection_tbl.lock().len(),
+        }
+    }
+
     #[must_use = "the returned concurrent table must be absorbed into the owned F64Table"]
     pub fn single_to_concurrent(&mut self) -> Arc<ConcurrentF64Table> {
         match self {


### PR DESCRIPTION
This splits repeated-load resource stability work out of #3394.

cc @triska @Skgland @mthom

## Why

During review of #3394, the repeated-load heap/atom check raised a broader question: what else grows? The checked facade PR exposed that risk, but the underlying concern is loader/runtime scoped, so this PR moves the repeat-load coverage to `load_module_string/2` on `master`.

## Changes

- Add repeated module-load tests for heap/atom stability, loader-state/stack stability, and float-table stability.
- Drop evacuated inactive live-load-state payloads on successful loader cleanup.
- Remove the synthetic `run_module_predicate` dispatch sentinel stack frame after deterministic module predicate calls.

## Not addressed

The investigation also found broader retained-allocation questions that this PR does not solve:

- Compiled code length still grows when replacing the same module repeatedly.
- Large integer source literals can still add arena integer slabs on repeated loads.
- Dropped arena slabs from source streams/load-state allocations remain allocated even when payloads are dropped.

Those seem to need maintainer design discussion, likely in a follow-up issue, rather than being bundled into either this PR or #3394.

## Tests

- `cargo test --no-default-features --lib`