### PR TITLE
stateful http server

### DIFF
--- a/src/lib/http/http_server.pl
+++ b/src/lib/http/http_server.pl
@@ -124,7 +124,7 @@ http_listen(Port, Module:Handlers0) :-
 % - `tls_cert(+Cert)` - a TLS cert for HTTPS (string)
 % - `content_length_limit(+Limit)` - maximum length (in bytes) for the incoming bodies. By default, 32KB.
 % - `initial_state(+State)` - initial server state. By default, `[]`. Can use any term as initial state.
-% - `catch_errors(+Boolean)` - whether to catch all program errors (aside for interrupts). By default, web server will exit if any programming error is encountered.
+% - `catch_errors(+Boolean)` - whether to catch all program errors (aside from interrupts). By default, web server will exit if any programming error is encountered.
 %
 % In order to have a HTTPS server (instead of plain HTTP), both `tls_key` and `tls_cert` options must be provided.
 http_listen(Port, Module:Handlers0, Options) :-

--- a/src/lib/http/http_server.pl
+++ b/src/lib/http/http_server.pl
@@ -123,7 +123,7 @@ http_listen(Port, Module:Handlers0) :-
 % - `tls_key(+Key)` - a TLS key for HTTPS (string)
 % - `tls_cert(+Cert)` - a TLS cert for HTTPS (string)
 % - `content_length_limit(+Limit)` - maximum length (in bytes) for the incoming bodies. By default, 32KB.
-% - `initial_state(+State)` - initial server state. By default, []. Can use any term as initial state.
+% - `initial_state(+State)` - initial server state. By default, `[]`. Can use any term as initial state.
 % - `catch_errors(+Boolean)` - whether to catch all program errors (aside for interrupts). By default, web server will exit if any programming error is encountered.
 %
 % In order to have a HTTPS server (instead of plain HTTP), both `tls_key` and `tls_cert` options must be provided.
@@ -178,7 +178,6 @@ member_option_default(Key, List, Default, Default) :-
     X =.. [Key, _],
     \+ member(X, List).
 
-% there exists a match that modifies a state
 call_(Module:Handler, HttpRequest, HttpResponse, State0, State) :-
     Handler =.. [Name | Args],
     length(Args, Arity0),

--- a/src/lib/http/http_server.pl
+++ b/src/lib/http/http_server.pl
@@ -46,6 +46,29 @@ recommeded to use the helper predicates, which are easier to understand and clea
    - `http_redirect(Response, Url)`
    - `http_query(Request, QueryName, QueryValue)`
 
+## State
+
+To maintain state in the web server, use `initial_state/1` parameter (by default, set to [])
+along with handlers that have one or two extra parameters:
+
+```
+:- use_module(library(http/http_server)).
+
+run :- http_listen(7890, [
+  get(/, val),
+  get(inc, inc)
+], [initial_state("I")]).
+
+% read-only
+val(_, Response, S) :-
+    http_body(Response, text(S)).
+
+% read-write
+inc(_, Response, S0, S) :-
+    S = ['I' | S0],
+    http_body(Response, text(S)).
+```
+
 Some things that are still missing:
 
    - Read forms in multipart format
@@ -71,6 +94,7 @@ Some things that are still missing:
 :- meta_predicate(http_basic_auth(:, :, ?, ?)).
 
 :- use_module(library(charsio)).
+:- use_module(library(clpz)).
 :- use_module(library(crypto)).
 :- use_module(library(error)).
 :- use_module(library(format)).
@@ -99,6 +123,8 @@ http_listen(Port, Module:Handlers0) :-
 % - `tls_key(+Key)` - a TLS key for HTTPS (string)
 % - `tls_cert(+Cert)` - a TLS cert for HTTPS (string)
 % - `content_length_limit(+Limit)` - maximum length (in bytes) for the incoming bodies. By default, 32KB.
