### PR TITLE
fix for issue #3231

### DIFF
--- a/src/machine/cycle_detection.rs
+++ b/src/machine/cycle_detection.rs
@@ -29,6 +29,8 @@ pub(crate) struct CycleDetectingIter<'a, const STOP_AT_CYCLES: bool> {
     next: u64,
     cycle_found: bool,
     mark_phase: bool,
+    pstr_save: Option<u64>,
+    next_override: Option<u64>,
 }
 
 impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
@@ -43,6 +45,8 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
             next,
             cycle_found: false,
             mark_phase: true,
+            pstr_save: None,
+            next_override: None,
         }
     }
 
@@ -214,7 +218,7 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
                         }
 
                         self.heap[tail_idx].set_forwarding_bit(true);
-
+                        self.pstr_save = Some(self.next);
                         self.next = self.heap[tail_idx].get_value();
                         self.heap[tail_idx].set_value(self.current as u64);
                         self.current = tail_idx;
@@ -304,6 +308,11 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
                 self.heap[self.current].set_forwarding_bit(true);
                 false
             }
+            HeapCellValueTag::PStrLoc => {
+                self.heap[self.current].set_mark_bit(self.mark_phase);
+                self.next_override = self.pstr_save.take();
+                true
+            }
             HeapCellValueTag::Lis => {
                 if self.heap[self.current].get_mark_bit() == self.mark_phase {
                     true
@@ -335,7 +344,7 @@ impl<'a, const STOP_AT_CYCLES: bool> CycleDetectingIter<'a, STOP_AT_CYCLES> {
             let temp = self.heap[self.current].get_value();
 
             self.heap[self.current].set_value(self.next);
-            self.next = self.current as u64;
+            self.next = self.next_override.take().unwrap_or(self.current as u64);
             self.current = temp as usize;
         }
 

--- a/src/tests/acyclic_term.pl
+++ b/src/tests/acyclic_term.pl
@@ -1,5 +1,6 @@
 :- use_module(library(dcgs)).
 :- use_module(library(format)).
+:- use_module(library(lists)).
 
 term1(A) :-
    B=[C|D],
@@ -258,6 +259,32 @@ test("acyclic_term#2130_2", (
 test("acyclic_term#2131", (
     A=[B],C=[B],C=[A],
     \+ acyclic_term(C)
+)).
+
+test("acyclic_term#3231_1", (
+    Term = f("a"),
+    acyclic_term(Term),
+    Term == f("a")
+)).
+
+test("acyclic_term#3231_2", (
+    Term = f("a", 0),
+    acyclic_term(Term),
+    Term == f("a", 0)
+)).
+
+test("acyclic_term#3231_append", (
+    append("hel", "lo", X),
+    acyclic_term(X),
+    X == "hello"
+)).
+
+test("acyclic_term#3231_not_destructive", (
+    T = [[a]],
+    findall(Copy,
+        ( ( true ; acyclic_term(T) ; true ),
+            copy_term(T, Copy) ), [R1,R2,R3]),
+    R1 == R2, R2 == R3
 )).
 
 main :-


### PR DESCRIPTION
Fixes #3231 

The pointer-reversal walk behind `acyclic_term/1` only had room for one pending restore-value at a time, but descending into a partial string's tail cell triggered a second nested descent that overwrote it before the outer value was restored. This corrupted the string's heap representation and left the heap mutated even after backtracking.