### PR TITLE
msrv cleanup

### DIFF
--- a/build/instructions_template.rs
+++ b/build/instructions_template.rs
@@ -2013,11 +2013,11 @@ impl InstructionData {
     fn generate_instruction_enum_loop(&mut self, input: syn::DeriveInput) {
         if let Data::Enum(DataEnum { variants, .. }) = input.data {
             for mut variant in variants {
-                if let Some(field) = variant.fields.iter().next() {
-                    if let Some(input) = derive_input(&field.ty) {
-                        self.generate_instruction_enum_loop(input);
-                        continue;
-                    }
+                if let Some(field) = variant.fields.iter().next()
+                    && let Some(input) = derive_input(&field.ty)
+                {
+                    self.generate_instruction_enum_loop(input);
+                    continue;
                 }
 
                 if input.ident == "InstructionTemplate" {

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -366,7 +366,7 @@ impl CodeGenerator {
     where
         Target: crate::targets::CompilationTarget<'a>,
     {
-        if let Some(ref mut instr) = target.back_mut()
+        if let Some(instr) = target.back_mut()
             && Target::is_void_instr(instr)
         {
             Target::incr_void_instr(instr);

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -366,11 +366,11 @@ impl CodeGenerator {
     where
         Target: crate::targets::CompilationTarget<'a>,
     {
-        if let Some(ref mut instr) = target.back_mut() {
-            if Target::is_void_instr(instr) {
-                Target::incr_void_instr(instr);
-                return;
-            }
+        if let Some(ref mut instr) = target.back_mut()
+            && Target::is_void_instr(instr)
+        {
+            Target::incr_void_instr(instr);
+            return;
         }
 
         target.push_back(Target::to_void(1));

--- a/src/debray_allocator.rs
+++ b/src/debray_allocator.rs
@@ -337,13 +337,11 @@ impl DebrayAllocator {
 
                 if let VarAlloc::Temp { temp_var_data, .. } =
                     &self.var_data.records[t_var].allocation
-                {
-                    if !temp_var_data
+                    && !temp_var_data
                         .use_set
                         .contains(&(GenContext::Last(chunk_num), k))
-                    {
-                        return Some((t_var, self.alloc_with_ca(t_var)));
-                    }
+                {
+                    return Some((t_var, self.alloc_with_ca(t_var)));
                 }
 
                 None

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -541,20 +541,18 @@ impl OpDecl {
     ) -> Result<(), SessionError> {
         let (spec, name) = (self.op_desc.get_spec(), self.name);
 
-        if spec.is_infix() {
-            if let Some(desc) = existing_desc {
-                if desc.post > 0 {
-                    return Err(SessionError::OpIsInfixAndPostFix(name));
-                }
-            }
+        if spec.is_infix()
+            && let Some(desc) = existing_desc
+            && desc.post > 0
+        {
+            return Err(SessionError::OpIsInfixAndPostFix(name));
         }
 
-        if spec.is_postfix() {
-            if let Some(desc) = existing_desc {
-                if desc.inf > 0 {
-                    return Err(SessionError::OpIsInfixAndPostFix(name));
-                }
-            }
+        if spec.is_postfix()
+            && let Some(desc) = existing_desc
+            && desc.inf > 0
+        {
+            return Err(SessionError::OpIsInfixAndPostFix(name));
         }
 
         self.insert_into_op_dir(op_dir);
@@ -611,13 +609,13 @@ pub(crate) fn fetch_op_spec_from_existing(
     op_desc: Option<OpDesc>,
     op_dir: &OpDir,
 ) -> Option<OpDesc> {
-    if let Some(op_desc) = &op_desc {
-        if op_desc.arity() != arity {
-            /* it's possible to extend operator functors with
-             * additional terms. When that happens,
-             * void the op_spec by returning None. */
-            return None;
-        }
+    if let Some(op_desc) = &op_desc
+        && op_desc.arity() != arity
+    {
+        /* it's possible to extend operator functors with
+         * additional terms. When that happens,
+         * void the op_spec by returning None. */
+        return None;
     }
 
     op_desc.or_else(|| fetch_op_spec(name, arity, op_dir))
@@ -633,10 +631,10 @@ pub(crate) fn fetch_op_spec(name: Atom, arity: usize, op_dir: &OpDir) -> Option<
             }
         }),
         1 => {
-            if let Some(op_desc) = op_dir.get(&(name, Fixity::Pre)) {
-                if op_desc.get_prec() > 0 {
-                    return Some(*op_desc);
-                }
+            if let Some(op_desc) = op_dir.get(&(name, Fixity::Pre))
+                && op_desc.get_prec() > 0
+            {
+                return Some(*op_desc);
             }
 
             op_dir.get(&(name, Fixity::Post)).and_then(|op_desc| {

--- a/src/heap_print.rs
+++ b/src/heap_print.rs
@@ -123,15 +123,15 @@ impl<'a, ElideLists> StackfulPreOrderHeapIter<'a, ElideLists> {
                 (HeapCellValueTag::Str, s) => {
                     read_heap_cell!(self.heap[s],
                         (HeapCellValueTag::Atom, (name, _arity)) => {
-                            if let Some(spec) = fetch_atom_op_spec(name, None, op_dir) {
-                                if spec.get_spec().is_postfix()  || spec.get_spec().is_infix() {
-                                    if needs_bracketing(spec, &parent_spec) {
-                                        return false;
-                                    } else {
-                                        h = IterStackLoc::iterable_loc(s + 1, HeapOrStackTag::Heap);
-                                        parent_spec = DirectedOp::Right(name, spec);
-                                        continue;
-                                    }
+                            if let Some(spec) = fetch_atom_op_spec(name, None, op_dir)
+                                && (spec.get_spec().is_postfix()  || spec.get_spec().is_infix())
+                            {
+                                if needs_bracketing(spec, &parent_spec) {
+                                    return false;
+                                } else {
+                                    h = IterStackLoc::iterable_loc(s + 1, HeapOrStackTag::Heap);
+                                    parent_spec = DirectedOp::Right(name, spec);
+                                    continue;
                                 }
                             }
 
@@ -457,10 +457,10 @@ pub fn fmt_float(mut fl: f64) -> String {
      * case.
      */
 
-    if let Some(e_index) = fl_str.find('e') {
-        if !fl_str[0..e_index].contains('.') {
-            return fl_str[0..e_index].to_string() + ".0" + &fl_str[e_index..];
-        }
+    if let Some(e_index) = fl_str.find('e')
+        && !fl_str[0..e_index].contains('.')
+    {
+        return fl_str[0..e_index].to_string() + ".0" + &fl_str[e_index..];
     }
 
     fl_str.to_string()
@@ -585,10 +585,11 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
     }
 
     fn set_parent_of_first_op(&mut self, parent_op: Option<DirectedOp>) {
-        if let Some(op) = parent_op {
-            if op.is_left() && op.is_prefix() {
-                self.parent_of_first_op = Some((op, self.last_item_idx));
-            }
+        if let Some(op) = parent_op
+            && op.is_left()
+            && op.is_prefix()
+        {
+            self.parent_of_first_op = Some((op, self.last_item_idx));
         }
     }
 
@@ -1356,11 +1357,11 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
     }
 
     fn close_list(&mut self, switch: Rc<Cell<(bool, usize)>>) -> Option<Rc<Cell<(bool, usize)>>> {
-        if let Some(TokenOrRedirect::Op(_, op_desc)) = self.state_stack.last() {
-            if op_desc.get_spec().is_postfix() || op_desc.get_spec().is_infix() {
-                self.state_stack.push(TokenOrRedirect::ChildCloseList);
-                return None;
-            }
+        if let Some(TokenOrRedirect::Op(_, op_desc)) = self.state_stack.last()
+            && (op_desc.get_spec().is_postfix() || op_desc.get_spec().is_infix())
+        {
+            self.state_stack.push(TokenOrRedirect::ChildCloseList);
+            return None;
         }
 
         self.state_stack
@@ -1452,13 +1453,12 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
                     });
 
                 for op in &[op, parent_op] {
-                    if let Some(op) = &op {
-                        if op.is_left()
-                            && (op.is_prefix() || requires_space(&op.as_atom().as_str(), "("))
-                        {
-                            self.state_stack.push(TokenOrRedirect::Space);
-                            return;
-                        }
+                    if let Some(op) = &op
+                        && op.is_left()
+                        && (op.is_prefix() || requires_space(&op.as_atom().as_str(), "("))
+                    {
+                        self.state_stack.push(TokenOrRedirect::Space);
+                        return;
                     }
                 }
             }
@@ -1627,10 +1627,9 @@ impl<'a, Outputter: HCValueOutputter> HCPrinter<'a, Outputter> {
             if name == atom!("[]") && arity == 0 {
                 if let Some(TokenOrRedirect::CloseList(_) | TokenOrRedirect::ChildCloseList) =
                     printer.state_stack.last()
+                    && printer.at_cdr("")
                 {
-                    if printer.at_cdr("") {
-                        return;
-                    }
+                    return;
                 }
 
                 append_str!(printer, "[]");

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -716,27 +716,27 @@ pub(crate) fn remove_constant_indices(
                         offset,
                     );
 
-                    if indexed_choice_instrs.len() == 1 {
-                        if let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back() {
-                            let ext = IndexingCodePtr::External(indexed_choice_instr.offset());
+                    if indexed_choice_instrs.len() == 1
+                        && let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back()
+                    {
+                        let ext = IndexingCodePtr::External(indexed_choice_instr.offset());
 
-                            match &mut indexing_code[constants_index] {
-                                IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
-                                    _,
-                                    _,
-                                    c,
-                                    ..,
-                                )) => {
-                                    *c = ext;
-                                }
-                                IndexingLine::Indexing(IndexingInstruction::SwitchOnConstant(
-                                    constants,
-                                )) => {
-                                    constants.insert(constant, ext);
-                                }
-                                _ => {
-                                    unreachable!()
-                                }
+                        match &mut indexing_code[constants_index] {
+                            IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
+                                _,
+                                _,
+                                c,
+                                ..,
+                            )) => {
+                                *c = ext;
+                            }
+                            IndexingLine::Indexing(IndexingInstruction::SwitchOnConstant(
+                                constants,
+                            )) => {
+                                constants.insert(constant, ext);
+                            }
+                            _ => {
+                                unreachable!()
                             }
                         }
                     }
@@ -749,27 +749,27 @@ pub(crate) fn remove_constant_indices(
                         offset,
                     );
 
-                    if indexed_choice_instrs.len() == 1 {
-                        if let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back() {
-                            let ext = IndexingCodePtr::DynamicExternal(indexed_choice_instr);
+                    if indexed_choice_instrs.len() == 1
+                        && let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back()
+                    {
+                        let ext = IndexingCodePtr::DynamicExternal(indexed_choice_instr);
 
-                            match &mut indexing_code[constants_index] {
-                                IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
-                                    _,
-                                    _,
-                                    c,
-                                    ..,
-                                )) => {
-                                    *c = ext;
-                                }
-                                IndexingLine::Indexing(IndexingInstruction::SwitchOnConstant(
-                                    constants,
-                                )) => {
-                                    constants.insert(constant, ext);
-                                }
-                                _ => {
-                                    unreachable!()
-                                }
+                        match &mut indexing_code[constants_index] {
+                            IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
+                                _,
+                                _,
+                                c,
+                                ..,
+                            )) => {
+                                *c = ext;
+                            }
+                            IndexingLine::Indexing(IndexingInstruction::SwitchOnConstant(
+                                constants,
+                            )) => {
+                                constants.insert(constant, ext);
+                            }
+                            _ => {
+                                unreachable!()
                             }
                         }
                     }
@@ -850,28 +850,28 @@ pub(crate) fn remove_structure_index(
             IndexingLine::IndexedChoice(indexed_choice_instrs) => {
                 StaticCodeIndices::remove_instruction_with_offset(indexed_choice_instrs, offset);
 
-                if indexed_choice_instrs.len() == 1 {
-                    if let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back() {
-                        let ext = IndexingCodePtr::External(indexed_choice_instr.offset());
+                if indexed_choice_instrs.len() == 1
+                    && let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back()
+                {
+                    let ext = IndexingCodePtr::External(indexed_choice_instr.offset());
 
-                        match &mut indexing_code[structures_index] {
-                            IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
-                                _,
-                                _,
-                                _,
-                                _,
-                                s,
-                            )) => {
-                                *s = ext;
-                            }
-                            IndexingLine::Indexing(IndexingInstruction::SwitchOnStructure(
-                                structures,
-                            )) => {
-                                structures.insert((name, arity), ext);
-                            }
-                            _ => {
-                                unreachable!()
-                            }
+                    match &mut indexing_code[structures_index] {
+                        IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
+                            _,
+                            _,
+                            _,
+                            _,
+                            s,
+                        )) => {
+                            *s = ext;
+                        }
+                        IndexingLine::Indexing(IndexingInstruction::SwitchOnStructure(
+                            structures,
+                        )) => {
+                            structures.insert((name, arity), ext);
+                        }
+                        _ => {
+                            unreachable!()
                         }
                     }
                 }
@@ -881,28 +881,28 @@ pub(crate) fn remove_structure_index(
             IndexingLine::DynamicIndexedChoice(indexed_choice_instrs) => {
                 DynamicCodeIndices::remove_instruction_with_offset(indexed_choice_instrs, offset);
 
-                if indexed_choice_instrs.len() == 1 {
-                    if let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back() {
-                        let ext = IndexingCodePtr::DynamicExternal(indexed_choice_instr);
+                if indexed_choice_instrs.len() == 1
+                    && let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back()
+                {
+                    let ext = IndexingCodePtr::DynamicExternal(indexed_choice_instr);
 
-                        match &mut indexing_code[structures_index] {
-                            IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
-                                _,
-                                _,
-                                _,
-                                _,
-                                s,
-                            )) => {
-                                *s = ext;
-                            }
-                            IndexingLine::Indexing(IndexingInstruction::SwitchOnStructure(
-                                structures,
-                            )) => {
-                                structures.insert((name, arity), ext);
-                            }
-                            _ => {
-                                unreachable!()
-                            }
+                    match &mut indexing_code[structures_index] {
+                        IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
+                            _,
+                            _,
+                            _,
+                            _,
+                            s,
+                        )) => {
+                            *s = ext;
+                        }
+                        IndexingLine::Indexing(IndexingInstruction::SwitchOnStructure(
+                            structures,
+                        )) => {
+                            structures.insert((name, arity), ext);
+                        }
+                        _ => {
+                            unreachable!()
                         }
                     }
                 }
@@ -957,23 +957,17 @@ pub(crate) fn remove_list_index(indexing_code: &mut [IndexingLine], offset: usiz
         IndexingLine::IndexedChoice(indexed_choice_instrs) => {
             StaticCodeIndices::remove_instruction_with_offset(indexed_choice_instrs, offset);
 
-            if indexed_choice_instrs.len() == 1 {
-                if let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back() {
-                    let ext = IndexingCodePtr::External(indexed_choice_instr.offset());
+            if indexed_choice_instrs.len() == 1
+                && let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back()
+            {
+                let ext = IndexingCodePtr::External(indexed_choice_instr.offset());
 
-                    match &mut indexing_code[0] {
-                        IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
-                            _,
-                            _,
-                            _,
-                            l,
-                            _,
-                        )) => {
-                            *l = ext;
-                        }
-                        _ => {
-                            unreachable!()
-                        }
+                match &mut indexing_code[0] {
+                    IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(_, _, _, l, _)) => {
+                        *l = ext;
+                    }
+                    _ => {
+                        unreachable!()
                     }
                 }
             }
@@ -981,23 +975,17 @@ pub(crate) fn remove_list_index(indexing_code: &mut [IndexingLine], offset: usiz
         IndexingLine::DynamicIndexedChoice(indexed_choice_instrs) => {
             DynamicCodeIndices::remove_instruction_with_offset(indexed_choice_instrs, offset);
 
-            if indexed_choice_instrs.len() == 1 {
-                if let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back() {
-                    let ext = IndexingCodePtr::DynamicExternal(indexed_choice_instr);
+            if indexed_choice_instrs.len() == 1
+                && let Some(indexed_choice_instr) = indexed_choice_instrs.pop_back()
+            {
+                let ext = IndexingCodePtr::DynamicExternal(indexed_choice_instr);
 
-                    match &mut indexing_code[0] {
-                        IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(
-                            _,
-                            _,
-                            _,
-                            l,
-                            _,
-                        )) => {
-                            *l = ext;
-                        }
-                        _ => {
-                            unreachable!()
-                        }
+                match &mut indexing_code[0] {
+                    IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(_, _, _, l, _)) => {
+                        *l = ext;
+                    }
+                    _ => {
+                        unreachable!()
                     }
                 }
             }
@@ -1070,10 +1058,10 @@ fn uncap_choice_seq_with_trust(prelude: &mut [IndexedChoiceInstruction]) {
 
 #[inline]
 fn uncap_choice_seq_with_try(prelude: &mut [IndexedChoiceInstruction]) {
-    if let Some(instr) = prelude.first_mut() {
-        if let IndexedChoiceInstruction::Try(i) = instr {
-            *instr = IndexedChoiceInstruction::Retry(*i);
-        }
+    if let Some(instr) = prelude.first_mut()
+        && let IndexedChoiceInstruction::Try(i) = instr
+    {
+        *instr = IndexedChoiceInstruction::Retry(*i);
     }
 }
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -350,10 +350,10 @@ pub(crate) struct ClauseIterator<'a> {
 }
 
 fn state_from_chunked_terms(chunk_vec: &VecDeque<ChunkedTerms>) -> ClauseIteratorState<'_> {
-    if chunk_vec.len() == 1 {
-        if let Some(ChunkedTerms::Branch { branch_nums, arms }) = chunk_vec.front() {
-            return ClauseIteratorState::RemainingBranches(branch_nums, arms, 0);
-        }
+    if chunk_vec.len() == 1
+        && let Some(ChunkedTerms::Branch { branch_nums, arms }) = chunk_vec.front()
+    {
+        return ClauseIteratorState::RemainingBranches(branch_nums, arms, 0);
     }
 
     ClauseIteratorState::RemainingChunks(chunk_vec, 0)

--- a/src/machine/arithmetic_ops.rs
+++ b/src/machine/arithmetic_ops.rs
@@ -329,10 +329,10 @@ pub(crate) fn int_pow(n1: Number, n2: Number, arena: &mut Arena) -> Result<Numbe
                 let n = Number::Fixnum(n1);
                 Err(numerical_type_error(ValidType::Float, n, stub_gen))
             } else {
-                if let Ok(n2_u) = u32::try_from(n2_i) {
-                    if let Some(result) = n1_i.checked_pow(n2_u) {
-                        return Ok(Number::arena_from(result, arena));
-                    }
+                if let Ok(n2_u) = u32::try_from(n2_i)
+                    && let Some(result) = n1_i.checked_pow(n2_u)
+                {
+                    return Ok(Number::arena_from(result, arena));
                 }
 
                 let n1 = Integer::from(n1_i);

--- a/src/machine/compile.rs
+++ b/src/machine/compile.rs
@@ -1210,13 +1210,13 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 return None;
             }
 
-            if let Some(path_str) = load_context.path.to_str() {
-                if !path_str.is_empty() {
-                    return Some(AtomTable::build_with(
-                        &LS::machine_st(&mut self.payload).atom_tbl,
-                        path_str,
-                    ));
-                }
+            if let Some(path_str) = load_context.path.to_str()
+                && !path_str.is_empty()
+            {
+                return Some(AtomTable::build_with(
+                    &LS::machine_st(&mut self.payload).atom_tbl,
+                    path_str,
+                ));
             }
         }
 
@@ -2220,23 +2220,23 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             let predicates = self.payload.predicates.take();
             let offset = self.compile(key, predicates, settings)?;
 
-            if let Some(filename) = self.listing_src_file_name() {
-                if let Some(ref mut module) = self.wam_prelude.indices.modules.get_mut(&filename) {
-                    let index_ptr = LS::machine_st(&mut self.payload)
-                        .arena
-                        .code_index_tbl
-                        .get_entry(offset.into());
+            if let Some(filename) = self.listing_src_file_name()
+                && let Some(ref mut module) = self.wam_prelude.indices.modules.get_mut(&filename)
+            {
+                let index_ptr = LS::machine_st(&mut self.payload)
+                    .arena
+                    .code_index_tbl
+                    .get_entry(offset.into());
 
-                    let offset = *module.code_dir.entry(key).or_insert(offset);
+                let offset = *module.code_dir.entry(key).or_insert(offset);
 
-                    set_code_index::<LS>(
-                        &mut self.payload,
-                        &CompilationTarget::Module(filename),
-                        key,
-                        offset,
-                        index_ptr,
-                    );
-                }
+                set_code_index::<LS>(
+                    &mut self.payload,
+                    &CompilationTarget::Module(filename),
+                    key,
+                    offset,
+                    index_ptr,
+                );
             }
         }
 

--- a/src/machine/compile.rs
+++ b/src/machine/compile.rs
@@ -2221,7 +2221,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             let offset = self.compile(key, predicates, settings)?;
 
             if let Some(filename) = self.listing_src_file_name()
-                && let Some(ref mut module) = self.wam_prelude.indices.modules.get_mut(&filename)
+                && let Some(module) = self.wam_prelude.indices.modules.get_mut(&filename)
             {
                 let index_ptr = LS::machine_st(&mut self.payload)
                     .arena

--- a/src/machine/dispatch.rs
+++ b/src/machine/dispatch.rs
@@ -292,11 +292,8 @@ impl MachineState {
     }
 
     #[inline(always)]
-    pub(crate) fn check_for_interrupt(&mut self) -> bool {
+    pub(crate) fn check_for_interrupt(&mut self, stub: impl FnOnce() -> MachineStub) -> CallResult {
         if INTERRUPT.swap(false, atomic::Ordering::Relaxed) {
-            self.throw_interrupt_exception();
-            self.backtrack();
-
             // We have extracted control over the Tokio runtime to the calling context for enabling library use case
             // (see https://github.com/mthom/scryer-prolog/pull/1880)
             // So we only have access to a runtime handle in here and can't shut it down.
@@ -313,9 +310,11 @@ impl MachineState {
 
             //let old_runtime = tokio::runtime::Handle::current();
             //old_runtime.shutdown_background();
-            true
+
+            let err = self.interrupt_error();
+            Err(self.error_form(err, stub()))
         } else {
-            false
+            Ok(())
         }
     }
 
@@ -1599,7 +1598,13 @@ impl Machine {
                 }
             }
 
-            self.machine_st.check_for_interrupt();
+            if let Err(err) = self
+                .machine_st
+                .check_for_interrupt(|| functor_stub(atom!("repl"), 0))
+            {
+                self.machine_st.throw_exception(err);
+                self.machine_st.backtrack();
+            }
         }
 
         Some(std::process::ExitCode::SUCCESS)
@@ -6033,7 +6038,13 @@ impl Machine {
                 }
             }
 
-            self.machine_st.check_for_interrupt();
+            if let Err(err) = self
+                .machine_st
+                .check_for_interrupt(|| functor_stub(atom!("dispatch_loop"), 0))
+            {
+                self.machine_st.throw_exception(err);
+                self.machine_st.backtrack();
+            };
         }
 
         std::process::ExitCode::SUCCESS

--- a/src/machine/heap.rs
+++ b/src/machine/heap.rs
@@ -271,7 +271,6 @@ impl ReservedHeapSection {
             return 0;
         }
 
-        let cells_written;
         let str_byte_len = src.len();
 
         unsafe {
@@ -287,7 +286,7 @@ impl ReservedHeapSection {
 
         unsafe { ptr::write_bytes(self.heap_ptr.add(zero_region_idx), 0u8, align_offset) };
 
-        cells_written = if align_offset == 1 {
+        let cells_written = if align_offset == 1 {
             unsafe {
                 ptr::write_bytes(
                     self.heap_ptr.add(zero_region_idx + 1),

--- a/src/machine/lib_machine/mod.rs
+++ b/src/machine/lib_machine/mod.rs
@@ -462,11 +462,12 @@ impl Iterator for QueryState<'_> {
             let exception_term =
                 Term::from_heapcell(machine, machine.machine_st.heap[h], &mut var_names.clone());
 
-            if let Term::Compound(functor, args) = &exception_term {
-                if functor == "error" && args.len() == 2 {
-                    // We have an error
-                    return Some(Err(exception_term));
-                }
+            if let Term::Compound(functor, args) = &exception_term
+                && functor == "error"
+                && args.len() == 2
+            {
+                // We have an error
+                return Some(Err(exception_term));
             }
 
             // We have an exception that is not an error
@@ -513,13 +514,13 @@ impl Iterator for QueryState<'_> {
                     .unwrap();
                 let term_idx =
                     var_dict.get_index_of(&VarKey::VarPtr(Var::from(term_str.clone()).into()));
-                if let Some(idx) = term_idx {
-                    if idx < var_name_idx {
-                        let new_term = Term::Var(var_name);
-                        let new_var_name = term_str.into();
-                        term = new_term;
-                        var_name = new_var_name;
-                    }
+                if let Some(idx) = term_idx
+                    && idx < var_name_idx
+                {
+                    let new_term = Term::Var(var_name);
+                    let new_var_name = term_str.into();
+                    term = new_term;
+                    var_name = new_var_name;
                 }
             }
 

--- a/src/machine/lib_machine/tests.rs
+++ b/src/machine/lib_machine/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::arena::ArenaHeaderTag;
 use crate::MachineBuilder;
+use crate::arena::ArenaHeaderTag;
 
 const REPEATED_LOAD_PROBE_PROGRAM: &str = r#"
     :- discontiguous(repeated_loader_probe_predicate/2).

--- a/src/machine/load_state.rs
+++ b/src/machine/load_state.rs
@@ -474,25 +474,24 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 continue;
             }
 
-            if let Some(code_index) = removed_module.code_dir.get_mut(key) {
-                if let Some(global_skeleton) = self
+            if let Some(code_index) = removed_module.code_dir.get_mut(key)
+                && let Some(global_skeleton) = self
                     .wam_prelude
                     .indices
                     .get_predicate_skeleton(local_compilation_target, key)
-                {
-                    let old_index_ptr = code_index.replace(
-                        &mut LS::machine_st(&mut self.payload).arena.code_index_tbl,
-                        if global_skeleton.core.is_dynamic {
-                            IndexPtr::dynamic_undefined()
-                        } else {
-                            IndexPtr::undefined()
-                        },
-                    );
+            {
+                let old_index_ptr = code_index.replace(
+                    &mut LS::machine_st(&mut self.payload).arena.code_index_tbl,
+                    if global_skeleton.core.is_dynamic {
+                        IndexPtr::dynamic_undefined()
+                    } else {
+                        IndexPtr::undefined()
+                    },
+                );
 
-                    self.payload.retraction_info.push_record(
-                        RetractionRecord::ReplacedModulePredicate(module_name, *key, old_index_ptr),
-                    );
-                }
+                self.payload.retraction_info.push_record(
+                    RetractionRecord::ReplacedModulePredicate(module_name, *key, old_index_ptr),
+                );
             }
         }
 
@@ -765,12 +764,11 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
 
         match payload_compilation_target {
             CompilationTarget::User => {
-                if let Some(filename) = listing_src_file_name {
-                    if let Some(ref mut module) =
+                if let Some(filename) = listing_src_file_name
+                    && let Some(ref mut module) =
                         self.wam_prelude.indices.modules.get_mut(&filename)
-                    {
-                        op_decl.insert_into_op_dir(&mut module.op_dir);
-                    }
+                {
+                    op_decl.insert_into_op_dir(&mut module.op_dir);
                 }
 
                 add_op_decl(

--- a/src/machine/load_state.rs
+++ b/src/machine/load_state.rs
@@ -629,7 +629,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
         key: PredicateKey,
     ) -> CodeIndex {
         match self.wam_prelude.indices.modules.get_mut(&module_name) {
-            Some(ref mut module) => *module.code_dir.entry(key).or_insert_with(|| {
+            Some(module) => *module.code_dir.entry(key).or_insert_with(|| {
                 CodeIndex::new(
                     IndexPtr::undefined(),
                     &mut LS::machine_st(&mut self.payload).arena.code_index_tbl,
@@ -639,7 +639,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 self.add_dynamically_generated_module(module_name);
 
                 match self.wam_prelude.indices.modules.get_mut(&module_name) {
-                    Some(ref mut module) => *module.code_dir.entry(key).or_insert_with(|| {
+                    Some(module) => *module.code_dir.entry(key).or_insert_with(|| {
                         CodeIndex::new(
                             IndexPtr::undefined(),
                             &mut LS::machine_st(&mut self.payload).arena.code_index_tbl,
@@ -765,8 +765,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
         match payload_compilation_target {
             CompilationTarget::User => {
                 if let Some(filename) = listing_src_file_name
-                    && let Some(ref mut module) =
-                        self.wam_prelude.indices.modules.get_mut(&filename)
+                    && let Some(module) = self.wam_prelude.indices.modules.get_mut(&filename)
                 {
                     op_decl.insert_into_op_dir(&mut module.op_dir);
                 }
@@ -780,7 +779,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             }
             CompilationTarget::Module(ref module_name) => {
                 match self.wam_prelude.indices.modules.get_mut(module_name) {
-                    Some(ref mut module) => {
+                    Some(module) => {
                         add_op_decl_as_module_export::<LS>(
                             &mut self.payload,
                             &mut module.op_dir,
@@ -1088,7 +1087,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         .modules
                         .get_mut(defining_module_name)
                     {
-                        Some(ref mut target_module) => {
+                        Some(target_module) => {
                             import_module_exports_into_module::<LS>(
                                 &mut self.payload,
                                 &payload_compilation_target,
@@ -1141,17 +1140,15 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         .modules
                         .get_mut(defining_module_name)
                     {
-                        Some(ref mut target_module) => {
-                            import_qualified_module_exports_into_module::<LS>(
-                                &mut self.payload,
-                                &module,
-                                &exports,
-                                &mut target_module.code_dir,
-                                &mut target_module.op_dir,
-                                &mut target_module.meta_predicates,
-                                &mut self.wam_prelude.indices.op_dir,
-                            )
-                        }
+                        Some(target_module) => import_qualified_module_exports_into_module::<LS>(
+                            &mut self.payload,
+                            &module,
+                            &exports,
+                            &mut target_module.code_dir,
+                            &mut target_module.op_dir,
+                            &mut target_module.meta_predicates,
+                            &mut self.wam_prelude.indices.op_dir,
+                        ),
                         None => Err(SessionError::ModuleCannotImportSelf(module_name)),
                     }
                 }

--- a/src/machine/loader.rs
+++ b/src/machine/loader.rs
@@ -580,7 +580,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             .modules
                             .get_mut(&target_module_name)
                         {
-                            Some(ref mut module) => {
+                            Some(module) => {
                                 module.meta_predicates.swap_remove(&key);
                             }
                             _ => {
@@ -603,7 +603,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             .modules
                             .get_mut(&target_module_name)
                         {
-                            Some(ref mut module) => {
+                            Some(module) => {
                                 module
                                     .meta_predicates
                                     .insert((name, meta_specs.len()), meta_specs);
@@ -622,7 +622,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                     listing_src,
                     local_extensible_predicates,
                 ) => match self.wam_prelude.indices.modules.get_mut(&module_decl.name) {
-                    Some(ref mut module) => {
+                    Some(module) => {
                         module.module_decl = module_decl;
                         module.listing_src = listing_src;
                         module.local_extensible_predicates = local_extensible_predicates;
@@ -641,7 +641,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             }
                         }
                         CompilationTarget::Module(module_name) => {
-                            if let Some(ref mut module) =
+                            if let Some(module) =
                                 self.wam_prelude.indices.modules.get_mut(&module_name)
                                 && let Some(skeleton) = module.extensible_predicates.get_mut(&key)
                             {
@@ -660,7 +660,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             }
                         }
                         CompilationTarget::Module(module_name) => {
-                            if let Some(ref mut module) =
+                            if let Some(module) =
                                 self.wam_prelude.indices.modules.get_mut(&module_name)
                                 && let Some(skeleton) = module.extensible_predicates.get_mut(&key)
                             {
@@ -680,7 +680,7 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                             }
                         }
                         CompilationTarget::Module(module_name) => {
-                            if let Some(ref mut module) =
+                            if let Some(module) =
                                 self.wam_prelude.indices.modules.get_mut(&module_name)
                                 && let Some(skeleton) = module.extensible_predicates.get_mut(&key)
                             {
@@ -690,30 +690,23 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                     }
                 }
                 RetractionRecord::AddedModuleOp(module_name, mut op_decl) => {
-                    if let Some(ref mut module) =
-                        self.wam_prelude.indices.modules.get_mut(&module_name)
-                    {
+                    if let Some(module) = self.wam_prelude.indices.modules.get_mut(&module_name) {
                         op_decl.remove(&mut module.op_dir);
                     }
                 }
                 RetractionRecord::ReplacedModuleOp(module_name, mut op_decl, op_desc) => {
-                    if let Some(ref mut module) =
-                        self.wam_prelude.indices.modules.get_mut(&module_name)
-                    {
+                    if let Some(module) = self.wam_prelude.indices.modules.get_mut(&module_name) {
                         op_decl.op_desc = op_desc;
                         op_decl.insert_into_op_dir(&mut module.op_dir);
                     }
                 }
                 RetractionRecord::AddedModulePredicate(module_name, key) => {
-                    if let Some(ref mut module) =
-                        self.wam_prelude.indices.modules.get_mut(&module_name)
-                    {
+                    if let Some(module) = self.wam_prelude.indices.modules.get_mut(&module_name) {
                         module.code_dir.swap_remove(&key);
                     }
                 }
                 RetractionRecord::ReplacedModulePredicate(module_name, key, old_code_idx) => {
-                    if let Some(ref mut module) =
-                        self.wam_prelude.indices.modules.get_mut(&module_name)
+                    if let Some(module) = self.wam_prelude.indices.modules.get_mut(&module_name)
                         && let Some(code_idx) = module.code_dir.get_mut(&key)
                     {
                         let code_index_tbl =
@@ -792,10 +785,10 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                     // write the retraction logic of this arm.
                 }
                 RetractionRecord::ReplacedChoiceOffset(instr_loc, offset) => {
-                    match self.wam_prelude.code[instr_loc] {
-                        Instruction::TryMeElse(ref mut o)
-                        | Instruction::RetryMeElse(ref mut o)
-                        | Instruction::DefaultRetryMeElse(ref mut o) => {
+                    match &mut self.wam_prelude.code[instr_loc] {
+                        Instruction::TryMeElse(o)
+                        | Instruction::RetryMeElse(o)
+                        | Instruction::DefaultRetryMeElse(o) => {
                             *o = offset;
                         }
                         _ => {
@@ -811,8 +804,8 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                     };
                 }
                 RetractionRecord::ReplacedSwitchOnTermVarIndex(index_loc, old_v) => {
-                    if let Instruction::IndexingCode(ref mut indexing_code) =
-                        self.wam_prelude.code[index_loc]
+                    if let Instruction::IndexingCode(indexing_code) =
+                        &mut self.wam_prelude.code[index_loc]
                         && let IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(_, v, ..)) =
                             &mut indexing_code[0]
                     {
@@ -1009,18 +1002,18 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                     }
                 }
                 RetractionRecord::ReplacedDynamicElseOffset(instr_loc, next) => {
-                    match self.wam_prelude.code[instr_loc] {
-                        Instruction::DynamicElse(_, _, NextOrFail::Next(ref mut o))
-                        | Instruction::DynamicInternalElse(_, _, NextOrFail::Next(ref mut o)) => {
+                    match &mut self.wam_prelude.code[instr_loc] {
+                        Instruction::DynamicElse(_, _, NextOrFail::Next(o))
+                        | Instruction::DynamicInternalElse(_, _, NextOrFail::Next(o)) => {
                             *o = next;
                         }
                         _ => {}
                     }
                 }
                 RetractionRecord::AppendedNextOrFail(instr_loc, fail) => {
-                    match self.wam_prelude.code[instr_loc] {
-                        Instruction::DynamicElse(_, _, ref mut next_or_fail)
-                        | Instruction::DynamicInternalElse(_, _, ref mut next_or_fail) => {
+                    match &mut self.wam_prelude.code[instr_loc] {
+                        Instruction::DynamicElse(_, _, next_or_fail)
+                        | Instruction::DynamicInternalElse(_, _, next_or_fail) => {
                             *next_or_fail = fail;
                         }
                         _ => {}
@@ -1100,8 +1093,8 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
             }
             CompilationTarget::Module(module_name) => {
                 match self.wam_prelude.indices.modules.get_mut(module_name) {
-                    Some(ref mut module) => match module.extensible_predicates.get_mut(&key) {
-                        Some(ref mut skeleton) => {
+                    Some(module) => match module.extensible_predicates.get_mut(&key) {
+                        Some(skeleton) => {
                             if !*flag_accessor(&mut skeleton.core) {
                                 *flag_accessor(&mut skeleton.core) = true;
 

--- a/src/machine/loader.rs
+++ b/src/machine/loader.rs
@@ -342,14 +342,13 @@ impl<'a> LoadState<'a> for LiveLoadAndMachineState<'a> {
             return Err(SessionError::CannotOverwriteBuiltIn(key));
         }
 
-        if let Some(builtins) = loader.wam_prelude.indices.modules.get(&atom!("builtins")) {
-            if builtins
+        if let Some(builtins) = loader.wam_prelude.indices.modules.get(&atom!("builtins"))
+            && builtins
                 .module_decl
                 .exports
                 .contains(&ModuleExport::PredicateKey(key))
-            {
-                return Err(SessionError::CannotOverwriteBuiltIn(key));
-            }
+        {
+            return Err(SessionError::CannotOverwriteBuiltIn(key));
         }
 
         Ok(())
@@ -644,10 +643,9 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         CompilationTarget::Module(module_name) => {
                             if let Some(ref mut module) =
                                 self.wam_prelude.indices.modules.get_mut(&module_name)
+                                && let Some(skeleton) = module.extensible_predicates.get_mut(&key)
                             {
-                                if let Some(skeleton) = module.extensible_predicates.get_mut(&key) {
-                                    skeleton.core.is_discontiguous = false;
-                                }
+                                skeleton.core.is_discontiguous = false;
                             }
                         }
                     }
@@ -664,12 +662,11 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         CompilationTarget::Module(module_name) => {
                             if let Some(ref mut module) =
                                 self.wam_prelude.indices.modules.get_mut(&module_name)
+                                && let Some(skeleton) = module.extensible_predicates.get_mut(&key)
                             {
-                                if let Some(skeleton) = module.extensible_predicates.get_mut(&key) {
-                                    skeleton.core.is_dynamic = false;
-                                    skeleton.core.retracted_dynamic_clauses = None;
-                                };
-                            }
+                                skeleton.core.is_dynamic = false;
+                                skeleton.core.retracted_dynamic_clauses = None;
+                            };
                         }
                     }
                 }
@@ -685,10 +682,9 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         CompilationTarget::Module(module_name) => {
                             if let Some(ref mut module) =
                                 self.wam_prelude.indices.modules.get_mut(&module_name)
+                                && let Some(skeleton) = module.extensible_predicates.get_mut(&key)
                             {
-                                if let Some(skeleton) = module.extensible_predicates.get_mut(&key) {
-                                    skeleton.core.is_multifile = false;
-                                }
+                                skeleton.core.is_multifile = false;
                             }
                         }
                     }
@@ -718,12 +714,11 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 RetractionRecord::ReplacedModulePredicate(module_name, key, old_code_idx) => {
                     if let Some(ref mut module) =
                         self.wam_prelude.indices.modules.get_mut(&module_name)
+                        && let Some(code_idx) = module.code_dir.get_mut(&key)
                     {
-                        if let Some(code_idx) = module.code_dir.get_mut(&key) {
-                            let code_index_tbl =
-                                &mut LS::machine_st(&mut self.payload).arena.code_index_tbl;
-                            code_idx.set(code_index_tbl, old_code_idx);
-                        }
+                        let code_index_tbl =
+                            &mut LS::machine_st(&mut self.payload).arena.code_index_tbl;
+                        code_idx.set(code_index_tbl, old_code_idx);
                     }
                 }
                 RetractionRecord::AddedExtensiblePredicate(compilation_target, key) => {
@@ -818,12 +813,10 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                 RetractionRecord::ReplacedSwitchOnTermVarIndex(index_loc, old_v) => {
                     if let Instruction::IndexingCode(ref mut indexing_code) =
                         self.wam_prelude.code[index_loc]
-                    {
-                        if let IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(_, v, ..)) =
+                        && let IndexingLine::Indexing(IndexingInstruction::SwitchOnTerm(_, v, ..)) =
                             &mut indexing_code[0]
-                        {
-                            *v = old_v;
-                        }
+                    {
+                        *v = old_v;
                     }
                 }
                 RetractionRecord::ModifiedTryMeElse(instr_loc, o) => {
@@ -945,18 +938,16 @@ impl<'a, LS: LoadState<'a>> Loader<'a, LS> {
                         .wam_prelude
                         .indices
                         .get_predicate_skeleton_mut(&compilation_target, &key)
+                        && let Some(removed_clauses) = &mut skeleton.core.retracted_dynamic_clauses
                     {
-                        if let Some(removed_clauses) = &mut skeleton.core.retracted_dynamic_clauses
-                        {
-                            let clause_index_info = removed_clauses.pop().unwrap();
+                        let clause_index_info = removed_clauses.pop().unwrap();
 
-                            skeleton
-                                .core
-                                .clause_clause_locs
-                                .insert(target_pos, clause_clause_loc);
+                        skeleton
+                            .core
+                            .clause_clause_locs
+                            .insert(target_pos, clause_clause_loc);
 
-                            skeleton.clauses.insert(target_pos, clause_index_info);
-                        }
+                        skeleton.clauses.insert(target_pos, clause_index_info);
                     }
                 }
                 RetractionRecord::RemovedSkeletonClause(
@@ -1667,14 +1658,14 @@ impl Machine {
                 None => None,
             };
 
-            if let Some(indexing_term) = indexing_arg {
-                if let Some(indexing_name) = indexing_term.name() {
-                    loader
-                        .wam_prelude
-                        .indices
-                        .goal_expansion_indices
-                        .insert((indexing_name, indexing_term.arity()));
-                }
+            if let Some(indexing_term) = indexing_arg
+                && let Some(indexing_name) = indexing_term.name()
+            {
+                loader
+                    .wam_prelude
+                    .indices
+                    .goal_expansion_indices
+                    .insert((indexing_name, indexing_term.arity()));
             }
 
             loader.incremental_compile_clause(
@@ -1932,16 +1923,15 @@ impl Machine {
     }
 
     pub(crate) fn load_context_directory(&mut self) {
-        if let Some(load_context) = self.load_contexts.last() {
-            if let Some(directory) = load_context.path.parent() {
-                let directory_str = directory.to_str().unwrap();
-                let directory_atom =
-                    AtomTable::build_with(&self.machine_st.atom_tbl, directory_str);
+        if let Some(load_context) = self.load_contexts.last()
+            && let Some(directory) = load_context.path.parent()
+        {
+            let directory_str = directory.to_str().unwrap();
+            let directory_atom = AtomTable::build_with(&self.machine_st.atom_tbl, directory_str);
 
-                self.machine_st
-                    .unify_atom(directory_atom, self.machine_st.registers[1]);
-                return;
-            }
+            self.machine_st
+                .unify_atom(directory_atom, self.machine_st.registers[1]);
+            return;
         }
 
         self.machine_st.fail = true;

--- a/src/machine/machine_state.rs
+++ b/src/machine/machine_state.rs
@@ -580,23 +580,21 @@ impl MachineState {
 
             read_heap_cell!(addr,
                 (HeapCellValueTag::Atom, (name, arity)) => {
-                    if arity == 0 {
-                        if let Some(c) = name.as_char() {
+                    if arity == 0
+                        && let Some(c) = name.as_char() {
                             chars.push(c);
                             continue;
                         }
-                    }
                 }
                 (HeapCellValueTag::Str, s) => {
                     let (name, arity) = cell_as_atom_cell!(self.heap[s])
                         .get_name_and_arity();
 
-                    if arity == 0 {
-                        if let Some(c) = name.as_char() {
+                    if arity == 0
+                        && let Some(c) = name.as_char() {
                             chars.push(c);
                             continue;
                         }
-                    }
                 }
                 _ => {
                 }
@@ -751,10 +749,10 @@ impl MachineState {
         let mut var_list = Vec::with_capacity(singleton_var_set.len());
 
         for (var_name, addr) in term_write_result.var_dict {
-            if let Some(var) = addr.as_var() {
-                if let Some(idx) = singleton_var_set.get_index_of(&var) {
-                    var_list.push((var_name, addr, idx));
-                }
+            if let Some(var) = addr.as_var()
+                && let Some(idx) = singleton_var_set.get_index_of(&var)
+            {
+                var_list.push((var_name, addr, idx));
             }
         }
 
@@ -1142,10 +1140,10 @@ impl CWIL {
 
     #[inline(always)]
     pub(crate) fn remove_limit(&mut self, block: usize) -> u128 {
-        if let Some((_, bl)) = self.limits.last() {
-            if bl == &block {
-                self.limits.pop();
-            }
+        if let Some((_, bl)) = self.limits.last()
+            && bl == &block
+        {
+            self.limits.pop();
         }
 
         self.local_count

--- a/src/machine/machine_state_impl.rs
+++ b/src/machine/machine_state_impl.rs
@@ -988,12 +988,4 @@ impl MachineState {
 
         self.p += 1;
     }
-
-    pub fn throw_interrupt_exception(&mut self) {
-        let err = self.interrupt_error();
-        let src = functor_stub(atom!("repl"), 0);
-        let err = self.error_form(err, src);
-
-        self.throw_exception(err);
-    }
 }

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -244,45 +244,45 @@ impl Machine {
         module_name: Atom,
         key: PredicateKey,
     ) -> std::process::ExitCode {
-        if let Some(module) = self.indices.modules.get(&module_name) {
-            if let Some(code_idx) = module.code_dir.get(&key) {
-                let index_ptr = self
-                    .machine_st
-                    .arena
-                    .code_index_tbl
-                    .get_entry(code_idx.into());
-                let p = index_ptr.local().unwrap();
+        if let Some(module) = self.indices.modules.get(&module_name)
+            && let Some(code_idx) = module.code_dir.get(&key)
+        {
+            let index_ptr = self
+                .machine_st
+                .arena
+                .code_index_tbl
+                .get_entry(code_idx.into());
+            let p = index_ptr.local().unwrap();
 
-                // Leave a halting choice point to backtrack to in case the predicate fails or throws.
-                if self.allocate_stub_choice_point().is_err() {
-                    return ExitCode::FAILURE;
-                }
-
-                let stub_b = self.machine_st.b;
-                self.machine_st.cp = BREAK_FROM_DISPATCH_LOOP_LOC;
-                self.machine_st.p = p;
-
-                let exit_code = self.dispatch_loop();
-
-                if self.machine_st.b == stub_b {
-                    // The synthetic choice point is only a dispatch-loop sentinel
-                    // for this deterministic call; do not retain its stack frame.
-                    let stub_frame = self.machine_st.stack.index_or_frame(stub_b);
-                    let b = stub_frame.prelude.b;
-                    let b0 = stub_frame.prelude.b0;
-                    let tr = stub_frame.prelude.tr;
-                    let h = stub_frame.prelude.h;
-
-                    self.machine_st.b = b;
-                    self.machine_st.b0 = b0;
-                    self.machine_st.tr = tr;
-                    self.machine_st.trail.truncate(tr);
-                    self.machine_st.hb = h;
-                    self.machine_st.stack.truncate(stub_b);
-                }
-
-                return exit_code;
+            // Leave a halting choice point to backtrack to in case the predicate fails or throws.
+            if self.allocate_stub_choice_point().is_err() {
+                return ExitCode::FAILURE;
             }
+
+            let stub_b = self.machine_st.b;
+            self.machine_st.cp = BREAK_FROM_DISPATCH_LOOP_LOC;
+            self.machine_st.p = p;
+
+            let exit_code = self.dispatch_loop();
+
+            if self.machine_st.b == stub_b {
+                // The synthetic choice point is only a dispatch-loop sentinel
+                // for this deterministic call; do not retain its stack frame.
+                let stub_frame = self.machine_st.stack.index_or_frame(stub_b);
+                let b = stub_frame.prelude.b;
+                let b0 = stub_frame.prelude.b0;
+                let tr = stub_frame.prelude.tr;
+                let h = stub_frame.prelude.h;
+
+                self.machine_st.b = b;
+                self.machine_st.b0 = b0;
+                self.machine_st.tr = tr;
+                self.machine_st.trail.truncate(tr);
+                self.machine_st.hb = h;
+                self.machine_st.stack.truncate(stub_b);
+            }
+
+            return exit_code;
         }
 
         unreachable!();
@@ -344,15 +344,15 @@ impl Machine {
 
         self.load_file(path_buf.to_str().unwrap(), stream);
 
-        if let Some(module) = self.indices.modules.get(&atom!("$atts")) {
-            if let Some(code_idx) = module.code_dir.get(&(atom!("driver"), 2)) {
-                let index_ptr = self
-                    .machine_st
-                    .arena
-                    .code_index_tbl
-                    .get_entry(code_idx.into());
-                self.machine_st.attr_var_init.verify_attrs_loc = index_ptr.local().unwrap();
-            }
+        if let Some(module) = self.indices.modules.get(&atom!("$atts"))
+            && let Some(code_idx) = module.code_dir.get(&(atom!("driver"), 2))
+        {
+            let index_ptr = self
+                .machine_st
+                .arena
+                .code_index_tbl
+                .get_entry(code_idx.into());
+            self.machine_st.attr_var_init.verify_attrs_loc = index_ptr.local().unwrap();
         }
     }
 
@@ -1182,22 +1182,22 @@ impl Machine {
             (r_c_w_h, r_c_wo_h)
         });
 
-        if let Some(&(_, b_cutoff, prev_block)) = self.machine_st.cont_pts.last() {
-            if self.machine_st.b < b_cutoff {
-                let (idx, arity) = if self.machine_st.effective_block() > prev_block {
-                    (r_c_w_h, 0)
-                } else {
-                    self.machine_st.registers[1] = fixnum_as_cell!(
-                        /* FIXME this is not safe */
-                        unsafe { Fixnum::build_with_unchecked(b_cutoff as i64) }
-                    );
+        if let Some(&(_, b_cutoff, prev_block)) = self.machine_st.cont_pts.last()
+            && self.machine_st.b < b_cutoff
+        {
+            let (idx, arity) = if self.machine_st.effective_block() > prev_block {
+                (r_c_w_h, 0)
+            } else {
+                self.machine_st.registers[1] = fixnum_as_cell!(
+                    /* FIXME this is not safe */
+                    unsafe { Fixnum::build_with_unchecked(b_cutoff as i64) }
+                );
 
-                    (r_c_wo_h, 1)
-                };
+                (r_c_wo_h, 1)
+            };
 
-                self.machine_st.call_at_index(arity, idx);
-                return true;
-            }
+            self.machine_st.call_at_index(arity, idx);
+            return true;
         }
 
         false

--- a/src/machine/preprocessor.rs
+++ b/src/machine/preprocessor.rs
@@ -362,104 +362,102 @@ fn build_meta_predicate_clause<'a, LS: LoadState<'a>>(
     let mut arg_terms = Vec::with_capacity(terms.len());
 
     for (term, meta_spec) in terms.into_iter().zip(meta_specs.iter()) {
-        if let MetaSpec::RequiresExpansionWithArgument(supp_args) = meta_spec {
-            if let Some(name) = term.name() {
-                if name == atom!("$call") {
-                    arg_terms.push(term);
-                    continue;
-                }
-
-                let arity = term.arity();
-
-                fn get_qualified_name(
-                    module_term: &Term,
-                    qualified_term: &Term,
-                ) -> Option<(Atom, Atom)> {
-                    if let Term::Literal(_, Literal::Atom(module_name)) = module_term {
-                        if let Some(name) = qualified_term.name() {
-                            return Some((*module_name, name));
-                        }
-                    }
-
-                    None
-                }
-
-                fn identity_fn(_module_name: Atom, term: Term) -> Term {
-                    term
-                }
-
-                fn tag_with_module_name(module_name: Atom, term: Term) -> Term {
-                    Term::Clause(
-                        Cell::default(),
-                        atom!(":"),
-                        vec![
-                            Term::Literal(Cell::default(), Literal::Atom(module_name)),
-                            term,
-                        ],
-                    )
-                }
-
-                let process_term: fn(Atom, Term) -> Term;
-
-                let (module_name, key, term) = match term {
-                    Term::Clause(cell, atom!(":"), mut terms) if terms.len() == 2 => {
-                        if let Some((module_name, name)) = get_qualified_name(&terms[0], &terms[1])
-                        {
-                            process_term = tag_with_module_name;
-                            (
-                                module_name,
-                                (name, terms[1].arity() + supp_args),
-                                terms.pop().unwrap(),
-                            )
-                        } else {
-                            arg_terms.push(Term::Clause(cell, atom!(":"), terms));
-                            continue;
-                        }
-                    }
-                    term => {
-                        process_term = identity_fn;
-                        (module_name, (name, arity + supp_args), term)
-                    }
-                };
-
-                let term = match term {
-                    Term::Clause(cell, name, mut terms) => {
-                        if let Some(Term::Literal(_, Literal::CodeIndexOffset(_))) = terms.last() {
-                            arg_terms
-                                .push(process_term(module_name, Term::Clause(cell, name, terms)));
-
-                            continue;
-                        }
-
-                        let idx = loader.get_or_insert_qualified_code_index(module_name, key);
-
-                        terms.push(Term::Literal(
-                            Cell::default(),
-                            Literal::CodeIndexOffset(idx.into()),
-                        ));
-                        process_term(module_name, Term::Clause(cell, name, terms))
-                    }
-                    Term::Literal(cell, Literal::Atom(name)) => {
-                        let idx = loader.get_or_insert_qualified_code_index(module_name, key);
-
-                        process_term(
-                            module_name,
-                            Term::Clause(
-                                cell,
-                                name,
-                                vec![Term::Literal(
-                                    Cell::default(),
-                                    Literal::CodeIndexOffset(idx.into()),
-                                )],
-                            ),
-                        )
-                    }
-                    term => term,
-                };
-
+        if let MetaSpec::RequiresExpansionWithArgument(supp_args) = meta_spec
+            && let Some(name) = term.name()
+        {
+            if name == atom!("$call") {
                 arg_terms.push(term);
                 continue;
             }
+
+            let arity = term.arity();
+
+            fn get_qualified_name(
+                module_term: &Term,
+                qualified_term: &Term,
+            ) -> Option<(Atom, Atom)> {
+                if let Term::Literal(_, Literal::Atom(module_name)) = module_term
+                    && let Some(name) = qualified_term.name()
+                {
+                    return Some((*module_name, name));
+                }
+
+                None
+            }
+
+            fn identity_fn(_module_name: Atom, term: Term) -> Term {
+                term
+            }
+
+            fn tag_with_module_name(module_name: Atom, term: Term) -> Term {
+                Term::Clause(
+                    Cell::default(),
+                    atom!(":"),
+                    vec![
+                        Term::Literal(Cell::default(), Literal::Atom(module_name)),
+                        term,
+                    ],
+                )
+            }
+
+            let process_term: fn(Atom, Term) -> Term;
+
+            let (module_name, key, term) = match term {
+                Term::Clause(cell, atom!(":"), mut terms) if terms.len() == 2 => {
+                    if let Some((module_name, name)) = get_qualified_name(&terms[0], &terms[1]) {
+                        process_term = tag_with_module_name;
+                        (
+                            module_name,
+                            (name, terms[1].arity() + supp_args),
+                            terms.pop().unwrap(),
+                        )
+                    } else {
+                        arg_terms.push(Term::Clause(cell, atom!(":"), terms));
+                        continue;
+                    }
+                }
+                term => {
+                    process_term = identity_fn;
+                    (module_name, (name, arity + supp_args), term)
+                }
+            };
+
+            let term = match term {
+                Term::Clause(cell, name, mut terms) => {
+                    if let Some(Term::Literal(_, Literal::CodeIndexOffset(_))) = terms.last() {
+                        arg_terms.push(process_term(module_name, Term::Clause(cell, name, terms)));
+
+                        continue;
+                    }
+
+                    let idx = loader.get_or_insert_qualified_code_index(module_name, key);
+
+                    terms.push(Term::Literal(
+                        Cell::default(),
+                        Literal::CodeIndexOffset(idx.into()),
+                    ));
+                    process_term(module_name, Term::Clause(cell, name, terms))
+                }
+                Term::Literal(cell, Literal::Atom(name)) => {
+                    let idx = loader.get_or_insert_qualified_code_index(module_name, key);
+
+                    process_term(
+                        module_name,
+                        Term::Clause(
+                            cell,
+                            name,
+                            vec![Term::Literal(
+                                Cell::default(),
+                                Literal::CodeIndexOffset(idx.into()),
+                            )],
+                        ),
+                    )
+                }
+                term => term,
+            };
+
+            arg_terms.push(term);
+            continue;
         }
 
         arg_terms.push(term);

--- a/src/machine/streams.rs
+++ b/src/machine/streams.rs
@@ -2073,10 +2073,10 @@ impl MachineState {
             return Err(self.stream_permission_error(permission, err_atom, stream, caller, arity));
         }
 
-        if let Some(input) = input {
-            if stream.past_end_of_stream() {
-                self.eof_action(input, stream, caller, arity)?;
-            }
+        if let Some(input) = input
+            && stream.past_end_of_stream()
+        {
+            self.eof_action(input, stream, caller, arity)?;
         }
 
         Ok(())
@@ -2096,10 +2096,10 @@ impl MachineState {
         }
 
         // 8.11.5.3l)
-        if let Some(alias) = options.get_alias() {
-            if indices.has_stream(alias) {
-                return Err(self.occupied_alias_permission_error(alias, atom!("open"), 4));
-            }
+        if let Some(alias) = options.get_alias()
+            && indices.has_stream(alias)
+        {
+            return Err(self.occupied_alias_permission_error(alias, atom!("open"), 4));
         }
 
         let mode = cell_as_atom!(self.store(MachineState::deref(self, self.registers[2])));
@@ -2172,13 +2172,12 @@ impl MachineState {
                 }
             };
 
-            if path.extension().is_none() {
-                if let Ok(metadata) = file.metadata() {
-                    if metadata.is_dir() {
-                        path.set_extension("pl");
-                        continue;
-                    }
-                }
+            if path.extension().is_none()
+                && let Ok(metadata) = file.metadata()
+                && metadata.is_dir()
+            {
+                path.set_extension("pl");
+                continue;
             }
 
             return Ok(if is_input_file {

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -3932,7 +3932,7 @@ impl Machine {
     }
 
     fn parse_module_name(module_name: HeapCellValue) -> Atom {
-        return read_heap_cell!(module_name,
+        read_heap_cell!(module_name,
             (HeapCellValueTag::Atom, (module_name, _arity)) => {
                 module_name
             }
@@ -3942,7 +3942,7 @@ impl Machine {
             _ => {
                 unreachable!()
             }
-        );
+        )
     }
 
     fn user_predicate_exists(&self, name: Atom, arity: usize, module_name: Atom) -> bool {
@@ -3963,7 +3963,7 @@ impl Machine {
 
             return !index_ptr.is_undefined();
         };
-        return false;
+        false
     }
 
     #[inline(always)]
@@ -4411,27 +4411,24 @@ impl Machine {
         }
         let stub_gen = || functor_stub(atom!("http_open"), 3);
 
-        let headers = match self
-            .machine_st
-            .try_from_list(self.machine_st.registers[7], stub_gen)
-        {
-            Ok(addrs) => {
-                let mut header_map = HeaderMap::new();
-                for heap_cell in addrs {
-                    read_heap_cell!(heap_cell,
-                        (HeapCellValueTag::Str, s) => {
-                            let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
-                            let value = self.machine_st.value_to_str_like(self.machine_st.heap[s + 1]).unwrap();
-                            header_map.insert(HeaderName::from_str(&name.as_str()).unwrap(), HeaderValue::from_str(&value.as_str()).unwrap());
-                        }
-                        _ => {
-                            unreachable!()
-                        }
-                    )
-                }
-                header_map
+        let headers = {
+            let addrs = self
+                .machine_st
+                .try_from_list(self.machine_st.registers[7], stub_gen)?;
+            let mut header_map = HeaderMap::new();
+            for heap_cell in addrs {
+                read_heap_cell!(heap_cell,
+                    (HeapCellValueTag::Str, s) => {
+                        let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
+                        let value = self.machine_st.value_to_str_like(self.machine_st.heap[s + 1]).unwrap();
+                        header_map.insert(HeaderName::from_str(&name.as_str()).unwrap(), HeaderValue::from_str(&value.as_str()).unwrap());
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                )
             }
-            Err(e) => return Err(e),
+            header_map
         };
         if let Some(address_sink) = self.machine_st.value_to_str_like(address_sink) {
             let address_string = address_sink.as_str(); //to_string();
@@ -4868,27 +4865,24 @@ impl Machine {
             _ => unreachable!(),
         };
         let stub_gen = || functor_stub(atom!("http_listen"), 2);
-        let headers = match self
-            .machine_st
-            .try_from_list(self.machine_st.registers[3], stub_gen)
-        {
-            Ok(addrs) => {
-                let mut header_map = HeaderMap::new();
-                for heap_cell in addrs {
-                    read_heap_cell!(heap_cell,
-                        (HeapCellValueTag::Str, s) => {
-                            let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
-                            let value = self.machine_st.value_to_str_like(self.machine_st.heap[s + 1]).unwrap();
-                            header_map.insert(HeaderName::from_str(&name.as_str()).unwrap(), HeaderValue::from_str(&value.as_str()).unwrap());
-                        }
-                        _ => {
-                            unreachable!()
-                        }
-                    )
-                }
-                header_map
+        let headers = {
+            let addrs = self
+                .machine_st
+                .try_from_list(self.machine_st.registers[3], stub_gen)?;
+            let mut header_map = HeaderMap::new();
+            for heap_cell in addrs {
+                read_heap_cell!(heap_cell,
+                    (HeapCellValueTag::Str, s) => {
+                        let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
+                        let value = self.machine_st.value_to_str_like(self.machine_st.heap[s + 1]).unwrap();
+                        header_map.insert(HeaderName::from_str(&name.as_str()).unwrap(), HeaderValue::from_str(&value.as_str()).unwrap());
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                )
             }
-            Err(e) => return Err(e),
+            header_map
         };
         let stream_addr = self.deref_register(4);
 
@@ -4941,22 +4935,20 @@ impl Machine {
                             read_heap_cell!(heap_cell,
                                 (HeapCellValueTag::Str, s) => {
                                     let name = cell_as_atom_cell!(self.machine_st.heap[s]).get_name();
-                                let args: Vec<Atom> = match self.machine_st.try_from_list(self.machine_st.heap[s + 1], stub_gen) {
-                                    Ok(addrs) => {
-                                    let mut args = Vec::new();
-                                    for heap_cell in addrs {
-                                        args.push(cell_as_atom_cell!(heap_cell).get_name());
-                                    }
-                                    args
-                                    }
-                                    Err(e) => return Err(e)
-                                };
-                                let return_value = cell_as_atom_cell!(self.machine_st.heap[s + 2]);
-                                functions.push(FunctionDefinition {
-                                    name,
-                                    args,
-                                    return_value: return_value.get_name(),
-                                });
+                                    let args: Vec<Atom> = {
+                                        let addrs = self.machine_st.try_from_list(self.machine_st.heap[s + 1], stub_gen)?;
+                                        let mut args = Vec::new();
+                                        for heap_cell in addrs {
+                                            args.push(cell_as_atom_cell!(heap_cell).get_name());
+                                        }
+                                        args
+                                    };
+                                    let return_value = cell_as_atom_cell!(self.machine_st.heap[s + 2]);
+                                    functions.push(FunctionDefinition {
+                                        name,
+                                        args,
+                                        return_value: return_value.get_name(),
+                                    });
                                 }
                                 _ => {
                                     let err = self.machine_st.unreachable_error();
@@ -5199,26 +5191,24 @@ impl Machine {
             let struct_name_arg = self.machine_st.store(self.deref_register(1));
             let fields_reg = self.deref_register(2);
             if let Some(struct_name) = struct_name_arg.to_atom() {
-                let fields: Vec<Atom> = match self.machine_st.try_from_list(fields_reg, stub_gen) {
-                    Ok(addrs) => {
-                        let mut args = Vec::new();
-                        for heap_cell in addrs {
-                            let arg_cell = self.machine_st.store(self.machine_st.deref(heap_cell));
-                            let Some(arg) = arg_cell.to_atom() else {
-                                let err = if arg_cell.is_var() {
-                                    self.machine_st.instantiation_error()
-                                } else {
-                                    self.machine_st.type_error(ValidType::Atom, heap_cell)
-                                };
-
-                                return Err(self.machine_st.error_form(err, stub_gen()));
+                let fields: Vec<Atom> = {
+                    let addrs = self.machine_st.try_from_list(fields_reg, stub_gen)?;
+                    let mut args = Vec::new();
+                    for heap_cell in addrs {
+                        let arg_cell = self.machine_st.store(self.machine_st.deref(heap_cell));
+                        let Some(arg) = arg_cell.to_atom() else {
+                            let err = if arg_cell.is_var() {
+                                self.machine_st.instantiation_error()
+                            } else {
+                                self.machine_st.type_error(ValidType::Atom, heap_cell)
                             };
 
-                            args.push(arg);
-                        }
-                        args
+                            return Err(self.machine_st.error_form(err, stub_gen()));
+                        };
+
+                        args.push(arg);
                     }
-                    Err(e) => return Err(e),
+                    args
                 };
                 self.foreign_function_table
                     .define_struct(struct_name, fields)

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -6957,7 +6957,8 @@ impl Machine {
             std::thread::sleep(step);
             remaining -= step;
 
-            if self.interrupt_occured() {
+            if self.machine_st.check_for_interrupt() {
+                // FIXME check_for_interrupt already throws an interrupt error
                 let err = self.machine_st.interrupt_error();
                 let src = functor_stub(atom!("repl"), 0);
                 return Err(self.machine_st.error_form(err, src));

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -1119,11 +1119,11 @@ impl MachineState {
 
             match Number::try_from((addr, &self.arena.f64_tbl)) {
                 Ok(Number::Fixnum(n)) => {
-                    if let Ok(n) = u32::try_from(n.get_num()) {
-                        if let Some(c) = std::char::from_u32(n) {
-                            string.push(c);
-                            continue;
-                        }
+                    if let Ok(n) = u32::try_from(n.get_num())
+                        && let Some(c) = std::char::from_u32(n)
+                    {
+                        string.push(c);
+                        continue;
                     }
                 }
                 Ok(Number::Integer(n)) => {
@@ -1856,14 +1856,14 @@ impl Machine {
             }
         };
 
-        if let Some(n) = n {
-            if n <= MAX_ARITY {
-                let target = self.machine_st.registers[n];
-                let addr = self.machine_st.registers[1];
+        if let Some(n) = n
+            && n <= MAX_ARITY
+        {
+            let target = self.machine_st.registers[n];
+            let addr = self.machine_st.registers[1];
 
-                unify_fn!(self.machine_st, addr, target);
-                return;
-            }
+            unify_fn!(self.machine_st, addr, target);
+            return;
         }
 
         self.machine_st.fail = true;
@@ -1872,15 +1872,15 @@ impl Machine {
     #[cfg(all(not(target_arch = "wasm32"), feature = "hostname"))]
     #[inline(always)]
     pub(crate) fn current_hostname(&mut self) {
-        if let Ok(host) = hostname::get() {
-            if let Some(host) = host.to_str() {
-                let hostname = AtomTable::build_with(&self.machine_st.atom_tbl, host);
+        if let Ok(host) = hostname::get()
+            && let Some(host) = host.to_str()
+        {
+            let hostname = AtomTable::build_with(&self.machine_st.atom_tbl, host);
 
-                let a1 = self.deref_register(1);
-                self.machine_st.unify_atom(hostname, a1);
+            let a1 = self.deref_register(1);
+            self.machine_st.unify_atom(hostname, a1);
 
-                return;
-            }
+            return;
         }
 
         self.machine_st.fail = true;
@@ -1970,16 +1970,16 @@ impl Machine {
 
             if let Ok(entries) = fs::read_dir(path) {
                 for entry in entries {
-                    if let Ok(entry) = entry {
-                        if let Some(name) = entry.file_name().to_str() {
-                            let file_string_cell = resource_error_call_result!(
-                                self.machine_st,
-                                self.machine_st.heap.allocate_cstr(name)
-                            );
+                    if let Ok(entry) = entry
+                        && let Some(name) = entry.file_name().to_str()
+                    {
+                        let file_string_cell = resource_error_call_result!(
+                            self.machine_st,
+                            self.machine_st.heap.allocate_cstr(name)
+                        );
 
-                            files.push(file_string_cell);
-                            continue;
-                        }
+                        files.push(file_string_cell);
+                        continue;
                     }
 
                     let stub = functor_stub(atom!("directory_files"), 2);
@@ -2068,25 +2068,25 @@ impl Machine {
         if let Some(file) = self.machine_st.value_to_str_like(self.deref_register(1)) {
             let which = cell_as_atom!(self.deref_register(2));
 
-            if let Ok(md) = fs::metadata(&*file.as_str()) {
-                if let Ok(time) = match which {
+            if let Ok(md) = fs::metadata(&*file.as_str())
+                && let Ok(time) = match which {
                     atom!("modification") => md.modified(),
                     atom!("access") => md.accessed(),
                     atom!("creation") => md.created(),
                     _ => {
                         unreachable!()
                     }
-                } {
-                    let chars_string = self.systemtime_to_timestamp(time);
-
-                    let cstr_cell = step_or_resource_error!(
-                        self.machine_st,
-                        self.machine_st.heap.allocate_cstr(&chars_string)
-                    );
-
-                    unify!(self.machine_st, cstr_cell, self.machine_st.registers[3]);
-                    return;
                 }
+            {
+                let chars_string = self.systemtime_to_timestamp(time);
+
+                let cstr_cell = step_or_resource_error!(
+                    self.machine_st,
+                    self.machine_st.heap.allocate_cstr(&chars_string)
+                );
+
+                unify!(self.machine_st, cstr_cell, self.machine_st.registers[3]);
+                return;
             }
         }
 
@@ -2141,12 +2141,11 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn rename_file(&mut self) {
-        if let Some(file) = self.machine_st.value_to_str_like(self.deref_register(1)) {
-            if let Some(renamed) = self.machine_st.value_to_str_like(self.deref_register(2)) {
-                if fs::rename(&*file.as_str(), &*renamed.as_str()).is_ok() {
-                    return;
-                }
-            }
+        if let Some(file) = self.machine_st.value_to_str_like(self.deref_register(1))
+            && let Some(renamed) = self.machine_st.value_to_str_like(self.deref_register(2))
+            && fs::rename(&*file.as_str(), &*renamed.as_str()).is_ok()
+        {
+            return;
         }
 
         self.machine_st.fail = true;
@@ -2154,12 +2153,11 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn file_copy(&mut self) {
-        if let Some(file) = self.machine_st.value_to_str_like(self.deref_register(1)) {
-            if let Some(copied) = self.machine_st.value_to_str_like(self.deref_register(2)) {
-                if fs::copy(&*file.as_str(), &*copied.as_str()).is_ok() {
-                    return;
-                }
-            }
+        if let Some(file) = self.machine_st.value_to_str_like(self.deref_register(1))
+            && let Some(copied) = self.machine_st.value_to_str_like(self.deref_register(2))
+            && fs::copy(&*file.as_str(), &*copied.as_str()).is_ok()
+        {
+            return;
         }
 
         self.machine_st.fail = true;
@@ -2208,10 +2206,10 @@ impl Machine {
 
             let target = self.deref_register(2);
 
-            if let Some(next) = self.machine_st.value_to_str_like(target) {
-                if env::set_current_dir(std::path::Path::new(&*next.as_str())).is_ok() {
-                    return Ok(());
-                }
+            if let Some(next) = self.machine_st.value_to_str_like(target)
+                && env::set_current_dir(std::path::Path::new(&*next.as_str())).is_ok()
+            {
+                return Ok(());
             }
         }
 
@@ -2221,31 +2219,31 @@ impl Machine {
 
     #[inline(always)]
     pub(crate) fn path_canonical(&mut self) -> CallResult {
-        if let Some(path) = self.machine_st.value_to_str_like(self.deref_register(1)) {
-            if let Ok(canonical) = fs::canonicalize(&*path.as_str()) {
-                let cs = match canonical.to_str() {
-                    Some(s) => s,
-                    _ => {
-                        let stub = functor_stub(atom!("path_canonical"), 2);
-                        let err = self.machine_st.representation_error(RepFlag::Character);
-                        let err = self.machine_st.error_form(err, stub);
+        if let Some(path) = self.machine_st.value_to_str_like(self.deref_register(1))
+            && let Ok(canonical) = fs::canonicalize(&*path.as_str())
+        {
+            let cs = match canonical.to_str() {
+                Some(s) => s,
+                _ => {
+                    let stub = functor_stub(atom!("path_canonical"), 2);
+                    let err = self.machine_st.representation_error(RepFlag::Character);
+                    let err = self.machine_st.error_form(err, stub);
 
-                        return Err(err);
-                    }
-                };
+                    return Err(err);
+                }
+            };
 
-                let canonical_string = resource_error_call_result!(
-                    self.machine_st,
-                    self.machine_st.heap.allocate_cstr(cs)
-                );
+            let canonical_string = resource_error_call_result!(
+                self.machine_st,
+                self.machine_st.heap.allocate_cstr(cs)
+            );
 
-                unify!(
-                    self.machine_st,
-                    canonical_string,
-                    self.machine_st.registers[2]
-                );
-                return Ok(());
-            }
+            unify!(
+                self.machine_st,
+                canonical_string,
+                self.machine_st.registers[2]
+            );
+            return Ok(());
         }
 
         self.machine_st.fail = true;
@@ -2963,12 +2961,11 @@ impl Machine {
                         return Ok(());
                     }
                     Ok(Number::Fixnum(n)) => {
-                        if let Ok(n) = u32::try_from(n.get_num()) {
-                            if let Some(c) = std::char::from_u32(n) {
+                        if let Ok(n) = u32::try_from(n.get_num())
+                            && let Some(c) = std::char::from_u32(n) {
                                 self.machine_st.unify_char(c, a1);
                                 return Ok(());
                             }
-                        }
 
                         let err = self.machine_st.representation_error(RepFlag::CharacterCode);
                         return Err(self.machine_st.error_form(err, stub_gen()));
@@ -4624,13 +4621,13 @@ impl Machine {
                           headers: warp::http::HeaderMap,
                           path: warp::filters::path::FullPath,
                           query| {
-                        if let Some(content_length) = content_length {
-                            if content_length > content_length_limit {
-                                return warp::http::Response::builder()
-                                    .status(413)
-                                    .body(warp::hyper::Body::empty())
-                                    .unwrap();
-                            }
+                        if let Some(content_length) = content_length
+                            && content_length > content_length_limit
+                        {
+                            return warp::http::Response::builder()
+                                .status(413)
+                                .body(warp::hyper::Body::empty())
+                                .unwrap();
                         }
 
                         let http_request_data = HttpRequestData {
@@ -7022,14 +7019,14 @@ impl Machine {
                 .reposition_error(atom!("socket_client_open"), 3));
         }
 
-        if let Some(alias) = options.get_alias() {
-            if self.indices.has_stream(alias) {
-                return Err(self.machine_st.occupied_alias_permission_error(
-                    alias,
-                    atom!("socket_client_open"),
-                    3,
-                ));
-            }
+        if let Some(alias) = options.get_alias()
+            && self.indices.has_stream(alias)
+        {
+            return Err(self.machine_st.occupied_alias_permission_error(
+                alias,
+                atom!("socket_client_open"),
+                3,
+            ));
         }
 
         let stream = match TcpStream::connect(&*socket_addr.as_str()).map_err(|e| e.kind()) {
@@ -7163,14 +7160,14 @@ impl Machine {
                 .reposition_error(atom!("socket_server_accept"), 4));
         }
 
-        if let Some(alias) = options.get_alias() {
-            if self.indices.has_stream(alias) {
-                return Err(self.machine_st.occupied_alias_permission_error(
-                    alias,
-                    atom!("socket_server_accept"),
-                    4,
-                ));
-            }
+        if let Some(alias) = options.get_alias()
+            && self.indices.has_stream(alias)
+        {
+            return Err(self.machine_st.occupied_alias_permission_error(
+                alias,
+                atom!("socket_server_accept"),
+                4,
+            ));
         }
 
         let culprit = self.deref_register(1);
@@ -9288,16 +9285,14 @@ impl Machine {
             }
         };
 
-        if path.is_dir() {
-            if let Some(path) = path.to_str() {
-                let path_string = step_or_resource_error!(
-                    self.machine_st,
-                    self.machine_st.heap.allocate_cstr(path)
-                );
+        if path.is_dir()
+            && let Some(path) = path.to_str()
+        {
+            let path_string =
+                step_or_resource_error!(self.machine_st, self.machine_st.heap.allocate_cstr(path));
 
-                unify!(self.machine_st, self.machine_st.registers[1], path_string);
-                return;
-            }
+            unify!(self.machine_st, self.machine_st.registers[1], path_string);
+            return;
         }
 
         self.machine_st.fail = true;

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4737,109 +4737,108 @@ impl Machine {
         let stream_addr = self.deref_register(6);
         let handle_addr = self.deref_register(7);
         read_heap_cell!(culprit,
-        (HeapCellValueTag::Cons, cons_ptr) => {
-        match_untyped_arena_ptr!(cons_ptr,
-            (ArenaHeaderTag::HttpListener, http_listener) => {
-            loop {
-                match http_listener.incoming.recv_timeout(std::time::Duration::from_millis(200)) {
-                    Ok(request) => {
-                        let method_atom = match request.request_data.method {
-                            Method::GET => atom!("get"),
-                            Method::POST => atom!("post"),
-                            Method::PUT => atom!("put"),
-                            Method::DELETE => atom!("delete"),
-                            Method::PATCH => atom!("patch"),
-                            Method::HEAD => atom!("head"),
-                            Method::OPTIONS => atom!("options"),
-                            Method::TRACE => atom!("trace"),
-                            Method::CONNECT => atom!("connect"),
-                            _ => atom!("unsupported_extension"),
-                        };
+            (HeapCellValueTag::Cons, cons_ptr) => {
+                match_untyped_arena_ptr!(cons_ptr,
+                    (ArenaHeaderTag::HttpListener, http_listener) => {
+                        loop {
+                            match http_listener.incoming.recv_timeout(std::time::Duration::from_millis(200)) {
+                                Ok(request) => {
+                                    let method_atom = match request.request_data.method {
+                                        Method::GET => atom!("get"),
+                                        Method::POST => atom!("post"),
+                                        Method::PUT => atom!("put"),
+                                        Method::DELETE => atom!("delete"),
+                                        Method::PATCH => atom!("patch"),
+                                        Method::HEAD => atom!("head"),
+                                        Method::OPTIONS => atom!("options"),
+                                        Method::TRACE => atom!("trace"),
+                                        Method::CONNECT => atom!("connect"),
+                                        _ => atom!("unsupported_extension"),
+                                    };
 
-                        let path_atom = AtomTable::build_with(&self.machine_st.atom_tbl, &request.request_data.path);
-                        let path_cell = resource_error_call_result!(
-                            self.machine_st,
-                            self.machine_st.heap.allocate_cstr(&request.request_data.path)
-                        );
+                                    let path_atom = AtomTable::build_with(&self.machine_st.atom_tbl, &request.request_data.path);
+                                    let path_cell = resource_error_call_result!(
+                                        self.machine_st,
+                                        self.machine_st.heap.allocate_cstr(&request.request_data.path)
+                                    );
 
-                        let mut headers = vec![];
+                                    let mut headers = vec![];
 
-                        for (header_name, header_value) in request.request_data.headers {
-                            let header_value = resource_error_call_result!(
-                                self.machine_st,
-                                self.machine_st.heap.allocate_cstr(header_value.to_str().unwrap())
-                            );
+                                    for (header_name, header_value) in request.request_data.headers {
+                                        let header_value = resource_error_call_result!(
+                                            self.machine_st,
+                                            self.machine_st.heap.allocate_cstr(header_value.to_str().unwrap())
+                                        );
 
-                            let header_term = functor!(
-                                AtomTable::build_with(&self.machine_st.atom_tbl, header_name.unwrap().as_str()),
-                                [cell(header_value)]
-                            );
+                                        let header_term = functor!(
+                                            AtomTable::build_with(&self.machine_st.atom_tbl, header_name.unwrap().as_str()),
+                                            [cell(header_value)]
+                                        );
 
-                            let mut functor_writer = Heap::functor_writer(header_term);
+                                        let mut functor_writer = Heap::functor_writer(header_term);
 
-                            let functor_cell = resource_error_call_result!(
-                                self.machine_st,
-                                functor_writer(&mut self.machine_st.heap)
-                            );
+                                        let functor_cell = resource_error_call_result!(
+                                            self.machine_st,
+                                            functor_writer(&mut self.machine_st.heap)
+                                        );
 
-                            headers.push(functor_cell);
+                                        headers.push(functor_cell);
+                                    }
+
+                                    let headers_list_cell = resource_error_call_result!(
+                                        self.machine_st,
+                                        sized_iter_to_heap_list(
+                                            &mut self.machine_st.heap,
+                                            headers.len(),
+                                            headers.into_iter(),
+                                        )
+                                    );
+
+                                    let query_str  = request.request_data.query;
+                                    let query_cell = resource_error_call_result!(
+                                        self.machine_st,
+                                        self.machine_st.heap.allocate_cstr(&query_str)
+                                    );
+
+                                    let mut stream = Stream::from_http_stream(
+                                        path_atom,
+                                        request.request_data.body,
+                                        &mut self.machine_st.arena
+                                    );
+                                    *stream.options_mut() = StreamOptions::default();
+                                    stream.options_mut().set_stream_type(StreamType::Binary);
+
+                                    self.indices.add_stream(stream, atom!("http_accept"), 7)
+                                        .map_err(|stub_gen| stub_gen(&mut self.machine_st))?;
+
+                                    let stream = stream_as_cell!(stream);
+
+                                    let handle = arena_alloc!(request.response, &mut self.machine_st.arena)
+                                        as TypedArenaPtr<HttpResponse>;
+
+                                    self.machine_st.bind(method.as_var().unwrap(), atom_as_cell!(method_atom));
+                                    self.machine_st.bind(path.as_var().unwrap(), path_cell);
+                                    unify!(self.machine_st, headers_list_cell, self.machine_st.registers[4]);
+                                    self.machine_st.bind(query.as_var().unwrap(), query_cell);
+                                    self.machine_st.bind(stream_addr.as_var().unwrap(), stream);
+                                    self.machine_st.bind(handle_addr.as_var().unwrap(), typed_arena_ptr_as_cell!(handle));
+
+                                    break
+                                }
+                                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                                    self.machine_st.check_for_interrupt(|| functor_stub(atom!("http_accept"), 7))?;
+                                }
+                            Err(_) => {
+                                self.machine_st.fail = true;
+                            }
                         }
-
-                        let headers_list_cell = resource_error_call_result!(
-                            self.machine_st,
-                            sized_iter_to_heap_list(
-                                &mut self.machine_st.heap,
-                                headers.len(),
-                                headers.into_iter(),
-                            )
-                        );
-
-                        let query_str  = request.request_data.query;
-                        let query_cell = resource_error_call_result!(
-                            self.machine_st,
-                            self.machine_st.heap.allocate_cstr(&query_str)
-                        );
-
-                        let mut stream = Stream::from_http_stream(
-                            path_atom,
-                            request.request_data.body,
-                            &mut self.machine_st.arena
-                        );
-                        *stream.options_mut() = StreamOptions::default();
-                        stream.options_mut().set_stream_type(StreamType::Binary);
-
-                        self.indices.add_stream(stream, atom!("http_accept"), 7)
-                            .map_err(|stub_gen| stub_gen(&mut self.machine_st))?;
-
-                        let stream = stream_as_cell!(stream);
-
-                        let handle = arena_alloc!(request.response, &mut self.machine_st.arena)
-                            as TypedArenaPtr<HttpResponse>;
-
-                        self.machine_st.bind(method.as_var().unwrap(), atom_as_cell!(method_atom));
-                        self.machine_st.bind(path.as_var().unwrap(), path_cell);
-                        unify!(self.machine_st, headers_list_cell, self.machine_st.registers[4]);
-                        self.machine_st.bind(query.as_var().unwrap(), query_cell);
-                        self.machine_st.bind(stream_addr.as_var().unwrap(), stream);
-                        self.machine_st.bind(handle_addr.as_var().unwrap(), typed_arena_ptr_as_cell!(handle));
-
-                        break
                     }
-                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                        if self.machine_st.check_for_interrupt() {
-                            break;
-                        }
-                    }
-                  Err(_) => {
-                      self.machine_st.fail = true;
-                  }
                 }
-            }
-            }
-            _ => {
-                    unreachable!();
+                _ => {
+                        unreachable!();
+
                 }
-            );
+                );
             }
             _ => {
                 unreachable!();
@@ -6957,12 +6956,8 @@ impl Machine {
             std::thread::sleep(step);
             remaining -= step;
 
-            if self.machine_st.check_for_interrupt() {
-                // FIXME check_for_interrupt already throws an interrupt error
-                let err = self.machine_st.interrupt_error();
-                let src = functor_stub(atom!("repl"), 0);
-                return Err(self.machine_st.error_form(err, src));
-            }
+            self.machine_st
+                .check_for_interrupt(|| functor_stub(atom!("sleep"), 1))?;
         }
 
         Ok(())
@@ -7208,9 +7203,7 @@ impl Machine {
                              }
                             Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
                                 std::thread::sleep(std::time::Duration::from_millis(200));
-                                if self.machine_st.check_for_interrupt() {
-                                    break;
-                                }
+                                self.machine_st.check_for_interrupt(|| functor_stub(atom!("socket_server_accept"), 4))?;
                             }
                             Err(_) => {
                                 println!("IO error");

--- a/src/machine/unify.rs
+++ b/src/machine/unify.rs
@@ -347,12 +347,9 @@ pub(crate) trait Unifier: DerefMut<Target = MachineState> {
     fn unify_internal(&mut self) {
         debug_assert!(self.unify_tabu_list.is_empty());
 
-        while let Some((s1, s2)) = self.pdl.pop() {
-            if self.fail {
-                // FIXME(msrv) FIXME(edition2024) use let chain to move this to check this in the while condition
-                break;
-            }
-
+        while !self.fail
+            && let Some((s1, s2)) = self.pdl.pop()
+        {
             let s1 = (self.deref() as &MachineState).deref(s1);
             let s2 = (self.deref() as &MachineState).deref(s2);
 

--- a/src/machine/unify.rs
+++ b/src/machine/unify.rs
@@ -298,10 +298,10 @@ pub(crate) trait Unifier: DerefMut<Target = MachineState> {
     }
 
     fn unify_constant(&mut self, ptr: UntypedArenaPtr, value: HeapCellValue) {
-        if let Some(ptr2) = value.to_untyped_arena_ptr() {
-            if ptr.get_ptr() == ptr2.get_ptr() {
-                return;
-            }
+        if let Some(ptr2) = value.to_untyped_arena_ptr()
+            && ptr.get_ptr() == ptr2.get_ptr()
+        {
+            return;
         }
 
         match_untyped_arena_ptr!(ptr,
@@ -467,11 +467,11 @@ fn bind_with_occurs_check<U: Unifier>(unifier: &mut U, r: Ref, value: HeapCellVa
         {
             let cell = unmark_cell_bits!(cell);
 
-            if let Some(inner_r) = cell.as_var() {
-                if r == inner_r {
-                    occurs_triggered = true;
-                    break;
-                }
+            if let Some(inner_r) = cell.as_var()
+                && r == inner_r
+            {
+                occurs_triggered = true;
+                break;
             }
         }
     }

--- a/src/parser/char_reader.rs
+++ b/src/parser/char_reader.rs
@@ -116,9 +116,9 @@ impl<R: Read> CharReader<R> {
         // to tell the compiler that the pos..cap slice is always valid.
         if self.pos >= self.buf.len() {
             // make some space in buf
-            if self.buf.len() > 4 {
-                // keep 4 bytes so that put_back_char can put back at least one char
-                self.buf.drain(4..);
+            if self.buf.len() > char::MAX_LEN_UTF8 {
+                // keep char::MAX_LEN_UTF8 (4) bytes so that put_back_char can put back at least one char
+                self.buf.drain(char::MAX_LEN_UTF8..);
             }
             self.pos = self.buf.len();
 
@@ -144,7 +144,7 @@ impl<R: Read> CharRead for CharReader<R> {
         }
 
         fn bad_bytes_error(buf: &[u8]) -> std::io::Error {
-            // If we have 4 bytes that still don't make up
+            // If we have char::MAX_LEN_UTF8 (4) bytes that still don't make up
             // a valid code point, then we have garbage.
 
             // We have bad data in the buffer. Remove
@@ -171,10 +171,14 @@ impl<R: Read> CharRead for CharReader<R> {
             // buf must be non-empty
             let buf = &self.buf[self.pos..];
 
-            // we need at most 4 bytes for a char so don't decode the whole buffer
+            // we need at most char::MAX_LEN_UTF8 (4) bytes for a char so don't decode the whole buffer
             // as it can be quite large and we are going to discard the remaining chars anyway
             // if there is a valid prefix
-            let prefix = if buf.len() > 4 { &buf[..4] } else { buf };
+            let prefix = if buf.len() > char::MAX_LEN_UTF8 {
+                &buf[..char::MAX_LEN_UTF8]
+            } else {
+                buf
+            };
 
             let e = match str::from_utf8(prefix) {
                 Ok(s) => {
@@ -208,10 +212,10 @@ impl<R: Read> CharRead for CharReader<R> {
             // we need to read more data from the underlying stream
             // so that we can determine its validity
 
-            if self.buf.len() > 4 {
-                // keep a prefix of 4 bytes so that we can put back at least one char
-                self.buf.drain(4..self.pos);
-                self.pos = 4;
+            if self.buf.len() > char::MAX_LEN_UTF8 {
+                // keep a prefix of char::MAX_LEN_UTF8 (4) bytes so that we can put back at least one char
+                self.buf.drain(char::MAX_LEN_UTF8..self.pos);
+                self.pos = char::MAX_LEN_UTF8;
             }
 
             match self.read_chunk() {
@@ -232,10 +236,8 @@ impl<R: Read> CharRead for CharReader<R> {
         if c_len <= self.pos {
             self.pos -= c_len;
         } else {
-            self.buf.insert_from_slice(
-                0,
-                &[0u8; 4/* char::MAX_LEN_UTF8 once msrv reached 1.93 */][..c_len - self.pos],
-            );
+            self.buf
+                .insert_from_slice(0, &[0u8; char::MAX_LEN_UTF8][..c_len - self.pos]);
             self.pos = 0;
         }
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -651,12 +651,13 @@ impl<'a, R: CharRead> Lexer<'a, R> {
             if single_quote_char!(c) {
                 self.skip_char(c);
 
-                if !token.is_empty() && token.chars().nth(1).is_none() {
-                    if let Some(c) = token.chars().next() {
-                        return Ok(Token::Literal(Literal::Atom(
-                            AtomCell::new_char_inlined(c).get_name(),
-                        )));
-                    }
+                // use exactly_one once stable in our msrv https://github.com/rust-lang/rust/issues/149266
+                if let Some(c) = token.chars().next()
+                    && token.chars().nth(1).is_none()
+                {
+                    return Ok(Token::Literal(Literal::Atom(
+                        AtomCell::new_char_inlined(c).get_name(),
+                    )));
                 }
             } else {
                 return Err(self.located_error(ParserErrorKind::InvalidSingleQuotedCharacter(c)));

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -565,11 +565,11 @@ impl<'a, R: CharRead> Parser<'a, R> {
                         .push(Term::Clause(Cell::default(), name, subterms));
                 }
 
-                if let Some(&mut TokenDesc {
-                    ref mut tt,
-                    ref mut priority,
-                    ref mut spec,
-                    ref mut unfold_bounds,
+                if let Some(TokenDesc {
+                    tt,
+                    priority,
+                    spec,
+                    unfold_bounds,
                 }) = self.stack.last_mut()
                 {
                     if *spec == BTERM {
@@ -748,7 +748,7 @@ impl<'a, R: CharRead> Parser<'a, R> {
             return Ok(false);
         }
 
-        if let Some(ref mut td) = self.stack.last_mut()
+        if let Some(td) = self.stack.last_mut()
             && td.tt == TokenType::OpenCurly
         {
             td.tt = TokenType::Term;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -326,41 +326,40 @@ impl<'a, R: CharRead> Parser<'a, R> {
     }
 
     fn push_binary_op(&mut self, td: TokenDesc, spec: Specifier) {
-        if let Some(arg2) = self.terms.pop() {
-            if let Some(name) = self.get_term_name(td) {
-                if let Some(arg1) = self.terms.pop() {
-                    let term = Term::Clause(Cell::default(), name, vec![arg1, arg2]);
+        if let Some(arg2) = self.terms.pop()
+            && let Some(name) = self.get_term_name(td)
+            && let Some(arg1) = self.terms.pop()
+        {
+            let term = Term::Clause(Cell::default(), name, vec![arg1, arg2]);
 
-                    self.terms.push(term);
-                    self.stack.push(TokenDesc {
-                        tt: TokenType::Term,
-                        priority: td.priority,
-                        spec,
-                        unfold_bounds: 0,
-                    });
-                }
-            }
+            self.terms.push(term);
+            self.stack.push(TokenDesc {
+                tt: TokenType::Term,
+                priority: td.priority,
+                spec,
+                unfold_bounds: 0,
+            });
         }
     }
 
     fn push_unary_op(&mut self, td: TokenDesc, spec: Specifier, assoc: OpDeclSpec) {
-        if let Some(mut arg1) = self.terms.pop() {
-            if let Some(mut name) = self.terms.pop() {
-                if assoc.is_postfix() {
-                    mem::swap(&mut arg1, &mut name);
-                }
+        if let Some(mut arg1) = self.terms.pop()
+            && let Some(mut name) = self.terms.pop()
+        {
+            if assoc.is_postfix() {
+                mem::swap(&mut arg1, &mut name);
+            }
 
-                if let Term::Literal(_, Literal::Atom(name)) = name {
-                    let term = Term::Clause(Cell::default(), name, vec![arg1]);
+            if let Term::Literal(_, Literal::Atom(name)) = name {
+                let term = Term::Clause(Cell::default(), name, vec![arg1]);
 
-                    self.terms.push(term);
-                    self.stack.push(TokenDesc {
-                        tt: TokenType::Term,
-                        priority: td.priority,
-                        spec,
-                        unfold_bounds: 0,
-                    });
-                }
+                self.terms.push(term);
+                self.stack.push(TokenDesc {
+                    tt: TokenType::Term,
+                    priority: td.priority,
+                    spec,
+                    unfold_bounds: 0,
+                });
             }
         }
     }
@@ -669,16 +668,16 @@ impl<'a, R: CharRead> Parser<'a, R> {
             return Ok(false);
         }
 
-        if let Some(ref mut td) = self.stack.last_mut() {
-            if td.tt == TokenType::OpenList {
-                td.spec = TERM;
-                td.tt = TokenType::Term;
-                td.priority = 0;
+        if let Some(td) = self.stack.last_mut()
+            && td.tt == TokenType::OpenList
+        {
+            td.spec = TERM;
+            td.tt = TokenType::Term;
+            td.priority = 0;
 
-                self.terms
-                    .push(Term::Literal(Cell::default(), Literal::Atom(atom!("[]"))));
-                return Ok(true);
-            }
+            self.terms
+                .push(Term::Literal(Cell::default(), Literal::Atom(atom!("[]"))));
+            return Ok(true);
         }
 
         self.reduce_op(1000);
@@ -749,44 +748,43 @@ impl<'a, R: CharRead> Parser<'a, R> {
             return Ok(false);
         }
 
-        if let Some(ref mut td) = self.stack.last_mut() {
-            if td.tt == TokenType::OpenCurly {
-                td.tt = TokenType::Term;
-                td.priority = 0;
-                td.spec = TERM;
+        if let Some(ref mut td) = self.stack.last_mut()
+            && td.tt == TokenType::OpenCurly
+        {
+            td.tt = TokenType::Term;
+            td.priority = 0;
+            td.spec = TERM;
 
-                let term = Term::Literal(Cell::default(), Literal::Atom(atom!("{}")));
+            let term = Term::Literal(Cell::default(), Literal::Atom(atom!("{}")));
 
-                self.terms.push(term);
-                return Ok(true);
-            }
+            self.terms.push(term);
+            return Ok(true);
         }
 
         self.reduce_op(1201);
 
-        if self.stack.len() > 1 {
-            if let Some(td) = self.stack.pop() {
-                if let Some(ref mut oc) = self.stack.last_mut() {
-                    if td.tt != TokenType::Term {
-                        return Ok(false);
-                    }
+        if self.stack.len() > 1
+            && let Some(td) = self.stack.pop()
+            && let Some(oc) = self.stack.last_mut()
+        {
+            if td.tt != TokenType::Term {
+                return Ok(false);
+            }
 
-                    if oc.tt == TokenType::OpenCurly {
-                        oc.tt = TokenType::Term;
-                        oc.priority = 0;
-                        oc.spec = TERM;
+            if oc.tt == TokenType::OpenCurly {
+                oc.tt = TokenType::Term;
+                oc.priority = 0;
+                oc.spec = TERM;
 
-                        let term = match self.terms.pop() {
-                            Some(term) => term,
-                            _ => return Err(self.lexer.incomplete_reduction()),
-                        };
+                let term = match self.terms.pop() {
+                    Some(term) => term,
+                    _ => return Err(self.lexer.incomplete_reduction()),
+                };
 
-                        self.terms
-                            .push(Term::Clause(Cell::default(), atom!("{}"), vec![term]));
+                self.terms
+                    .push(Term::Clause(Cell::default(), atom!("{}"), vec![term]));
 
-                        return Ok(true);
-                    }
-                }
+                return Ok(true);
             }
         }
 
@@ -898,25 +896,24 @@ impl<'a, R: CharRead> Parser<'a, R> {
         Negator: Fn(N, &mut Arena) -> N,
         ToLiteral: Fn(N) -> Literal,
     {
-        if let Some(desc) = self.stack.last().cloned() {
-            if let Some(term) = self.terms.last().cloned() {
-                match term {
-                    Term::Literal(_, Literal::Atom(name))
-                        if name == atom!("-")
-                            && (is_prefix!(desc.spec) || is_negate!(desc.spec)) =>
-                    {
-                        self.stack.pop();
-                        self.terms.pop();
+        if let Some(desc) = self.stack.last().cloned()
+            && let Some(term) = self.terms.last().cloned()
+        {
+            match term {
+                Term::Literal(_, Literal::Atom(name))
+                    if name == atom!("-") && (is_prefix!(desc.spec) || is_negate!(desc.spec)) =>
+                {
+                    self.stack.pop();
+                    self.terms.pop();
 
-                        let arena = &mut self.lexer.machine_st.arena;
-                        let literal = constr(negator(n, arena));
+                    let arena = &mut self.lexer.machine_st.arena;
+                    let literal = constr(negator(n, arena));
 
-                        self.shift(Token::Literal(literal), 0, TERM);
+                    self.shift(Token::Literal(literal), 0, TERM);
 
-                        return;
-                    }
-                    _ => {}
+                    return;
                 }
+                _ => {}
             }
         }
 

--- a/src/raw_block.rs
+++ b/src/raw_block.rs
@@ -373,7 +373,7 @@ impl<T: RawBlockTraits, C: RawBlockConcurrency> RawBlock<T, C> {
     pub unsafe fn get_offset(&self, ptr: *const u8) -> usize {
         // SAFETY:
         // - Guaranteed by caller: `ptr` is still valid
-        // - Guranteed by caller: `ptr` was obtained from `get()` or `alloc()`
+        // - Guaranteed by caller: `ptr` was obtained from `get()` or `alloc()`
         // - get() and alloc() return pointers in the same allocation as `self.base`
         // - All functions modifying `self.base` invalidate pointers in their contract
         // - Thus `ptr` and `self.base` originate from the same allocation

--- a/src/read/user_interaction.rs
+++ b/src/read/user_interaction.rs
@@ -11,15 +11,15 @@ pub(crate) fn get_key() -> KeyEvent {
         enable_raw_mode().expect("failed to enable raw mode");
         loop {
             let key_ = read();
-            if let Ok(Event::Key(key_)) = key_ {
-                if key_.kind != KeyEventKind::Release {
-                    match key_.code {
-                        KeyCode::Char(_) | KeyCode::Enter | KeyCode::Tab => {
-                            key = key_;
-                            break;
-                        }
-                        _ => (),
+            if let Ok(Event::Key(key_)) = key_
+                && key_.kind != KeyEventKind::Release
+            {
+                match key_.code {
+                    KeyCode::Char(_) | KeyCode::Enter | KeyCode::Tab => {
+                        key = key_;
+                        break;
                     }
+                    _ => (),
                 }
             }
         }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -74,7 +74,7 @@ impl<'a> CompilationTarget<'a> for FactInstruction {
     }
 
     fn incr_void_instr(instr: &mut Instruction) {
-        if let &mut Instruction::UnifyVoid(ref mut incr) = instr {
+        if let Instruction::UnifyVoid(incr) = instr {
             *incr += 1
         }
     }
@@ -144,7 +144,7 @@ impl<'a> CompilationTarget<'a> for QueryInstruction {
     }
 
     fn incr_void_instr(instr: &mut Instruction) {
-        if let &mut Instruction::SetVoid(ref mut incr) = instr {
+        if let Instruction::SetVoid(incr) = instr {
             *incr += 1
         }
     }

--- a/src/variable_records.rs
+++ b/src/variable_records.rs
@@ -218,13 +218,11 @@ impl VariableRecords {
                             temp_var_data,
                             ..
                         } = &mut record.allocation
+                            && cn_u == term_loc.chunk_num()
+                            && u != var_gen_index
+                            && !temp_var_data.uses_reg(reg)
                         {
-                            if cn_u == term_loc.chunk_num()
-                                && u != var_gen_index
-                                && !temp_var_data.uses_reg(reg)
-                            {
-                                temp_var_data.no_use_set.insert(reg);
-                            }
+                            temp_var_data.no_use_set.insert(reg);
                         }
                     }
                 }


### PR DESCRIPTION
- use let chain now that we are on edition 2024 with a sufficiently recent msrv
- replace magic number with char::MAX_LEN_UTF8
- fix a lot of clippy warnings (mostly collapsible if, I would recommend to hide white-space changes)
- cleanup unnecessary use of `ref mut` match binding modifier