+% - `initial_state(+State)` - initial server state. By default, []. Can use any term as initial state.
+% - `catch_errors(+Boolean)` - whether to catch all program errors (aside for interrupts). By default, web server will exit if any programming error is encountered.
 %
 % In order to have a HTTPS server (instead of plain HTTP), both `tls_key` and `tls_cert` options must be provided.
 http_listen(Port, Module:Handlers0, Options) :-
@@ -125,22 +151,25 @@ http_answer_(ResponseHandle, Code, Headers, ResponseStream) :-
     '$http_answer'(ResponseHandle, Code, Headers, ResponseStream).
 
 http_listen_(Port, Handlers, Options) :-
-    parse_options(Options, TLSKey, TLSCert, ContentLengthLimit),
+    parse_options(Options, TLSKey, TLSCert, ContentLengthLimit, InitialState, CatchErrors),
     phrase(format_("0.0.0.0:~d", [Port]), Addr),
     setup_call_cleanup(
         (
             http_listen__(Addr, HttpListener, TLSKey, TLSCert, ContentLengthLimit),
             format("Listening at http://~s\n", [Addr])
         ),
-        http_loop(HttpListener, Handlers),
+        http_loop(HttpListener, Handlers, InitialState, CatchErrors),
         http_listen_stop_(HttpListener)
     ).
 
-parse_options(Options, TLSKey, TLSCert, ContentLengthLimit) :-
+parse_options(Options, TLSKey, TLSCert, ContentLengthLimit, InitialState, CatchErrors) :-
     member_option_default(tls_key, Options, "", TLSKey),
     member_option_default(tls_cert, Options, "", TLSCert),
     member_option_default(content_length_limit, Options, 32768, ContentLengthLimit),
-    must_be(integer, ContentLengthLimit).
+    must_be(integer, ContentLengthLimit),
+    member_option_default(initial_state, Options, [], InitialState),
+    member_option_default(catch_errors, Options, false, CatchErrors),
+    must_be(boolean, CatchErrors).
 
 member_option_default(Key, List, _Default, Value) :-
     X =.. [Key, Value],
@@ -149,50 +178,85 @@ member_option_default(Key, List, Default, Default) :-
     X =.. [Key, _],
     \+ member(X, List).
 
