### PR TITLE
Fix issue mthom/scryer-prolog#3400

### DIFF
--- a/src/lib/sgml.pl
+++ b/src/lib/sgml.pl
@@ -33,6 +33,12 @@ represented as a list of elements where each is of the form:
 
     - `Children` is a list of elements as specified here.
 
+  * `doctype(Name)`
+
+  * `comment(Comment)`
+
+  * `processing_instruction(Target, Data)`
+
 Currently, Options are ignored. In the future, more options may be
 provided to control parsing.
 

--- a/src/lib/sgml.pl
+++ b/src/lib/sgml.pl
@@ -39,6 +39,8 @@ represented as a list of elements where each is of the form:
 
   * `processing_instruction(Target, Data)`
 
+  * `fragment(Children)`
+
 Currently, Options are ignored. In the future, more options may be
 provided to control parsing.
 

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -9431,8 +9431,26 @@ impl Machine {
                 unreachable!("we never iterate the root itself only its children")
             }
             scraper::Node::Fragment => {
-                // TODO should we represent the fragment somehow?  skipping it for now
-                Ok(None)
+                let cvec = node
+                    .children()
+                    .filter_map(|child| self.html_node_to_term(child).transpose())
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let children = sized_iter_to_heap_list(
+                    &mut self.machine_st.heap,
+                    cvec.len(),
+                    cvec.into_iter(),
+                )?;
+
+                let result = str_loc_as_cell!(self.machine_st.heap.cell_len());
+                let mut writer = self.machine_st.heap.reserve(2)?;
+
+                writer.write_with(|section| {
+                    section.push_cell(atom_as_cell!(atom!("fragment"), 1));
+                    section.push_cell(children);
+                });
+
+                Ok(Some(result))
             }
             scraper::Node::Doctype(doctype) => {
                 // what about public and system id?

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -8547,7 +8547,7 @@ impl Machine {
                 .tree
                 .root()
                 .children()
-                .filter_map(|child| self.html_node_to_term(child).transpose())
+                .map(|child| self.html_node_to_term(child))
                 .collect::<Result<Vec<_>, _>>()?;
 
             let nodes = sized_iter_to_heap_list(
@@ -9425,7 +9425,7 @@ impl Machine {
     pub(super) fn html_node_to_term(
         &mut self,
         node: ego_tree::NodeRef<'_, scraper::Node>,
-    ) -> Result<Option<HeapCellValue>, AllocError> {
+    ) -> Result<HeapCellValue, AllocError> {
         match node.value() {
             scraper::Node::Document => {
                 unreachable!("we never iterate the root itself only its children")
@@ -9433,7 +9433,7 @@ impl Machine {
             scraper::Node::Fragment => {
                 let cvec = node
                     .children()
-                    .filter_map(|child| self.html_node_to_term(child).transpose())
+                    .map(|child| self.html_node_to_term(child))
                     .collect::<Result<Vec<_>, _>>()?;
 
                 let children = sized_iter_to_heap_list(
@@ -9450,7 +9450,7 @@ impl Machine {
                     section.push_cell(children);
                 });
 
-                Ok(Some(result))
+                Ok(result)
             }
             scraper::Node::Doctype(doctype) => {
                 // what about public and system id?
@@ -9464,7 +9464,7 @@ impl Machine {
                     section.push_cell(name);
                 });
 
-                Ok(Some(result))
+                Ok(result)
             }
             scraper::Node::Comment(comment) => {
                 let comment = self.machine_st.heap.allocate_cstr(comment)?;
@@ -9477,9 +9477,9 @@ impl Machine {
                     section.push_cell(comment);
                 });
 
-                Ok(Some(result))
+                Ok(result)
             }
-            scraper::Node::Text(text) => self.machine_st.heap.allocate_cstr(&text.text).map(Some),
+            scraper::Node::Text(text) => self.machine_st.heap.allocate_cstr(&text.text),
             scraper::Node::Element(element) => {
                 let mut avec = Vec::new();
 
@@ -9506,7 +9506,7 @@ impl Machine {
 
                 let cvec = node
                     .children()
-                    .filter_map(|child| self.html_node_to_term(child).transpose())
+                    .map(|child| self.html_node_to_term(child))
                     .collect::<Result<Vec<_>, _>>()?;
 
                 let children = sized_iter_to_heap_list(
@@ -9526,7 +9526,7 @@ impl Machine {
                     section.push_cell(children);
                 });
 
-                Ok(Some(result))
+                Ok(result)
             }
             scraper::Node::ProcessingInstruction(processing_instruction) => {
                 let target = self
@@ -9547,7 +9547,7 @@ impl Machine {
                     section.push_cell(data);
                 });
 
-                Ok(Some(result))
+                Ok(result)
             }
         }
     }

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -8547,7 +8547,7 @@ impl Machine {
                 .tree
                 .root()
                 .children()
-                .map(|child| self.html_node_to_term(child))
+                .filter_map(|child| self.html_node_to_term(child).transpose())
                 .collect::<Result<Vec<_>, _>>()?;
 
             let nodes = sized_iter_to_heap_list(
@@ -9425,10 +9425,14 @@ impl Machine {
     pub(super) fn html_node_to_term(
         &mut self,
         node: ego_tree::NodeRef<'_, scraper::Node>,
-    ) -> Result<HeapCellValue, AllocError> {
+    ) -> Result<Option<HeapCellValue>, AllocError> {
         match node.value() {
-            scraper::Node::Document | scraper::Node::Fragment => {
+            scraper::Node::Document => {
                 unreachable!("we never iterate the root itself only its children")
+            }
+            scraper::Node::Fragment => {
+                // TODO should we represent the fragment somehow?  skipping it for now
+                Ok(None)
             }
             scraper::Node::Doctype(doctype) => {
                 // what about public and system id?
@@ -9442,7 +9446,7 @@ impl Machine {
                     section.push_cell(name);
                 });
 
-                Ok(result)
+                Ok(Some(result))
             }
             scraper::Node::Comment(comment) => {
                 let comment = self.machine_st.heap.allocate_cstr(comment)?;
@@ -9455,9 +9459,9 @@ impl Machine {
                     section.push_cell(comment);
                 });
 
-                Ok(result)
+                Ok(Some(result))
             }
-            scraper::Node::Text(text) => self.machine_st.heap.allocate_cstr(&text.text),
+            scraper::Node::Text(text) => self.machine_st.heap.allocate_cstr(&text.text).map(Some),
             scraper::Node::Element(element) => {
                 let mut avec = Vec::new();
 
@@ -9484,7 +9488,7 @@ impl Machine {
 
                 let cvec = node
                     .children()
-                    .map(|child| self.html_node_to_term(child))
+                    .filter_map(|child| self.html_node_to_term(child).transpose())
                     .collect::<Result<Vec<_>, _>>()?;
 
                 let children = sized_iter_to_heap_list(
@@ -9504,7 +9508,7 @@ impl Machine {
                     section.push_cell(children);
                 });
 
-                Ok(result)
+                Ok(Some(result))
             }
             scraper::Node::ProcessingInstruction(processing_instruction) => {
                 let target = self
@@ -9525,7 +9529,7 @@ impl Machine {
                     section.push_cell(data);
                 });
 
-                Ok(result)
+                Ok(Some(result))
             }
         }
     }

--- a/tests-pl/issue3400.pl
+++ b/tests-pl/issue3400.pl
@@ -1,0 +1,5 @@
+:- use_module(library(sgml)).
+
+test :- load_html("<html><head><template>Hello!</template></head></html>", Es, []), write(Es).
+
+:- initialization(test).

--- a/tests/scryer/helper.rs
+++ b/tests/scryer/helper.rs
@@ -31,11 +31,13 @@ impl Expectable for &[u8] {
 
 /// Tests whether the file can be successfully loaded
 /// and produces the expected output during it
+#[track_caller]
 pub(crate) fn load_module_test<T: Expectable>(file: &str, expected: T) {
     let mut wam = MachineBuilder::default().build();
     expected.assert_eq(wam.test_load_file(file).as_slice());
 }
 
+#[track_caller]
 pub(crate) fn load_module_test_with_input<T: Expectable>(
     file: &str,
     input: impl Into<Cow<'static, str>>,

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -27,7 +27,7 @@ fn issue2588_load_html() {
 fn issue3400_load_html() {
     load_module_test(
         "tests-pl/issue3400.pl",
-        "[element(html,[],[element(head,[],[element(template,[],[])]),element(body,[],[])])]",
+        "[element(html,[],[element(head,[],[element(template,[],[fragment([[H,e,l,l,o,!]])])]),element(body,[],[])])]",
     );
 }
 

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -22,6 +22,16 @@ fn issue2588_load_html() {
     );
 }
 
+#[test]
+#[cfg_attr(miri, ignore = "unsupported operation when isolation is enabled")]
+#[should_panic] // FIXME actually a bug but ensuring the tests detects the issue before it is fixed
+fn issue3400_load_html() {
+    load_module_test(
+        "tests-pl/issue3400.pl",
+        "[element(html,[],[element(head,[],[element(template,[],[])]),element(body,[],[])])]",
+    );
+}
+
 // issue #2914
 #[test]
 #[cfg_attr(miri, ignore = "unsupported operation when isolation is enabled")]

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -24,7 +24,6 @@ fn issue2588_load_html() {
 
 #[test]
 #[cfg_attr(miri, ignore = "unsupported operation when isolation is enabled")]
-#[should_panic] // FIXME actually a bug but ensuring the tests detects the issue before it is fixed
 fn issue3400_load_html() {
     load_module_test(
         "tests-pl/issue3400.pl",


### PR DESCRIPTION
`html_node_to_term` did not account for fragment roots in non-root position that can occur when an html document contains a template tag.

fixes mthom/scryer-prolog#3400