### PR TITLE
Fix panic in http_listen when the address is already in use

### DIFF
--- a/o.log
+++ b/o.log
@@ -1,0 +1,21 @@
+warning: method `get` is never used
+   --> src/raw_block.rs:344:12
+    |
+145 | impl<T: RawBlockTraits, C: RawBlockConcurrency> RawBlock<T, C> {
+    | -------------------------------------------------------------- method in this implementation
+...
+344 |     pub fn get(&self, offset: usize) -> *const u8 {
+    |            ^^^
+    |
+    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+
+warning: `scryer-prolog` (lib) generated 1 warning
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.86s
+     Running tests/scryer/main.rs (target/debug/deps/scryer-075d9d6a472bdbb2)
+
+running 1 test
+test issues::issue3415_http_listen_port_in_use has been running for over 60 seconds
+test issues::issue3415_http_listen_port_in_use ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 46 filtered out; finished in 73.09s
+

--- a/src/machine/system_calls.rs
+++ b/src/machine/system_calls.rs
@@ -4660,29 +4660,26 @@ impl Machine {
                 );
 
             let warp_shutdown_clone = warp_shutdown.clone();
-            runtime.spawn(async move {
-                match ssl_server {
-                    Some((key, cert)) => {
-                        let (_addr, server) = warp::serve(serve)
-                            .tls()
-                            .key(key)
-                            .cert(cert)
-                            .bind_with_graceful_shutdown(addr, async move {
-                                warp_shutdown_clone.notified().await;
-                            });
+            let bound = match ssl_server {
+                Some((key, cert)) => warp::serve(serve)
+                    .tls()
+                    .key(key)
+                    .cert(cert)
+                    .try_bind_with_graceful_shutdown(addr, async move {
+                        warp_shutdown_clone.notified().await;
+                    })
+                    .map(|(_addr, server)| runtime.spawn(server)),
+                None => warp::serve(serve)
+                    .try_bind_with_graceful_shutdown(addr, async move {
+                        warp_shutdown_clone.notified().await;
+                    })
+                    .map(|(_addr, server)| runtime.spawn(server)),
+            };
 
-                        tokio::task::spawn(server);
-                    }
-                    None => {
-                        let (_addr, server) =
-                            warp::serve(serve).bind_with_graceful_shutdown(addr, async move {
-                                warp_shutdown_clone.notified().await;
-                            });
-
-                        tokio::task::spawn(server);
-                    }
-                }
-            });
+            if bound.is_err() {
+                self.machine_st.fail = true;
+                return Ok(());
+            }
 
             let http_listener = HttpListener {
                 incoming: rx,

--- a/tests-pl/issue3415.pl
+++ b/tests-pl/issue3415.pl
@@ -1,0 +1,13 @@
+:- use_module(library(http/http_server)).
+
+main :-
+    Addr = "0.0.0.0:8475",
+    '$http_listen'(Addr, Listener, "", "", 32768),
+    (   '$http_listen'(Addr, _, "", "", 32768) ->
+        write(listened_twice)
+    ;   write(second_listen_failed)
+    ),
+    nl,
+    '$http_listen_stop'(Listener).
+
+:- initialization(main).

--- a/tests/scryer/issues.rs
+++ b/tests/scryer/issues.rs
@@ -199,6 +199,13 @@ async fn stateful_http() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(all(feature = "http", not(target_arch = "wasm32")))]
+#[cfg_attr(miri, ignore = "it takes too long to run")]
+async fn issue3415_http_listen_port_in_use() {
+    load_module_test("tests-pl/issue3415.pl", "second_listen_failed\n");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "repl")]
 #[cfg(unix)]
 #[cfg_attr(miri, ignore = "it takes too long to run")]


### PR DESCRIPTION
`http_listen/2,3` binds the warp server inside a spawned task with `bind_with_graceful_shutdown`, which panics on a tokio worker when the address is already taken. This binds with `try_bind_with_graceful_shutdown` before spawning and fails the predicate on a bind error, like `socket_server_open/4` does.

fixes mthom/scryer-prolog#3415