-http_loop(HttpListener, Handlers) :-
-    time((
-        http_accept_(HttpListener, RequestMethod, RequestPath, RequestHeaders, RequestQuery, RequestStream, ResponseHandle),
-        current_time(Time),
-        phrase(format_time("%Y-%m-%d (%H:%M:%S)", Time), TimeString),
-        format("~s ~w ~s", [TimeString, RequestMethod, RequestPath]),
-        maplist(map_header_kv, RequestHeaders, RequestHeadersKV),
-        phrase(parse_queries(RequestQueries), RequestQuery),
+% there exists a match that modifies a state
+call_(Module:Handler, HttpRequest, HttpResponse, State0, State) :-
+    Handler =.. [Name | Args],
+    length(Args, Arity0),
+    current_predicate(Module:Name/Arity),
+    NumExtraParams #= Arity - Arity0 - 2,
+    call_extra_params_(NumExtraParams, Module:Handler, HttpRequest, HttpResponse, State0, State).
+
+call_extra_params_(0, Module:Handler, HttpRequest, HttpResponse, State, State) :-
+    call(Module:Handler, HttpRequest, HttpResponse).
+
+call_extra_params_(1, Module:Handler, HttpRequest, HttpResponse, State, State) :-
+    call(Module:Handler, HttpRequest, HttpResponse, State).
+
+call_extra_params_(2, Module:Handler, HttpRequest, HttpResponse, State0, State) :-
+    call(Module:Handler, HttpRequest, HttpResponse, State0, State).
+
+http_reply(HttpListener, Handlers, State0, State) :-
+    http_accept_(HttpListener, RequestMethod, RequestPath, RequestHeaders, RequestQuery, RequestStream, ResponseHandle),
+    current_time(Time),
+    phrase(format_time("%Y-%m-%d (%H:%M:%S)", Time), TimeString),
+    format("~s ~w ~s", [TimeString, RequestMethod, RequestPath]),
+    maplist(map_header_kv, RequestHeaders, RequestHeadersKV),
+    phrase(parse_queries(RequestQueries), RequestQuery),
+    (
+        match_handler(Handlers, RequestMethod, RequestPath, Handler) ->
         (
-            match_handler(Handlers, RequestMethod, RequestPath, Handler) ->
-            (
-                HttpRequest = http_request(RequestHeadersKV, stream(RequestStream), RequestQueries),
-                HttpResponse = http_response(_, _, _),
-                catch(
-                    (call(Handler, HttpRequest, HttpResponse) ->
-                        send_response(ResponseHandle, HttpResponse)
-                    ;
-                        setup_call_cleanup(
-                            http_answer_(ResponseHandle, 500, [], ResponseStream),
-                            format(ResponseStream, "Internal Server Error", []),
-                            close(ResponseStream)
-                        ),
-                        throw(handler_not_available(Handler, RequestMethod, RequestPath, RequestQuery, RequestHeaders))
+            HttpRequest = http_request(RequestHeadersKV, stream(RequestStream), RequestQueries),
+            HttpResponse = http_response(_, _, _),
+            catch(
+                (call_(Handler, HttpRequest, HttpResponse, State0, State) ->
+                    send_response(ResponseHandle, HttpResponse)
+                ;
+                    setup_call_cleanup(
+                        http_answer_(ResponseHandle, 500, [], ResponseStream),
+                        format(ResponseStream, "Internal Server Error", []),
+                        close(ResponseStream)
                     ),
-                    HandlerError,
-                    (
-                        setup_call_cleanup(
-                            http_answer_(ResponseHandle, 500, [], ResponseStream),
-                            format(ResponseStream, "Internal Server Error", []),
-                            close(ResponseStream)
-                        ),
-                        throw(HandlerError)
-                    )
+                    call_with_error_context(handler_not_available(Handler, RequestMethod, RequestPath, RequestQuery, RequestHeaders), [])
+                ),
+                HandlerError,
+                (
+                    setup_call_cleanup(
+                        http_answer_(ResponseHandle, 500, [], ResponseStream),
+                        format(ResponseStream, "Internal Server Error", []),
+                        close(ResponseStream)
+                    ),
+                    throw(HandlerError)
                 )
             )
-            ;
-            setup_call_cleanup(
-                http_answer_(ResponseHandle, 404, [], ResponseStream),
-                format(ResponseStream, "Not Found", []),
-                close(ResponseStream)
-            )
         )
-    )),
-    http_loop(HttpListener, Handlers).
+        ;
+        setup_call_cleanup(
+            http_answer_(ResponseHandle, 404, [], ResponseStream),
+            format(ResponseStream, "Not Found", []),
+            (close(ResponseStream), State = State0)
+        )
+    ).
+
+% don't catch errors (for development web servers)
+http_loop(HttpListener, Handlers, State0, false) :-
+    call_with_error_context(time(http_reply(HttpListener, Handlers, State0, State)), state-State0),
+    http_loop(HttpListener, Handlers, State, false).
+
+% catch most errors (for production web servers)
+http_loop(HttpListener, Handlers, State0, true) :-
+   catch(
+    http_loop(HttpListener, Handlers, State0, false),
+    error(E,Pairs),
+    (
+        E = '$interrupt_thrown' -> throw(error(E, Pairs))
+        ;
+        (
+            write(error(E, Pairs)),nl, % TODO: should we not display the whole state?
+            member(state-State, Pairs),
+            http_loop(HttpListener, Handlers, State, true)
+        )
+    )
+   ).
 
 send_response(ResponseHandle, http_response(StatusCode0, text(ResponseText), ResponseHeaders0)) :-
     default(StatusCode0, 200, StatusCode),

--- a/tests-pl/issue-stateful-http.pl
+++ b/tests-pl/issue-stateful-http.pl
@@ -39,6 +39,7 @@ error(Val) :- send_request("error", Val).
 missing(Val) :- send_request("missing", Val).
 not_found(Val) :- send_request("not_found", Val).
 echo(In,Resp) :- append("echo/", In, URL), send_request(URL, Resp).
+set(Val,Resp) :- append("set/", Val, URL), send_request(URL, Resp).
 
 run_tests([]).
 run_tests([T|Ts]) :-
@@ -57,7 +58,9 @@ tests([
     val("3"), % after errors, previous value is saved
     not_found("Not Found"),
     echo("hello", "hello"),
-    val("3")
+    val("3"),
+    set("9000"),
+    val("9000")
 ]).
 
 main :-

--- a/tests-pl/issue-stateful-http.pl
+++ b/tests-pl/issue-stateful-http.pl
@@ -1,0 +1,78 @@
+% Server
+:- use_module(library(process)).
+:- use_module(library(iso_ext)).
+:- use_module(library(os)).
+:- use_module(library(lists)).
+
+prolog_path(Prolog) :-
+    read(Body),
+    term_variables(Body, [Prolog]),
+    Body.
+
+server_start([Process,Out]) :-
+    prolog_path(Prolog),
+    process_create(Prolog,
+        ["tests-pl/issue-stateful-http_server", "-t", "run_uninterrupted"],
+        [process(Process), stdout(pipe(Out))]).
+
+server_wait_start([_Process, Out]) :-
+    get_char(Out, _C).
+
+server_stop([Process,_Out]) :-
+    process_kill(Process).
+
+% Client 
+:- use_module(library(charsio)).
+:- use_module(library(http/http_open)).
+
+send_request(Path, Result) :-
+    append("http://localhost:8472/", Path, URL),
+    http_open(URL, Stream, []),
+    get_line_to_chars(Stream,Result,"").
+
+% client
+val(Val) :- send_request("", Val).
+inc(Val) :- send_request("inc", Val).
+dec(Val) :- send_request("dec", Val).
+times2(Val) :- send_request("times2", Val).
+error(Val) :- send_request("error", Val).
+missing(Val) :- send_request("missing", Val).
+not_found(Val) :- send_request("not_found", Val).
+echo(In,Resp) :- append("echo/", In, URL), send_request(URL, Resp).
+
+run_tests([]).
+run_tests([T|Ts]) :-
+    T -> run_tests(Ts)
+    ; write(["test failed", T]).
+
+tests([
+    val("0"),
+    inc("1"),
+    val("1"),
+    inc("2"),
+    times2("4"),
+    dec("3"),
+    error("Internal Server Error"),
+    missing("Internal Server Error"),
+    val("3"), % after errors, previous value is saved
+    not_found("Not Found"),
+    echo("hello", "hello"),
+    val("3")
+]).
+
+main :-
+    setup_call_cleanup(
+        server_start(Server),
+        ((
+            server_wait_start(Server),
+            tests(Tests),
+            run_tests(Tests)
+        )
+        ;
+        (
+            write(fail),nl
+        )),
+        server_stop(Server)
+    ).
+
+:- initialization(main).

--- a/tests-pl/issue-stateful-http.pl
+++ b/tests-pl/issue-stateful-http.pl
@@ -59,7 +59,7 @@ tests([
     not_found("Not Found"),
     echo("hello", "hello"),
     val("3"),
-    set("9000"),
+    set("9000", "9000"),
     val("9000")
 ]).
 

--- a/tests-pl/issue-stateful-http_server.pl
+++ b/tests-pl/issue-stateful-http_server.pl
@@ -12,7 +12,8 @@ run(CatchErrors, State) :- http_listen(8472, [
   get(times2, times2),
   get(error, my_error),
   get(missing, missing),
-  get(echo/Echo, echo(Echo))
+  get(echo/Echo, echo(Echo)),
+  get(set/Val, set(Val))
 ], [initial_state(State), catch_errors(CatchErrors)]).
 
 run_uninterrupted :- run(true, 0).
@@ -45,3 +46,7 @@ dec(_, Response, S0, S) :-
     S #= S0 - 1,
     val_resp(Response, S).
 
+% example using both path parameters and state
+set(Val, _, Response, _, ValN) :-
+    number_chars(ValN, Val),
+    val_resp(Response, ValN).

--- a/tests-pl/issue-stateful-http_server.pl
+++ b/tests-pl/issue-stateful-http_server.pl
@@ -1,0 +1,47 @@
+:- use_module(library(http/http_server)).
+:- use_module(library(clpz)).
+:- use_module(library(charsio)).
+:- use_module(library(lists)).
+
+run :- run(false, 0).
+
+run(CatchErrors, State) :- http_listen(8472, [
+  get(/, val),
+  get(inc, inc),
+  get(dec, dec),
+  get(times2, times2),
+  get(error, my_error),
+  get(missing, missing),
+  get(echo/Echo, echo(Echo))
+], [initial_state(State), catch_errors(CatchErrors)]).
+
+run_uninterrupted :- run(true, 0).
+
+% NOTE: do not use raw throw/1 if you wish the state to be persisted on errors, see library(error).
+my_error(_, _) :- resource_error("all cookies expired").
+
+% does not use state
+echo(Echo, _, Response) :-
+    http_body(Response, text(Echo)).
+
+val_resp(Response, S) :-
+    nl, write(S), nl,
+    number_chars(S, SC),
+    http_body(Response, text(SC)).
+
+% can only read state
+val(_, Response, S) :- val_resp(Response, S).
+
+% can read and modify state
+inc(_, Response, S0, S) :-
+    S #= S0 + 1,
+    val_resp(Response, S).
+
+times2(_, Response, S0, S) :-
+    S #= S0*2,
+    val_resp(Response, S).
+
+dec(_, Response, S0, S) :-
+    S #= S0 - 1,
+    val_resp(Response, S).
+

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -188,6 +188,17 @@ async fn http_open_hanging() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(all(feature = "http", not(target_arch = "wasm32")))]
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+async fn stateful_http() {
+    load_module_test_with_input(
+        "tests-pl/issue-stateful-http.pl",
+        format!("PROLOG={:?}.", env!("CARGO_BIN_EXE_scryer-prolog")),
+        "",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "repl")]
 #[cfg(unix)]
 #[cfg_attr(miri, ignore = "it takes too long to run")]


### PR DESCRIPTION
Closes #3353 

Allows to store state in a running http server as shown in the included docs:

```prolog
:- use_module(library(http/http_server)).

run :- http_listen(7890, [
  get(/, val),
  get(inc, inc)
], [initial_state("I")]).

% read-only
val(_, Response, S) :-
    http_body(Response, text(S)).

% read-write
inc(_, Response, S0, S) :-
    S = ['I' | S0],
    http_body(Response, text(S)).
```

This would be useful for implementing long http requests. For example, you can open http request once and not close it in a handler, but instead append it to the state. This would allow to implement server sent events and long running tasks that don't hang the whole server while they are running.

Adds two options to http_server:

- `initial_state(+State)` - initial server state. By default, `[]`. Can use any term as initial state.
- `catch_errors(+Boolean)` - whether to catch all program errors (aside from interrupts). By default, web server will exit if any programming error is encountered.

Edit:
- If `catch_errors(true)` is set, when it encounters a runtime error, will fallback to previous state. This doesn't necessarily mean this state is valid, and more advanced strategies can be implemented. For example, can record last `n` states and gradually fallback to the `i-1`th state if `i`th still crashes the program. Can also fallback to the initial state.